### PR TITLE
Macos ft8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,3 +49,22 @@ jobs:
       # build it (above) but don't run its tests on a headless runner.
       - name: Test (core + server)
         run: cargo test -p rigflow-core -p rigflow-server
+
+  # The macOS client is a shipped artifact (release.yml). Build it here so the
+  # `cfg(target_os = "macos")` paths (digital_audio no-op, digital_tx gating,
+  # the platform-aware WSJT-X setup window) can't bit-rot between releases.
+  macos-client:
+    name: macOS client build
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install Rust (stable)
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo build
+        uses: Swatinem/rust-cache@v2
+
+      # CoreAudio is built in; the client needs no extra system libraries.
+      - name: Build client (macOS)
+        run: cargo build -p rigflow-client

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,124 @@
+name: Release
+
+# Build the distributable binaries and attach them to a GitHub Release.
+#
+# Trigger: pushing a `v*` tag (e.g. `v0.1.0`) builds + publishes. A manual
+# `workflow_dispatch` run builds the same matrix as a dry run but does NOT
+# publish (the `publish` job is gated on a tag), so you can validate the
+# pipeline before tagging.
+#
+# Platforms: server + client for Linux x86-64 and ARM64; client-only for
+# macOS arm64 (the server stays on Linux/Pi by design). macOS binaries are
+# unsigned — see the installation guide for the Gatekeeper first-launch step.
+
+on:
+  push:
+    tags: ["v*"]
+  workflow_dispatch:
+
+permissions:
+  contents: write # create the release + upload assets
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    name: build (${{ matrix.label }})
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - label: linux-x86_64
+            runner: ubuntu-latest
+            os: linux
+            packages: rigflow-server rigflow-client
+            build_args: -p rigflow-server -p rigflow-client
+          - label: linux-arm64
+            runner: ubuntu-24.04-arm
+            os: linux
+            packages: rigflow-server rigflow-client
+            build_args: -p rigflow-server -p rigflow-client
+          - label: macos-arm64
+            runner: macos-latest
+            os: macos
+            packages: rigflow-client
+            build_args: -p rigflow-client
+    steps:
+      - uses: actions/checkout@v5
+
+      # Linux: client links ALSA, server links libusb. macOS uses CoreAudio
+      # (built in) and the client needs no extra libraries.
+      - name: Install system libraries (Linux)
+        if: matrix.os == 'linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libasound2-dev libusb-1.0-0-dev
+
+      - name: Install Rust (stable)
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo build
+        uses: Swatinem/rust-cache@v2
+        with:
+          key: release-${{ matrix.label }}
+
+      # `dist` profile = release + stripped (small) binaries → target/dist/.
+      - name: Build (dist profile)
+        run: cargo build --profile dist ${{ matrix.build_args }}
+
+      # One tar.gz per binary: `<binary>-<label>.tar.gz`, extracting to a
+      # folder containing the binary + README + LICENSE + DISCLAIMER.
+      - name: Package archives
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p dist-out
+          for bin in ${{ matrix.packages }}; do
+            name="${bin}-${{ matrix.label }}"
+            stage="staging/${name}"
+            mkdir -p "$stage"
+            cp "target/dist/${bin}" "$stage/"
+            cp README.md LICENSE DISCLAIMER.md "$stage/"
+            tar -C staging -czf "dist-out/${name}.tar.gz" "${name}"
+          done
+          ls -l dist-out
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: archives-${{ matrix.label }}
+          path: dist-out/*.tar.gz
+          if-no-files-found: error
+
+  publish:
+    name: publish release
+    needs: build
+    runs-on: ubuntu-latest
+    # Only publish for real tags; a workflow_dispatch run stops after `build`.
+    if: startsWith(github.ref, 'refs/tags/v')
+    steps:
+      - name: Download all archives
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+          pattern: archives-*
+          merge-multiple: true
+
+      - name: Generate SHA256SUMS
+        working-directory: artifacts
+        run: |
+          set -euo pipefail
+          sha256sum *.tar.gz | tee SHA256SUMS
+
+      # Draft release: the maintainer reviews the assets and the (hand-written)
+      # notes from docs/RELEASE_NOTES.md, then publishes.
+      - name: Create GitHub Release (draft)
+        uses: softprops/action-gh-release@v2
+        with:
+          draft: true
+          fail_on_unmatched_files: true
+          files: |
+            artifacts/*.tar.gz
+            artifacts/SHA256SUMS

--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ operate from your laptop.
 **Transmit** (Hermes Lite 2)
 - **SSB** from your microphone (USB/LSB), with a soft limiter + speech compressor
 - **CW** via straight-key (Space bar), or Text-to-CW with F1–F4 memory macros and sidetone
-- **Digital (FT8 / WSJT-X)** — selecting the **Data** mode auto-routes audio; an in-app setup
-  window shows the device names and CAT/PTT settings
+- **Digital (FT8 / WSJT-X)** — on **Linux** via virtual audio (PipeWire/Pulse) **or** TCI; on
+  **macOS** via TCI only (experimental). An in-app setup window shows the exact settings
 - Built-in two-tone and tune/SWR test aids
 
 **Station**

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -29,8 +29,8 @@ receive and transmit on HF over the network. Highlights:
 **Hardware & platforms**
 - Radios: Hermes Lite 2 (RX + TX), RTL-SDR (receive, incl. direct-sampling HF), plus WAV IQ playback
   and a built-in test tone. Optional Hardrock-50 amplifier.
-- Server: Linux (x86-64 and Raspberry Pi / ARM). Client: Linux and macOS. *(Digital/FT8 is supported
-  on the Linux client only.)*
+- Server: Linux (x86-64 and Raspberry Pi / ARM). Client: Linux and macOS. *(Digital/FT8 uses PipeWire
+  virtual audio on Linux and a built-in TCI server on macOS — the latter is **experimental**; see below.)*
 
 See the [Operator guide](operator-guide.md) for how to use these, and the
 [Validation](validation.md) page for transmit signal-quality results.
@@ -38,6 +38,17 @@ See the [Operator guide](operator-guide.md) for how to use these, and the
 ---
 
 ## Known Issues & Workarounds
+
+### macOS FT8 / digital over TCI is experimental
+
+On macOS, digital modes (FT8/WSJT-X) run over a built-in **TCI** server instead of
+a virtual audio device — no BlackHole and no microphone permission required. This
+path is **experimental**: it has been confirmed transmitting and decoding on the
+air with mainline WSJT-X (Rig = TCI, `127.0.0.1:40001`, *Use TCI Audio*), but it
+has less on-air mileage than the Linux PipeWire path and has not been exercised
+across the full range of TCI-capable apps (JTDX, MSHV) or band/rate combinations.
+If you hit trouble, see the [Operator guide](operator-guide.md). The Linux digital
+path is unaffected.
 
 ### Signal-strength, TX power, and SWR readings are approximate
 

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -29,8 +29,8 @@ receive and transmit on HF over the network. Highlights:
 **Hardware & platforms**
 - Radios: Hermes Lite 2 (RX + TX), RTL-SDR (receive, incl. direct-sampling HF), plus WAV IQ playback
   and a built-in test tone. Optional Hardrock-50 amplifier.
-- Server: Linux (x86-64 and Raspberry Pi / ARM). Client: Linux and macOS. *(Digital/FT8 uses PipeWire
-  virtual audio on Linux and a built-in TCI server on macOS — the latter is **experimental**; see below.)*
+- Server: Linux (x86-64 and Raspberry Pi / ARM). Client: Linux and macOS. *(Digital/FT8: on Linux via
+  PipeWire/PulseAudio virtual audio **or** TCI; on macOS via TCI only. TCI is **experimental**; see below.)*
 
 See the [Operator guide](operator-guide.md) for how to use these, and the
 [Validation](validation.md) page for transmit signal-quality results.

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -29,8 +29,10 @@ receive and transmit on HF over the network. Highlights:
 **Hardware & platforms**
 - Radios: Hermes Lite 2 (RX + TX), RTL-SDR (receive, incl. direct-sampling HF), plus WAV IQ playback
   and a built-in test tone. Optional Hardrock-50 amplifier.
-- Server: Linux (x86-64 and Raspberry Pi / ARM). Client: Linux and macOS. *(Digital/FT8: on Linux via
-  PipeWire/PulseAudio virtual audio **or** TCI; on macOS via TCI only. TCI is **experimental**; see below.)*
+- Server: Linux (x86-64 and Raspberry Pi / ARM). Client: Linux (x86-64, ARM64) and **macOS (Apple
+  Silicon)**. Prebuilt binaries are provided for all of these; the macOS client is **unsigned** (a
+  one-time Gatekeeper step is in the installation guide). *(Digital/FT8: on Linux via PipeWire/PulseAudio
+  virtual audio **or** TCI; on macOS via TCI only. TCI is **experimental**; see below.)*
 
 See the [Operator guide](operator-guide.md) for how to use these, and the
 [Validation](validation.md) page for transmit signal-quality results.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -79,12 +79,18 @@ From **v0.1.0** onward, prebuilt binaries are published on the project's
 [Releases page](https://github.com/dbourgoyne/rigflow/releases) — no Rust toolchain needed, just the
 runtime libraries from §1.
 
-1. Download the archive for the component and platform you need — **`rigflow-server`** for the radio
-   host (**Linux x86-64** or **Linux ARM64** / Raspberry Pi) and **`rigflow-client`** for your desktop.
-   *(macOS: build from source for now — see Option B; native macOS binaries come in a later release.)*
+1. Download the archive for the component and platform you need:
+   - **`rigflow-server`** — the radio host: **Linux x86-64** or **Linux ARM64** (Raspberry Pi).
+   - **`rigflow-client`** — your desktop: **Linux x86-64**, **Linux ARM64**, or **macOS (Apple Silicon)**.
+
+   macOS runs the **client only** — run the server on a Linux box or Raspberry Pi and point the client
+   at it (see [Networking](#5-networking)).
 2. *(Optional)* verify the download against the published `SHA256SUMS`.
 3. Extract it. Each archive contains the binary plus `README.md`, `LICENSE`, and `DISCLAIMER.md`.
 4. Make it executable if needed: `chmod +x rigflow-server` (or `rigflow-client`).
+5. **macOS first launch:** the client is **unsigned**, so macOS Gatekeeper blocks it the first time.
+   Either **right-click `rigflow-client` → Open** (then confirm in the dialog), or clear the quarantine
+   flag once from a terminal: `xattr -dr com.apple.quarantine rigflow-client`.
 
 ### Option B — Build from source
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -40,8 +40,10 @@ sudo apt install build-essential pkg-config libusb-1.0-0-dev
 sudo apt install build-essential pkg-config libasound2-dev
 ```
 
-For **digital modes (WSJT-X/FT8)** the client also needs **PipeWire** (or PulseAudio), which is
-standard on modern Linux desktops — no extra step on most systems.
+For **digital modes (WSJT-X/FT8)** on Linux you have two options: the **virtual-audio** method,
+which needs **PipeWire** (or PulseAudio) — standard on modern Linux desktops, so no extra step on
+most systems — **or** the **TCI** method, which needs no virtual audio at all (experimental, and
+works with TCI-capable apps such as WSJT-X 2.7+, JTDX, MSHV). See the operator guide.
 
 **Client (macOS):** install the Xcode Command Line Tools (`xcode-select --install`). Audio uses
 CoreAudio (built in). The macOS client supports **receive, SSB/CW transmit, and FT8/digital** —

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -7,54 +7,89 @@ This guide covers building Rigflow and connecting your radios. Rigflow is two pr
 - **`rigflow-client`** — the desktop UI. Run it on your operating computer (Linux or macOS).
 
 They can be the **same machine** (server + client on one computer) or **two machines** on the same
-network. Build from source on each machine that runs a component.
+network. On each machine that runs a component, **download a prebuilt binary** (recommended) or
+**build it from source** — both are covered below.
 
 ---
 
-## 1. Prerequisites
+## 1. Requirements
 
-### Rust toolchain (server + client)
+Rigflow needs a few shared libraries at **runtime** to run the binaries. You only need the separate
+**build tools** further down if you build from source.
 
-Install Rust with [rustup](https://rustup.rs) (the client uses Rust **edition 2024**, so you need
-**Rust 1.85 or newer**):
+### Runtime libraries (to run Rigflow)
+
+**Server (Linux, including Raspberry Pi):** the RTL-SDR driver uses **libusb**. The server needs no
+audio library.
+
+```bash
+# Debian / Ubuntu / Raspberry Pi OS
+sudo apt install libusb-1.0-0
+```
+*(Fedora: `libusb1` · Arch: `libusb`)*
+
+**Client (Linux):** the UI plays audio through ALSA.
+
+```bash
+sudo apt install libasound2
+```
+
+**Client (macOS):** audio uses CoreAudio — nothing to install.
+
+**Digital modes (WSJT-X/FT8):** On **Linux** you can use either the **virtual-audio** method —
+which needs **PipeWire** (or PulseAudio), standard on modern Linux desktops — **or** the **TCI**
+method, which needs no extra audio software (experimental; for TCI-capable apps like WSJT-X 2.7+,
+JTDX, MSHV). On **macOS**, FT8/digital runs over a built-in **TCI** server only (experimental) — no
+BlackHole or virtual audio driver. See the [operator guide](operator-guide.md).
+
+### Build tools (only if you build from source)
+
+Skip this if you use a prebuilt binary.
+
+**Rust toolchain** — install with [rustup](https://rustup.rs) (the client uses Rust **edition 2024**,
+so you need **Rust 1.85 or newer**):
 
 ```bash
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 rustc --version    # 1.85.0 or newer
 ```
 
-### System libraries
-
-**Server (Linux, including Raspberry Pi):** the build needs a C toolchain and **libusb** (used by the
-RTL-SDR driver). The server does *not* need an audio library.
+**Server (Linux/Pi)** — a C toolchain plus the libusb **dev** headers:
 
 ```bash
-# Debian / Ubuntu / Raspberry Pi OS
 sudo apt install build-essential pkg-config libusb-1.0-0-dev
 ```
 *(Fedora: `gcc pkgconf-pkg-config libusb1-devel` · Arch: `base-devel libusb`)*
 
-**Client (Linux):** the UI plays audio through ALSA, so it needs the ALSA dev headers:
+**Client (Linux)** — the ALSA **dev** headers:
 
 ```bash
 sudo apt install build-essential pkg-config libasound2-dev
 ```
 
-For **digital modes (WSJT-X/FT8)** on Linux you have two options: the **virtual-audio** method,
-which needs **PipeWire** (or PulseAudio) — standard on modern Linux desktops, so no extra step on
-most systems — **or** the **TCI** method, which needs no virtual audio at all (experimental, and
-works with TCI-capable apps such as WSJT-X 2.7+, JTDX, MSHV). See the operator guide.
-
-**Client (macOS):** install the Xcode Command Line Tools (`xcode-select --install`). Audio uses
-CoreAudio (built in). The macOS client supports **receive, SSB/CW transmit, and FT8/digital** —
-the latter via a built-in **TCI** server (no BlackHole or virtual audio driver needed; see the
-operator guide). FT8 over TCI is **experimental**.
+**Client (macOS)** — the Xcode Command Line Tools: `xcode-select --install`.
 
 ---
 
-## 2. Build
+## 2. Get Rigflow
 
-From the repository root, on each machine:
+### Option A — Prebuilt binary (recommended)
+
+From **v0.1.0** onward, prebuilt binaries are published on the project's
+[Releases page](https://github.com/dbourgoyne/rigflow/releases) — no Rust toolchain needed, just the
+runtime libraries from §1.
+
+1. Download the archive for the component and platform you need — **`rigflow-server`** for the radio
+   host (**Linux x86-64** or **Linux ARM64** / Raspberry Pi) and **`rigflow-client`** for your desktop.
+   *(macOS: build from source for now — see Option B; native macOS binaries come in a later release.)*
+2. *(Optional)* verify the download against the published `SHA256SUMS`.
+3. Extract it. Each archive contains the binary plus `README.md`, `LICENSE`, and `DISCLAIMER.md`.
+4. Make it executable if needed: `chmod +x rigflow-server` (or `rigflow-client`).
+
+### Option B — Build from source
+
+For developers, or platforms without a prebuilt binary (e.g. macOS today). Install the **build tools**
+from §1, then from the repository root on each machine:
 
 ```bash
 cargo build --release
@@ -67,15 +102,19 @@ while (especially on a Pi); later builds are fast.
 
 ## 3. Run
 
-**Single machine** (server and client on one computer):
+**Single machine** (server and client on one computer), from the folder you extracted the binaries
+into:
 
 ```bash
 # terminal 1
-cargo run --release -p rigflow-server
+./rigflow-server
 
 # terminal 2
-cargo run --release -p rigflow-client
+./rigflow-client
 ```
+
+*(From a source build, run `cargo run --release -p rigflow-server` / `-p rigflow-client`, or the
+binaries directly at `./target/release/rigflow-server`.)*
 
 The client defaults its server address to `127.0.0.1`, so click **Connect** and you're talking to the
 local server.
@@ -88,6 +127,8 @@ Both programs are driven live from the UI; their command-line options are minima
 - Server: `--help`, `--recordings-dir PATH` (where WAV/IQ recordings live),
   `--hr50-serial auto|<path>[:baud]|none` (amplifier port — see below).
 - Client: `--help`, `--window-size <WxH>` (default `1280x720`).
+
+For logs, set `RUST_LOG`, e.g. `RUST_LOG=info ./rigflow-server` (use `=debug` for more detail).
 
 ---
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -44,8 +44,9 @@ For **digital modes (WSJT-X/FT8)** the client also needs **PipeWire** (or PulseA
 standard on modern Linux desktops — no extra step on most systems.
 
 **Client (macOS):** install the Xcode Command Line Tools (`xcode-select --install`). Audio uses
-CoreAudio (built in). The macOS client supports **receive and SSB/CW transmit**; FT8/digital is
-**Linux-only** (it relies on PipeWire virtual audio).
+CoreAudio (built in). The macOS client supports **receive, SSB/CW transmit, and FT8/digital** —
+the latter via a built-in **TCI** server (no BlackHole or virtual audio driver needed; see the
+operator guide). FT8 over TCI is **experimental**.
 
 ---
 

--- a/docs/operator-guide.md
+++ b/docs/operator-guide.md
@@ -104,7 +104,15 @@ With **"Show advanced & diagnostics controls"** ticked:
 
 ## Digital modes (WSJT-X / FT8)
 
-### Linux — PipeWire virtual audio
+There are two transports, and which you use depends on your platform:
+
+- **Linux** — use **either** the **virtual-audio** method (PipeWire/PulseAudio; the default, and works
+  with any digital app including FLDigi and JS8Call) **or** the **TCI** method (experimental;
+  for TCI-capable apps). Both are described below.
+- **macOS** — **TCI only** (experimental). macOS has no virtual audio device, so the PipeWire method
+  does not apply.
+
+### Linux — virtual audio (PipeWire/PulseAudio)
 
 Rigflow makes digital nearly one-click:
 
@@ -120,9 +128,8 @@ Rigflow makes digital nearly one-click:
 
 Leaving **DATA** turns RX routing back off.
 
-Linux can also use the **TCI** method below (the same one macOS uses) for TCI-capable apps (WSJT-X 2.7+,
-JTDX, MSHV) — the Setup window lists it as "Method 2". The virtual-audio method above is the default and
-works with any digital app, including FLDigi and JS8Call.
+On Linux you can instead use the **TCI** method below (the same one macOS uses) for TCI-capable apps —
+the Setup window lists it as "Method 2".
 
 ### macOS — TCI (experimental)
 

--- a/docs/operator-guide.md
+++ b/docs/operator-guide.md
@@ -104,7 +104,7 @@ With **"Show advanced & diagnostics controls"** ticked:
 
 ## Digital modes (WSJT-X / FT8)
 
-*(Linux client only — digital uses PipeWire virtual audio.)*
+### Linux — PipeWire virtual audio
 
 Rigflow makes digital nearly one-click:
 
@@ -119,6 +119,25 @@ Rigflow makes digital nearly one-click:
    data/pkt mode also drives Rigflow into Data mode automatically.
 
 Leaving **DATA** turns RX routing back off.
+
+Linux can also use the **TCI** method below (the same one macOS uses) for TCI-capable apps (WSJT-X 2.7+,
+JTDX, MSHV) — the Setup window lists it as "Method 2". The virtual-audio method above is the default and
+works with any digital app, including FLDigi and JS8Call.
+
+### macOS — TCI (experimental)
+
+macOS has no virtual audio device, so digital uses **TCI** instead: WSJT-X carries CAT, PTT, and **both
+audio directions over one localhost connection** — no BlackHole and no microphone permission. The client
+runs a TCI server at `ws://127.0.0.1:40001` whenever it's running.
+
+In WSJT-X:
+
+- **Settings → Radio:** Rig = **TCI**, TCI Server = **`127.0.0.1:40001`**, and tick **Use TCI Audio**.
+- **Settings → Audio:** Input and Output both = the **TCI** device.
+- **Mode:** Data/Pkt (or USB). Set Rigflow to **DATA**.
+
+Then operate normally — no soundcard or CAT plumbing to configure. This path also works on Linux, but the
+PipeWire route above is the default there.
 
 ---
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -75,19 +75,30 @@ Common problems and fixes, by symptom. For setup steps see the
 
 ## Digital (WSJT-X / FT8)
 
-*(Linux client only.)*
+FT8 works two ways: **virtual audio** (Linux only — PipeWire/PulseAudio) and **TCI** (Linux *and*
+macOS — and the **only** method on macOS; experimental). The fixes below are grouped by method.
+
+### Virtual-audio method (Linux)
 
 **WSJT-X has no audio / can't find the devices.**
 - Make sure the mode is **DATA** in Rigflow (that's what routes the audio).
 - The device names must match exactly: input **`RigflowDigitalRX`**, output **`RigflowDigitalInput`**.
-- The virtual devices need **PipeWire** (or PulseAudio) running on the client desktop.
+- The virtual devices need **PipeWire** (or PulseAudio) running on the client desktop. If you don't
+  have it, use the **TCI** method instead — it needs no virtual audio.
 
 **WSJT-X won't key the radio.**
 - In WSJT-X, CAT = **Hamlib NET rigctl**, host/port **`127.0.0.1:4532`**, and **PTT = CAT**. The
   client provides that rig-control endpoint while connected.
 
-The in-app **WSJT-X / FT8 Setup** window (Radio Control → Advanced) shows the exact values and a
-live status for each piece.
+### TCI method (Linux & macOS)
+
+**No audio over TCI.**
+- In WSJT-X: **Rig = TCI**, **TCI Server = `127.0.0.1:40001`**, tick **Use TCI Audio**, and set
+  **Audio → Input/Output** to the **TCI** device.
+- Use a TCI-capable app (WSJT-X 2.7+, JTDX, MSHV). TCI support is experimental.
+
+The in-app **WSJT-X / FT8 Setup** window (Radio Control → Advanced) shows the exact values for your
+platform, with a live status for each piece.
 
 ---
 

--- a/rigflow-client/src/client_runtime.rs
+++ b/rigflow-client/src/client_runtime.rs
@@ -187,6 +187,13 @@ pub fn start_media_runtime(
         .map(|s| Arc::clone(&s.digital_rx))
         .unwrap_or_else(|_| crate::digital_rx::DigitalRxOutput::new());
 
+    // TCI server RX-audio tap: a copy of received audio is mirrored here while a
+    // TCI digital app (JTDX) is streaming.  Shared with the TCI server task.
+    let tci_rx_audio = ui_state
+        .lock()
+        .map(|s| Arc::clone(&s.tci_rx_audio))
+        .unwrap_or_else(|_| crate::tci_server::TciRxAudio::new());
+
     // --- Dedicated mic-TX send thread -------------------------------------
     // Mic / digital-TX audio is sent from its own paced thread, NOT the media
     // loop.  The media loop processes the inbound full-duplex RX/waterfall flood
@@ -357,6 +364,7 @@ pub fn start_media_runtime(
                             &stats_for_thread,
                             &mut cw_decoder,
                             &digital_rx,
+                            &tci_rx_audio,
                         );
                     }
                 }

--- a/rigflow-client/src/digital_audio.rs
+++ b/rigflow-client/src/digital_audio.rs
@@ -26,22 +26,33 @@
 //! through the `pactl` CLI (works under both via the Pulse compat layer), so no
 //! extra crate dependency is needed.  Format is fixed mono / 48000 Hz / float32.
 
+#[cfg(target_os = "linux")]
 use std::fs::File;
-use std::process::{Child, Command, Stdio};
+use std::process::Child;
+#[cfg(target_os = "linux")]
+use std::process::{Command, Stdio};
 
-/// Sink Rigflow plays RX audio into (the remap master).
+/// Sink Rigflow plays RX audio into (the remap master).  Referenced by the
+/// cross-platform `digital_rx` module, so it stays defined on every target.
 pub const DIGITAL_OUTPUT_NAME: &str = "RigflowDigitalOutput";
 /// Monitor of the output sink — master for the RX remap source.
+#[cfg(target_os = "linux")]
 const DIGITAL_OUTPUT_MONITOR: &str = "RigflowDigitalOutput.monitor";
-/// Source digital apps record from (remapped from the output monitor).
+/// Source digital apps record from (remapped from the output monitor).  Shown in
+/// the WSJT-X/FT8 Setup window's Linux "virtual audio" method (kept cross-platform
+/// so the window references it on every target).
 pub const DIGITAL_RX_NAME: &str = "RigflowDigitalRX";
 /// Sink digital apps play TX audio into (Rigflow reads its `.monitor`).
 pub const DIGITAL_INPUT_NAME: &str = "RigflowDigitalInput";
 
 /// Fixed audio format for the endpoints (matches the Rigflow pipeline).
+#[cfg(target_os = "linux")]
 const RATE_HZ: &str = "48000";
+#[cfg(target_os = "linux")]
 const FORMAT: &str = "float32le";
+#[cfg(target_os = "linux")]
 const CHANNELS: &str = "1";
+#[cfg(target_os = "linux")]
 const CHANNEL_MAP: &str = "mono";
 
 /// Owns the lifecycle of the virtual audio devices.  Drop unloads any modules
@@ -73,6 +84,38 @@ impl DigitalAudio {
     /// the client keeps running.  Order matters: the output sink (and its
     /// monitor) must exist before the RX remap source that masters off it.
     pub fn start() -> Self {
+        // PipeWire/Pulse virtual audio is Linux-only; on other platforms digital
+        // modes use the built-in TCI server instead, so create nothing here (and
+        // never shell out to pactl, which doesn't exist on macOS/Windows).
+        #[cfg(not(target_os = "linux"))]
+        {
+            Self::unavailable()
+        }
+        #[cfg(target_os = "linux")]
+        {
+            Self::start_linux()
+        }
+    }
+
+    /// All endpoints unavailable, no devices created (non-Linux: digital = TCI).
+    #[cfg(not(target_os = "linux"))]
+    fn unavailable() -> Self {
+        Self {
+            output_module: None,
+            rx_module: None,
+            input_module: None,
+            input_keepalive: None,
+            output_available: false,
+            rx_available: false,
+            input_available: false,
+            output_reason: None,
+            rx_reason: None,
+            input_reason: None,
+        }
+    }
+
+    #[cfg(target_os = "linux")]
+    fn start_linux() -> Self {
         let (output_available, output_module, output_reason) = ensure_output_sink();
         let (rx_available, rx_module, rx_reason) = ensure_rx_remap_source();
         let (input_available, input_module, input_reason) = ensure_input_sink();
@@ -143,6 +186,7 @@ impl DigitalAudio {
     }
 }
 
+#[cfg(target_os = "linux")]
 impl Drop for DigitalAudio {
     fn drop(&mut self) {
         // Stop the silence keep-alive before unloading its sink.
@@ -175,6 +219,7 @@ impl Drop for DigitalAudio {
 
 /// Ensure the `RigflowDigitalOutput` **sink** exists, then force it to unity /
 /// unmuted so the digital RX level is fixed regardless of the speaker volume.
+#[cfg(target_os = "linux")]
 fn ensure_output_sink() -> (bool, Option<u32>, Option<String>) {
     let module = if device_exists("sinks", DIGITAL_OUTPUT_NAME) {
         log::info!("[digital-audio] reusing existing sink {DIGITAL_OUTPUT_NAME}");
@@ -217,6 +262,7 @@ fn ensure_output_sink() -> (bool, Option<u32>, Option<String>) {
 /// Ensure the `RigflowDigitalRX` **remap source** (master =
 /// `RigflowDigitalOutput.monitor`) exists.  This is what apps record from,
 /// because most apps won't list monitor sources directly.
+#[cfg(target_os = "linux")]
 fn ensure_rx_remap_source() -> (bool, Option<u32>, Option<String>) {
     if device_exists("sources", DIGITAL_RX_NAME) {
         log::info!("[digital-audio] reusing existing source {DIGITAL_RX_NAME}");
@@ -247,6 +293,7 @@ fn ensure_rx_remap_source() -> (bool, Option<u32>, Option<String>) {
 /// Ensure the `RigflowDigitalInput` **sink** exists.  Apps play TX audio into
 /// it; Rigflow reads `RigflowDigitalInput.monitor` (TX routing is a later
 /// phase).  A null sink auto-creates the matching monitor source.
+#[cfg(target_os = "linux")]
 fn ensure_input_sink() -> (bool, Option<u32>, Option<String>) {
     if device_exists("sinks", DIGITAL_INPUT_NAME) {
         log::info!("[digital-audio] reusing existing sink {DIGITAL_INPUT_NAME}");
@@ -279,6 +326,7 @@ fn ensure_input_sink() -> (bool, Option<u32>, Option<String>) {
 /// (so its monitor never suspends).  Reads zeros from `/dev/zero` — pacat paces
 /// reads to the sink rate, so this is real-time silence, not a busy loop.  Tries
 /// `pacat` (Pulse/PipeWire-pulse) then `pw-cat` (PipeWire-native).
+#[cfg(target_os = "linux")]
 fn spawn_input_keepalive() -> Option<Child> {
     let zero = File::open("/dev/zero").ok()?;
     let pacat = Command::new("pacat")
@@ -322,6 +370,7 @@ fn spawn_input_keepalive() -> Option<Child> {
 
 /// Return true if a `pactl list short <kind>` entry with `name` exists.
 /// `kind` is `"sinks"` or `"sources"`.
+#[cfg(target_os = "linux")]
 fn device_exists(kind: &str, name: &str) -> bool {
     let out = match Command::new("pactl").args(["list", "short", kind]).output() {
         Ok(o) if o.status.success() => o.stdout,
@@ -337,6 +386,7 @@ fn device_exists(kind: &str, name: &str) -> bool {
 /// Run `pactl load-module …`; on success return the new module index that
 /// `pactl` prints on stdout, otherwise the failure reason (so callers can
 /// surface *why* the endpoint is unavailable rather than just a red dot).
+#[cfg(target_os = "linux")]
 fn load_module(args: &[String]) -> Result<u32, String> {
     let out = Command::new("pactl")
         .args(args)
@@ -358,6 +408,7 @@ fn load_module(args: &[String]) -> Result<u32, String> {
 }
 
 /// Best-effort `pactl unload-module <id>`; returns a short status for logging.
+#[cfg(target_os = "linux")]
 fn unload_status(id: u32) -> &'static str {
     match Command::new("pactl")
         .args(["unload-module", &id.to_string()])

--- a/rigflow-client/src/digital_tx.rs
+++ b/rigflow-client/src/digital_tx.rs
@@ -28,11 +28,17 @@
 //! PCM from `parec` (Pulse) / `pw-record` (PipeWire).  A dedicated capture
 //! thread owns the child process; it only runs while PTT is keyed.
 
-use std::io::Read;
-use std::process::{Child, Command, Stdio};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
+// PipeWire/Pulse capture (parec/pw-record) is Linux-only; gate the machinery so
+// macOS/Windows never shell out to it (digital TX there flows over TCI instead).
+#[cfg(target_os = "linux")]
+use std::io::Read;
+#[cfg(target_os = "linux")]
+use std::process::{Child, Command, Stdio};
+#[cfg(target_os = "linux")]
 use std::thread;
+#[cfg(target_os = "linux")]
 use std::time::Duration;
 
 use crate::digital_audio::DIGITAL_INPUT_NAME;
@@ -58,10 +64,14 @@ impl DigitalTxInput {
             available: AtomicBool::new(false),
             mic_shared,
         });
-        let worker = Arc::clone(&me);
-        let _ = thread::Builder::new()
-            .name("digital-tx".into())
-            .spawn(move || capture_loop(worker));
+        // The monitor-capture thread (and its parec/pw-record child) is Linux-only.
+        #[cfg(target_os = "linux")]
+        {
+            let worker = Arc::clone(&me);
+            let _ = thread::Builder::new()
+                .name("digital-tx".into())
+                .spawn(move || capture_loop(worker));
+        }
         me
     }
 
@@ -106,6 +116,7 @@ impl DigitalTxInput {
 /// silence at the front of each transmission (startup underruns).  Once we've
 /// been keyed at least once we leave the recorder running and just *discard* its
 /// samples while unkeyed — so the next key-down forwards live audio instantly.
+#[cfg(target_os = "linux")]
 fn capture_loop(shared: Arc<DigitalTxInput>) {
     let mut child: Option<Child> = None;
     // Holds a partial float across reads so 4-byte samples stay aligned.
@@ -199,6 +210,7 @@ fn capture_loop(shared: Arc<DigitalTxInput>) {
 /// Spawn a raw mono/48k/float32 recorder reading `RigflowDigitalInput.monitor`
 /// and writing PCM to stdout.  Tries `parec` (Pulse/PipeWire-pulse) then
 /// `pw-record` (PipeWire-native).
+#[cfg(target_os = "linux")]
 fn spawn_recorder() -> Option<Child> {
     let monitor = format!("{DIGITAL_INPUT_NAME}.monitor");
 
@@ -237,6 +249,7 @@ fn spawn_recorder() -> Option<Child> {
         .ok()
 }
 
+#[cfg(target_os = "linux")]
 fn stop_child(child: &mut Option<Child>) {
     if let Some(mut c) = child.take() {
         let _ = c.kill();

--- a/rigflow-client/src/main.rs
+++ b/rigflow-client/src/main.rs
@@ -118,6 +118,7 @@ mod net;
 mod persistence;
 mod rigctl_server;
 mod sidetone;
+mod tci_server;
 mod ui;
 mod widgets;
 
@@ -204,6 +205,20 @@ fn main() -> Result<(), eframe::Error> {
         let cmd_tx_for_cat = ws_cmd_tx.clone();
         rt.spawn(async move {
             rigctl_server::RigctlServer::new(ui_state_for_cat, cmd_tx_for_cat)
+                .run()
+                .await;
+        });
+    }
+
+    // TCI server on 127.0.0.1:40001 for TCI-capable digital apps (JTDX,
+    // WSJT-X-Improved): carries CAT + PTT + RX/TX audio over one WebSocket, so
+    // FT8 works with no virtual audio driver (no BlackHole) and no mic
+    // permission.  Coexists with the rigctld CAT server above.
+    {
+        let ui_state_for_tci = Arc::clone(&ui_state);
+        let cmd_tx_for_tci = ws_cmd_tx.clone();
+        rt.spawn(async move {
+            tci_server::TciServer::new(ui_state_for_tci, cmd_tx_for_tci)
                 .run()
                 .await;
         });

--- a/rigflow-client/src/net/udp.rs
+++ b/rigflow-client/src/net/udp.rs
@@ -62,6 +62,7 @@ pub fn handle_media_packet(
     stats: &Arc<Mutex<MediaPacketStats>>,
     cw_decoder: &mut crate::cw_decode::CwDecoder,
     digital_rx: &crate::digital_rx::DigitalRxOutput,
+    tci_rx_audio: &crate::tci_server::TciRxAudio,
 ) {
     let Some(header) = parse_media_header(packet) else {
         return;
@@ -84,7 +85,14 @@ pub fn handle_media_packet(
                 update_sequence_stats(&mut s, StreamKind::Audio, header.sequence);
             }
 
-            handle_audio_packet(payload, header.sequence, jitter, cw_decoder, digital_rx);
+            handle_audio_packet(
+                payload,
+                header.sequence,
+                jitter,
+                cw_decoder,
+                digital_rx,
+                tci_rx_audio,
+            );
         }
 
         STREAM_TYPE_WATERFALL => {
@@ -138,6 +146,7 @@ fn handle_audio_packet(
     jitter: &Arc<Mutex<JitterBuffer>>,
     cw_decoder: &mut crate::cw_decode::CwDecoder,
     digital_rx: &crate::digital_rx::DigitalRxOutput,
+    tci_rx_audio: &crate::tci_server::TciRxAudio,
 ) {
     if payload.len() < 2 || !payload.len().is_multiple_of(2) {
         return;
@@ -157,6 +166,9 @@ fn handle_audio_packet(
     // Mirror a copy to the digital RX output sink (no-op unless enabled).  This
     // tap is post-server-volume; the speaker path below is unaffected.
     digital_rx.push(&samples);
+
+    // Same tap for the TCI server (no-op unless a TCI client is streaming).
+    tci_rx_audio.push(&samples);
 
     if let Ok(mut jb) = jitter.lock() {
         jb.push_packet(sequence, samples);

--- a/rigflow-client/src/net/websocket.rs
+++ b/rigflow-client/src/net/websocket.rs
@@ -87,7 +87,7 @@ pub async fn websocket_control_task(
                         let renew = ClientRadioMessage::RenewLease;
                         let text = serde_json::to_string(&renew)?;
 
-                        info!("CLIENT sending RenewLease");
+                        debug!("CLIENT sending RenewLease");
 
                         write.send(Message::Text(text.into())).await?;
                     }
@@ -197,11 +197,11 @@ pub async fn websocket_control_task(
                     }
 
             Some(ControlCommand::RadioMessage(cmd)) => {
-            info!("WEBSOCKET got RadioMessage: {:?}", cmd);
+            debug!("WEBSOCKET got RadioMessage: {:?}", cmd);
 
             if let Some(write) = write_opt.as_mut() {
                 let text = serde_json::to_string(&cmd)?;
-                info!("WEBSOCKET sending text: {}", text);
+                debug!("WEBSOCKET sending text: {}", text);
 
                 write.send(Message::Text(text.into())).await?;
             }
@@ -224,7 +224,7 @@ pub async fn websocket_control_task(
                         if let Ok(radio_msg) =
                             serde_json::from_str::<ServerRadioMessage>(&text)
                         {
-                            info!("CLIENT got radio message: {:?}", radio_msg);
+                            debug!("CLIENT got radio message: {:?}", radio_msg);
 
                             // Single-client policy: the server already has a
                             // client.  Keep retrying through its heartbeat-eviction
@@ -253,7 +253,7 @@ pub async fn websocket_control_task(
                                 &audio_session_generation,
                             ) {
                                 let text = serde_json::to_string(&outgoing)?;
-                                info!("CLIENT sending radio message: {}", text);
+                                debug!("CLIENT sending radio message: {}", text);
 
                                 if let Some(write) = write_opt.as_mut() {
                                     write.send(Message::Text(text.into())).await?;
@@ -266,7 +266,7 @@ pub async fn websocket_control_task(
                             let mut state = ui_state.lock().unwrap();
                             state.runtime_error = format!("error: {}", message);
                         } else {
-                            info!("CLIENT unknown message: {}", text);
+                            debug!("CLIENT unknown message: {}", text);
                         }
                     }
 

--- a/rigflow-client/src/tci_server.rs
+++ b/rigflow-client/src/tci_server.rs
@@ -168,9 +168,20 @@ impl TciServer {
             Ok(l) => l,
             Err(e) => {
                 log::error!("[tci] failed to bind 127.0.0.1:{}: {e}", self.port);
+                // Surface the bind failure to the UI (mirrors rigctl_status), so
+                // the WSJT-X/FT8 Setup window can show it instead of silent dead air.
+                if let Ok(mut s) = self.shared.ui_state.lock() {
+                    s.tci_status = Some(format!(
+                        "TCI server cannot bind 127.0.0.1:{} — {e}",
+                        self.port
+                    ));
+                }
                 return;
             }
         };
+        if let Ok(mut s) = self.shared.ui_state.lock() {
+            s.tci_status = None; // bound OK
+        }
         log::info!("[tci] TCI server listening on ws://127.0.0.1:{}", self.port);
 
         loop {
@@ -437,7 +448,7 @@ fn handle_tx_audio(buf: &[u8], shared: &TciShared) {
 
     let seen = TX_FRAMES_SEEN.fetch_add(1, Ordering::Relaxed) + 1;
     if seen == 1 || seen % 50 == 0 {
-        log::info!(
+        log::debug!(
             "[tci] TX frame #{seen}: {} bytes, data_type={data_type}, rate={sample_rate}, \
              length={length} (expect data_type={TCI_STREAM_TX_AUDIO})",
             buf.len()
@@ -456,19 +467,7 @@ fn handle_tx_audio(buf: &[u8], shared: &TciShared) {
         return;
     }
 
-    // Read only the first `length` floats (the valid, interleaved-stereo region)
-    // and downmix to mono — yielding length/2 samples per chrono.  Sanitise any
-    // stray non-finite value so garbage never reaches the modulator / HL2 DAC.
-    let avail = (buf.len() - TCI_HEADER_LEN) / 4;
-    let valid = length.min(avail);
-    let mut samples = Vec::with_capacity(valid);
-    for i in 0..valid {
-        let o = TCI_HEADER_LEN + i * 4;
-        let s = f32::from_le_bytes([buf[o], buf[o + 1], buf[o + 2], buf[o + 3]]);
-        samples.push(if s.is_finite() { s } else { 0.0 });
-    }
-
-    let mono = downmix(&samples, 2); // WSJT-X TX audio is interleaved stereo
+    let mono = tx_stereo_to_mono(buf, length);
     let out = resample(&mono, sample_rate as f32, TX_SERVER_RATE_HZ as f32);
 
     // Log signal level so we can tell "no frames" from "silent frames" from
@@ -481,7 +480,7 @@ fn handle_tx_audio(buf: &[u8], shared: &TciShared) {
         } else {
             (out.iter().map(|&s| s * s).sum::<f32>() / out.len() as f32).sqrt()
         };
-        log::info!(
+        log::debug!(
             "[tci] TX audio fed #{fed}: {} samples, peak={peak:.3}, rms={rms:.4}, \
              streaming={}",
             out.len(),
@@ -490,6 +489,22 @@ fn handle_tx_audio(buf: &[u8], shared: &TciShared) {
     }
 
     shared.mic_shared.push_tx(&out);
+}
+
+/// Decode a `TxAudioStream` frame body to mono.  WSJT-X fills only the first
+/// `length` floats (interleaved stereo) of a `length*2` buffer — the tail is
+/// uninitialised heap — so read exactly `length`, sanitise non-finite samples
+/// (NaN/Inf garbage must never reach the modulator / HL2 DAC), and downmix by 2.
+fn tx_stereo_to_mono(buf: &[u8], length: usize) -> Vec<f32> {
+    let avail = buf.len().saturating_sub(TCI_HEADER_LEN) / 4;
+    let valid = length.min(avail);
+    let mut samples = Vec::with_capacity(valid);
+    for i in 0..valid {
+        let o = TCI_HEADER_LEN + i * 4;
+        let s = f32::from_le_bytes([buf[o], buf[o + 1], buf[o + 2], buf[o + 3]]);
+        samples.push(if s.is_finite() { s } else { 0.0 });
+    }
+    downmix(&samples, 2)
 }
 
 /// Build the next outbound RX-audio frame (drains the tap, resamples to the
@@ -530,7 +545,12 @@ fn interleave(mono: &[f32], channels: u32) -> Vec<f32> {
 
 /// Encode a TCI `Data_Stream` packet: 8×u32 header (`<8I`) + 32 bytes pad +
 /// little-endian float32 samples.  `length` is the sample count.  SPIKE: mono.
-fn encode_data_stream(sample_rate: u32, stream_type: u32, channels: u32, samples: &[f32]) -> Vec<u8> {
+fn encode_data_stream(
+    sample_rate: u32,
+    stream_type: u32,
+    channels: u32,
+    samples: &[f32],
+) -> Vec<u8> {
     let mut v = Vec::with_capacity(TCI_HEADER_LEN + samples.len() * 4);
     let header: [u32; 8] = [
         0,                    // receiver
@@ -598,7 +618,11 @@ fn current_demod(shared: &TciShared) -> DemodMode {
 /// recenter the LO on a band change so far jumps actually take.
 fn set_frequency(shared: &TciShared, hz: u64) {
     let (center, sample_rate, limits) = match shared.ui_state.lock() {
-        Ok(s) => (s.center_freq_hz, s.input_sample_rate_hz, active_freq_limits(&s)),
+        Ok(s) => (
+            s.center_freq_hz,
+            s.input_sample_rate_hz,
+            active_freq_limits(&s),
+        ),
         Err(_) => return,
     };
     let freq = clamp_center(hz as f32, &limits);
@@ -747,4 +771,93 @@ fn resample(input: &[f32], from_hz: f32, to_hz: f32) -> Vec<f32> {
         pos += step;
     }
     out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn u32_at(buf: &[u8], byte: usize) -> u32 {
+        u32::from_le_bytes([buf[byte], buf[byte + 1], buf[byte + 2], buf[byte + 3]])
+    }
+
+    /// Build a TxAudioStream frame body: 64-byte header + the given floats.  The
+    /// header `length` is set independently so tests can mimic WSJT-X sending a
+    /// `length*2` buffer whose tail is uninitialised.
+    fn tx_frame(length: u32, floats: &[f32]) -> Vec<u8> {
+        let mut v = encode_data_stream(48_000, TCI_STREAM_TX_AUDIO, 2, floats);
+        v[20..24].copy_from_slice(&length.to_le_bytes()); // override length field
+        v
+    }
+
+    #[test]
+    fn chrono_is_header_only_with_expected_fields() {
+        let frame = encode_tx_chrono(48_000, 1920);
+        assert_eq!(
+            frame.len(),
+            TCI_HEADER_LEN,
+            "chrono carries no audio payload"
+        );
+        assert_eq!(u32_at(&frame, 4), 48_000); // sample_rate
+        assert_eq!(u32_at(&frame, 8), TCI_SAMPLE_FLOAT32); // format
+        assert_eq!(u32_at(&frame, 20), 1920); // length (float budget)
+        assert_eq!(u32_at(&frame, 24), TCI_STREAM_TX_CHRONO); // type = 3
+    }
+
+    #[test]
+    fn data_stream_header_round_trips() {
+        let frame = encode_data_stream(48_000, TCI_STREAM_RX_AUDIO, 2, &[0.5, -0.5, 0.25, -0.25]);
+        assert_eq!(frame.len(), TCI_HEADER_LEN + 4 * 4);
+        assert_eq!(u32_at(&frame, 4), 48_000);
+        assert_eq!(u32_at(&frame, 20), 4); // length = float count
+        assert_eq!(u32_at(&frame, 24), TCI_STREAM_RX_AUDIO);
+    }
+
+    #[test]
+    fn downmix_averages_interleaved_stereo() {
+        assert_eq!(downmix(&[1.0, 3.0, 2.0, 4.0], 2), vec![2.0, 3.0]);
+        assert_eq!(downmix(&[1.0, 2.0, 3.0], 1), vec![1.0, 2.0, 3.0]);
+    }
+
+    #[test]
+    fn tx_decode_reads_only_valid_length_and_downmixes() {
+        // length=6 valid floats (3 stereo frames, L==R) → 3 mono samples.
+        let frame = tx_frame(6, &[1.0, 1.0, 2.0, 2.0, 3.0, 3.0]);
+        assert_eq!(tx_stereo_to_mono(&frame, 6), vec![1.0, 2.0, 3.0]);
+    }
+
+    #[test]
+    fn tx_decode_ignores_uninitialised_tail() {
+        // WSJT-X allocates length*2 floats but fills only `length`; the tail is
+        // garbage (incl. NaN/Inf) and must never be read.
+        let floats = [1.0, 1.0, 2.0, 2.0, f32::NAN, f32::INFINITY, 9.9e30, -9.9e30];
+        let frame = tx_frame(4, &floats); // only first 4 floats are valid
+        assert_eq!(tx_stereo_to_mono(&frame, 4), vec![1.0, 2.0]);
+    }
+
+    #[test]
+    fn tx_decode_sanitises_non_finite_within_valid_region() {
+        // A non-finite sample inside the valid region is zeroed, not propagated.
+        let frame = tx_frame(2, &[f32::NAN, 2.0]);
+        assert_eq!(tx_stereo_to_mono(&frame, 2), vec![1.0]); // (0.0 + 2.0) / 2
+    }
+
+    #[test]
+    fn chrono_length_yields_half_as_many_mono_samples() {
+        // Sizing contract: a chrono of float length N produces N/2 mono samples,
+        // so the pump must request 2× the mono samples it owes.
+        let n = 1920u32;
+        let valid: Vec<f32> = (0..n).map(|i| (i % 7) as f32 * 0.1).collect();
+        let frame = tx_frame(n, &valid);
+        assert_eq!(
+            tx_stereo_to_mono(&frame, n as usize).len(),
+            (n / 2) as usize
+        );
+    }
+
+    #[test]
+    fn mode_mapping_round_trips_ft8_data_usb() {
+        assert_eq!(tci_mode_to_demod("digu"), Some(DemodMode::DgtU));
+        assert_eq!(demod_to_tci_mode(DemodMode::DgtU), "digu");
+    }
 }

--- a/rigflow-client/src/tci_server.rs
+++ b/rigflow-client/src/tci_server.rs
@@ -1,0 +1,616 @@
+//! Minimal **TCI** (Transceiver Control Interface) server — macOS-FT8 spike.
+//!
+//! TCI is Expert Electronics' WebSocket protocol that carries CAT + PTT **and**
+//! RX/TX audio over one localhost connection, so a TCI-capable digital app
+//! (JTDX, WSJT-X-Improved, MSHV) can do FT8 with **no virtual audio driver**
+//! (no BlackHole) and **no macOS mic permission**.  Like the Hamlib `rigctld`
+//! server (`rigctl_server.rs`), this runs in the *client*, reads freq/mode from
+//! `UiState`, and issues control via the existing `ControlCommand` channel.
+//!
+//! ```text
+//!   JTDX ──ws://127.0.0.1:40001──▶ TciServer (here)
+//!     RX audio  ◀── binary Data_Stream frames (tap of received audio)
+//!     TX audio  ──▶ binary Data_Stream frames ─▶ MicShared::push_tx ─▶ UDP mic ─▶ server
+//!     freq/mode/PTT  ◀─▶ text commands ─▶ ControlCommand / UiState
+//! ```
+//!
+//! Scope boundary: this is **only** the localhost client↔app hop.  The Rigflow
+//! client↔server RF path is unchanged (UDP media + WebSocket control); TX audio
+//! still reaches the server via the existing `STREAM_TYPE_MIC_AUDIO` UDP stream.
+//!
+//! **Spike status:** single client, single receiver (`rx0`), the decode/transmit
+//! path only.  The exact handshake parameter set, the audio `channels` (mono vs
+//! interleaved stereo), and the IF/offset mapping are pinned empirically against
+//! JTDX; items flagged `SPIKE:` below are the first things to verify/adjust.
+
+use std::collections::VecDeque;
+use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use futures_util::{SinkExt, StreamExt};
+use tokio::net::{TcpListener, TcpStream};
+use tokio::sync::mpsc::UnboundedSender;
+use tokio_tungstenite::tungstenite::Message;
+
+use rigflow_core::dsp::modes::{DemodMode, Sideband};
+use rigflow_protocol::radio_control::ClientRadioMessage;
+
+use crate::mic::MicShared;
+use crate::net::control::ControlCommand;
+use crate::ui::freq_limits::{active_freq_limits, clamp_center};
+use crate::ui::state::UiState;
+
+/// Default TCI WebSocket port (JTDX/ExpertSDR default).
+pub const DEFAULT_TCI_PORT: u16 = 40001;
+
+/// RX audio rate the Rigflow server delivers (matches the speaker path).
+const RX_SERVER_RATE_HZ: u32 = 48_000;
+/// Mic-TX rate the Rigflow server expects on the UDP mic stream.
+const TX_SERVER_RATE_HZ: u32 = 48_000;
+/// Default TCI audio rate until the client sets one via `audio_samplerate`.
+const DEFAULT_AUDIO_RATE_HZ: u32 = 48_000;
+/// Audio channels we emit.  TCI audio (SunSDR, what WSJT-X is written against)
+/// is 2-channel interleaved; we duplicate mono into L/R.  SPIKE: drop to 1 if a
+/// client turns out to want mono.
+const TCI_AUDIO_CHANNELS: u32 = 2;
+
+/// `~0.5 s` at 48 kHz — bounds the RX tap ring; drop oldest on overrun.
+const RX_RING_MAX: usize = 24_000;
+
+/// TCI binary `Data_Stream` constants (header is 8×u32 then 32 bytes pad = 64).
+const TCI_HEADER_LEN: usize = 64;
+const TCI_SAMPLE_FLOAT32: u32 = 3; // TciSampleType::FLOAT32
+const TCI_STREAM_RX_AUDIO: u32 = 1; // TciStreamType::RX_AUDIO_STREAM
+const TCI_STREAM_TX_AUDIO: u32 = 2; // TciStreamType::TX_AUDIO_STREAM
+
+/// RX-audio tap fed by the media thread (`net::udp`) and drained by the TCI
+/// connection task.  No-op unless a client has requested `audio_start`.  Lives
+/// in `UiState` so both the media thread and the TCI task share one instance —
+/// the same pattern as `DigitalRxOutput`.
+#[derive(Debug)]
+pub struct TciRxAudio {
+    enabled: AtomicBool,
+    ring: Mutex<VecDeque<f32>>,
+}
+
+impl TciRxAudio {
+    pub fn new() -> Arc<Self> {
+        Arc::new(Self {
+            enabled: AtomicBool::new(false),
+            ring: Mutex::new(VecDeque::new()),
+        })
+    }
+
+    /// Enable/disable buffering (set by `audio_start`/`audio_stop`).  Clears the
+    /// ring on disable so a new session doesn't replay stale audio.
+    fn set_enabled(&self, on: bool) {
+        if self.enabled.swap(on, Ordering::Relaxed) != on && !on {
+            if let Ok(mut r) = self.ring.lock() {
+                r.clear();
+            }
+        }
+    }
+
+    /// Push a copy of received 48 kHz mono audio (media thread).  No-op unless a
+    /// TCI client is streaming.  Drop oldest past the cap so RX never stalls.
+    pub fn push(&self, samples: &[f32]) {
+        if !self.enabled.load(Ordering::Relaxed) {
+            return;
+        }
+        if let Ok(mut r) = self.ring.lock() {
+            r.extend(samples.iter().copied());
+            if r.len() > RX_RING_MAX {
+                let drop = r.len() - RX_RING_MAX;
+                r.drain(..drop);
+            }
+        }
+    }
+
+    fn drain(&self) -> Vec<f32> {
+        match self.ring.lock() {
+            Ok(mut r) => r.drain(..).collect(),
+            Err(_) => Vec::new(),
+        }
+    }
+}
+
+/// Shared handles each connection uses to read state and issue commands.
+struct TciShared {
+    ui_state: Arc<Mutex<UiState>>,
+    cmd_tx: UnboundedSender<ControlCommand>,
+    /// TX-audio sink (the same ring the mic/digital TX path feeds).
+    mic_shared: Arc<MicShared>,
+    /// RX-audio tap (shared with the media thread via `UiState`).
+    rx_audio: Arc<TciRxAudio>,
+    /// Negotiated TCI audio sample rate (`audio_samplerate`), default 48 kHz.
+    audio_rate_hz: AtomicU32,
+}
+
+/// The TCI WebSocket server.
+pub struct TciServer {
+    port: u16,
+    shared: Arc<TciShared>,
+}
+
+impl TciServer {
+    pub fn new(ui_state: Arc<Mutex<UiState>>, cmd_tx: UnboundedSender<ControlCommand>) -> Self {
+        let (mic_shared, rx_audio) = match ui_state.lock() {
+            Ok(s) => (Arc::clone(&s.mic_shared), Arc::clone(&s.tci_rx_audio)),
+            Err(_) => (Arc::new(MicShared::default()), TciRxAudio::new()),
+        };
+        Self {
+            port: DEFAULT_TCI_PORT,
+            shared: Arc::new(TciShared {
+                ui_state,
+                cmd_tx,
+                mic_shared,
+                rx_audio,
+                audio_rate_hz: AtomicU32::new(DEFAULT_AUDIO_RATE_HZ),
+            }),
+        }
+    }
+
+    /// Listen on `127.0.0.1:<port>` until the process exits.  Never panics.
+    pub async fn run(self) {
+        let listener = match TcpListener::bind(("127.0.0.1", self.port)).await {
+            Ok(l) => l,
+            Err(e) => {
+                log::error!("[tci] failed to bind 127.0.0.1:{}: {e}", self.port);
+                return;
+            }
+        };
+        log::info!("[tci] TCI server listening on ws://127.0.0.1:{}", self.port);
+
+        loop {
+            match listener.accept().await {
+                Ok((stream, peer)) => {
+                    let shared = Arc::clone(&self.shared);
+                    tokio::spawn(async move {
+                        log::info!("[tci] client connected: {peer}");
+                        if let Err(e) = handle_connection(stream, &shared).await {
+                            log::debug!("[tci] connection error ({peer}): {e}");
+                        }
+                        // Leave the rig safe if the app vanished mid-transmit.
+                        end_session(&shared);
+                        log::info!("[tci] client disconnected: {peer}");
+                    });
+                }
+                Err(e) => log::warn!("[tci] accept failed: {e}"),
+            }
+        }
+    }
+}
+
+/// Per-connection loop: WebSocket upgrade, send the handshake, then interleave
+/// inbound commands/TX-audio with periodic RX-audio frames.
+async fn handle_connection(
+    stream: TcpStream,
+    shared: &Arc<TciShared>,
+) -> Result<(), tokio_tungstenite::tungstenite::Error> {
+    let ws = tokio_tungstenite::accept_async(stream).await?;
+    let (mut sink, mut source) = ws.split();
+
+    // Initialization handshake the client waits for before going ready.
+    for line in handshake_lines(shared) {
+        sink.send(Message::text(line)).await?;
+    }
+
+    // RX audio is flushed on a fixed cadence; ~20 ms keeps latency low and frames
+    // a sensible size (~960 samples at 48 kHz).
+    let mut flush = tokio::time::interval(Duration::from_millis(20));
+    let mut rx_frames_sent = 0u64;
+
+    loop {
+        tokio::select! {
+            msg = source.next() => {
+                let Some(msg) = msg else { break };
+                match msg? {
+                    Message::Text(text) => {
+                        // A frame may carry several `;`-terminated commands.
+                        for cmd in text.as_str().split(';') {
+                            let cmd = cmd.trim();
+                            if cmd.is_empty() {
+                                continue;
+                            }
+                            log::debug!("[tci] cmd: {cmd}");
+                            if let Some(reply) = handle_text_command(cmd, shared) {
+                                sink.send(Message::text(reply)).await?;
+                            }
+                        }
+                    }
+                    Message::Binary(buf) => handle_tx_audio(&buf, shared),
+                    Message::Ping(p) => sink.send(Message::Pong(p)).await?,
+                    Message::Close(_) => break,
+                    _ => {}
+                }
+            }
+            _ = flush.tick() => {
+                if shared.rx_audio.enabled.load(Ordering::Relaxed) {
+                    if let Some(frame) = next_rx_frame(shared) {
+                        let samples = (frame.len() - TCI_HEADER_LEN) / 4;
+                        sink.send(Message::binary(frame)).await?;
+                        rx_frames_sent += 1;
+                        if rx_frames_sent == 1 || rx_frames_sent % 50 == 0 {
+                            log::debug!(
+                                "[tci] sent {rx_frames_sent} RX audio frames ({samples} floats last)"
+                            );
+                        }
+                    }
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+/// The parameter burst sent on connect.  SPIKE: this is a reasonable superset of
+/// what TCI clients read at startup; trim/extend against JTDX's actual reads.
+fn handshake_lines(shared: &TciShared) -> Vec<String> {
+    let freq = current_freq_hz(shared);
+    let mode = demod_to_tci_mode(current_demod(shared));
+    vec![
+        "protocol:Rigflow,1.8;".to_string(),
+        "device:Rigflow;".to_string(),
+        "receive_only:false;".to_string(),
+        "trx_count:1;".to_string(),
+        "channels_count:1;".to_string(),
+        "vfo_limits:0,500000000;".to_string(),
+        "if_limits:-24000,24000;".to_string(),
+        "modulations_list:am,sam,dsb,lsb,usb,cw,nfm,digl,digu,wfm;".to_string(),
+        format!("dds:0,{freq};"),
+        format!("vfo:0,0,{freq};"),
+        "if:0,0,0;".to_string(),
+        format!("modulation:0,{mode};"),
+        "rx_enable:0,true;".to_string(),
+        "trx:0,false;".to_string(),
+        "start;".to_string(),
+        "ready;".to_string(),
+    ]
+}
+
+/// Handle one text command (`name` or `name:arg,arg`).  Returns an optional
+/// reply line.  Sets carry the value param; bare-`rx` reads are answered.
+fn handle_text_command(cmd: &str, shared: &TciShared) -> Option<String> {
+    let (name, args) = match cmd.split_once(':') {
+        Some((n, a)) => (n.trim(), a.trim()),
+        None => (cmd.trim(), ""),
+    };
+    let params: Vec<&str> = if args.is_empty() {
+        Vec::new()
+    } else {
+        args.split(',').map(|s| s.trim()).collect()
+    };
+
+    match name {
+        // dds:rx,freq / vfo:rx,chan,freq — set (value present) or read.  ALWAYS
+        // echo the resulting state: TCI clients (WSJT-X) block waiting for this
+        // confirmation after setting the frequency, and time out without it.
+        "dds" | "vfo" => {
+            // vfo carries an extra channel index: vfo:rx,chan,freq.
+            let val_idx = if name == "vfo" { 2 } else { 1 };
+            if let Some(hz) = params.get(val_idx).and_then(|s| s.parse::<f64>().ok()) {
+                set_frequency(shared, hz.max(0.0) as u64);
+            }
+            let f = current_freq_hz(shared);
+            Some(if name == "vfo" {
+                format!("vfo:0,0,{f};")
+            } else {
+                format!("dds:0,{f};")
+            })
+        }
+
+        // modulation:rx,mode — set or read; always echo the current mode.
+        "modulation" => {
+            if let Some(m) = params.get(1) {
+                set_mode_by_name(shared, m);
+            }
+            Some(format!(
+                "modulation:0,{};",
+                demod_to_tci_mode(current_demod(shared))
+            ))
+        }
+
+        // trx:rx,state (PTT set) | trx:rx (read).
+        "trx" => match params.get(1).copied() {
+            Some(state) => {
+                let on = state.eq_ignore_ascii_case("true");
+                set_ptt(shared, on);
+                Some(format!("trx:0,{};", if on { "true" } else { "false" }))
+            }
+            None => {
+                let on = shared.ui_state.lock().map(|s| s.cat_ptt).unwrap_or(false);
+                Some(format!("trx:0,{};", if on { "true" } else { "false" }))
+            }
+        },
+
+        // WSJT-X blocks its startup waiting for the server to ECHO audio_start
+        // (Cmd_AudioStart sets stream_audio_ only on the echo); without it the
+        // rig init times out → "Rig Control Error".  Same for stop/samplerate.
+        "audio_start" => {
+            shared.rx_audio.set_enabled(true);
+            log::info!("[tci] RX audio streaming started");
+            Some(format!("{cmd};"))
+        }
+        "audio_stop" => {
+            shared.rx_audio.set_enabled(false);
+            log::info!("[tci] RX audio streaming stopped");
+            Some(format!("{cmd};"))
+        }
+        "audio_samplerate" => {
+            if let Some(rate) = params.first().and_then(|s| s.parse::<u32>().ok()) {
+                shared.audio_rate_hz.store(rate.max(1), Ordering::Relaxed);
+                log::info!("[tci] audio sample rate set to {rate} Hz");
+            }
+            Some(format!("{cmd};"))
+        }
+
+        // Reflect these back as the accept-confirmation the client expects (the
+        // rig has no real IF offset / split, so they're otherwise no-ops).
+        "if" | "rx_enable" | "split_enable" | "start" | "stop" => Some(format!("{cmd};")),
+
+        other => {
+            log::debug!("[tci] unhandled command: {other}");
+            None
+        }
+    }
+}
+
+/// Decode an inbound TX-audio `Data_Stream` and feed it to the mic-TX ring.
+fn handle_tx_audio(buf: &[u8], shared: &TciShared) {
+    if buf.len() < TCI_HEADER_LEN {
+        return;
+    }
+    let u32_at = |i: usize| u32::from_le_bytes([buf[i], buf[i + 1], buf[i + 2], buf[i + 3]]);
+    let sample_rate = u32_at(4);
+    let length = u32_at(20) as usize; // field 5 (sample count)
+    let data_type = u32_at(24); // field 6 (TciStreamType)
+    let channels = u32_at(28).max(1); // field 7
+
+    if data_type != TCI_STREAM_TX_AUDIO {
+        return; // ignore IQ / chrono / unexpected streams
+    }
+
+    let avail = (buf.len() - TCI_HEADER_LEN) / 4;
+    let n = length.min(avail);
+    let mut samples = Vec::with_capacity(n);
+    for i in 0..n {
+        let o = TCI_HEADER_LEN + i * 4;
+        samples.push(f32::from_le_bytes([buf[o], buf[o + 1], buf[o + 2], buf[o + 3]]));
+    }
+
+    let mono = downmix(&samples, channels);
+    let out = resample(&mono, sample_rate as f32, TX_SERVER_RATE_HZ as f32);
+    shared.mic_shared.push_tx(&out);
+}
+
+/// Build the next outbound RX-audio frame (drains the tap, resamples to the
+/// negotiated rate, encodes a `Data_Stream`).  `None` when nothing is buffered.
+fn next_rx_frame(shared: &TciShared) -> Option<Vec<u8>> {
+    let mono48 = shared.rx_audio.drain();
+    if mono48.is_empty() {
+        return None;
+    }
+    let rate = shared.audio_rate_hz.load(Ordering::Relaxed).max(1);
+    let out = resample(&mono48, RX_SERVER_RATE_HZ as f32, rate as f32);
+    if out.is_empty() {
+        return None;
+    }
+    let buf = interleave(&out, TCI_AUDIO_CHANNELS);
+    Some(encode_data_stream(
+        rate,
+        TCI_STREAM_RX_AUDIO,
+        TCI_AUDIO_CHANNELS,
+        &buf,
+    ))
+}
+
+/// Duplicate mono into `channels` interleaved channels (no-op for mono).
+fn interleave(mono: &[f32], channels: u32) -> Vec<f32> {
+    if channels <= 1 {
+        return mono.to_vec();
+    }
+    let ch = channels as usize;
+    let mut out = Vec::with_capacity(mono.len() * ch);
+    for &s in mono {
+        for _ in 0..ch {
+            out.push(s);
+        }
+    }
+    out
+}
+
+/// Encode a TCI `Data_Stream` packet: 8×u32 header (`<8I`) + 32 bytes pad +
+/// little-endian float32 samples.  `length` is the sample count.  SPIKE: mono.
+fn encode_data_stream(sample_rate: u32, stream_type: u32, channels: u32, samples: &[f32]) -> Vec<u8> {
+    let mut v = Vec::with_capacity(TCI_HEADER_LEN + samples.len() * 4);
+    let header: [u32; 8] = [
+        0,                    // receiver
+        sample_rate,          // sample_rate
+        TCI_SAMPLE_FLOAT32,   // data_format
+        0,                    // codec
+        0,                    // crc (unused)
+        samples.len() as u32, // length (total float count)
+        stream_type,          // data_type
+        channels,             // channels
+    ];
+    for field in header {
+        v.extend_from_slice(&field.to_le_bytes());
+    }
+    v.extend_from_slice(&[0u8; 32]); // pad header to 64 bytes
+    for s in samples {
+        v.extend_from_slice(&s.to_le_bytes());
+    }
+    v
+}
+
+// ── State access (mirrors rigctl_server.rs) ──────────────────────────────────
+
+fn current_freq_hz(shared: &TciShared) -> u64 {
+    shared
+        .ui_state
+        .lock()
+        .map(|s| s.target_freq_hz.max(0.0) as u64)
+        .unwrap_or(0)
+}
+
+fn current_demod(shared: &TciShared) -> DemodMode {
+    shared
+        .ui_state
+        .lock()
+        .map(|s| s.demod_mode)
+        .unwrap_or(DemodMode::Usb)
+}
+
+/// Tune to a TCI frequency — same in-band-vs-band-change logic as the CAT path
+/// (`rigctl_server::set_frequency`): move the target within the visible band, or
+/// recenter the LO on a band change so far jumps actually take.
+fn set_frequency(shared: &TciShared, hz: u64) {
+    let (center, sample_rate, limits) = match shared.ui_state.lock() {
+        Ok(s) => (s.center_freq_hz, s.input_sample_rate_hz, active_freq_limits(&s)),
+        Err(_) => return,
+    };
+    let freq = clamp_center(hz as f32, &limits);
+    let half_bw = (sample_rate / 2.0).max(0.0);
+    let in_band = half_bw > 0.0 && (freq - center).abs() <= half_bw;
+
+    if in_band {
+        if let Ok(mut s) = shared.ui_state.lock() {
+            s.target_freq_hz = freq;
+        }
+        let _ = shared.cmd_tx.send(ControlCommand::RadioMessage(
+            ClientRadioMessage::SetTargetFrequency {
+                target_freq_hz: freq as u64,
+            },
+        ));
+    } else {
+        if let Ok(mut s) = shared.ui_state.lock() {
+            s.center_freq_hz = freq;
+            s.target_freq_hz = freq;
+        }
+        let _ = shared.cmd_tx.send(ControlCommand::RadioMessage(
+            ClientRadioMessage::SetCenterFrequency {
+                center_freq_hz: freq as u64,
+            },
+        ));
+        let _ = shared.cmd_tx.send(ControlCommand::RadioMessage(
+            ClientRadioMessage::SetTargetFrequency {
+                target_freq_hz: freq as u64,
+            },
+        ));
+    }
+}
+
+/// Set the demod from a TCI modulation name (maps `digu`→data-USB, etc.).
+fn set_mode_by_name(shared: &TciShared, name: &str) {
+    let Some(mode) = tci_mode_to_demod(name) else {
+        log::warn!("[tci] unsupported modulation: {name}");
+        return;
+    };
+    if let Ok(mut s) = shared.ui_state.lock() {
+        s.demod_mode = mode;
+    }
+    let _ = shared.cmd_tx.send(ControlCommand::RadioMessage(
+        ClientRadioMessage::SetDemodMode { mode },
+    ));
+    if matches!(mode, DemodMode::Usb | DemodMode::Lsb) {
+        let sideband = if mode == DemodMode::Usb {
+            Sideband::Usb
+        } else {
+            Sideband::Lsb
+        };
+        let _ = shared.cmd_tx.send(ControlCommand::RadioMessage(
+            ClientRadioMessage::SetSideband { sideband },
+        ));
+    }
+}
+
+/// Key/unkey TX.  The TCI server is itself the TX-audio producer, so it claims
+/// the mic-TX ring as the external source (suppressing the always-on mic
+/// capture) and enables streaming, then keys the server — exactly the contract
+/// `rigctl_server::set_ptt` + `DigitalTxInput::set_active` use on Linux.
+fn set_ptt(shared: &TciShared, on: bool) {
+    if let Ok(mut s) = shared.ui_state.lock() {
+        s.cat_ptt = on;
+    }
+    if on {
+        shared.mic_shared.set_external_tx_source(true);
+        shared.mic_shared.set_tx_streaming(true);
+    } else {
+        shared.mic_shared.set_tx_streaming(false);
+        shared.mic_shared.set_external_tx_source(false);
+    }
+    let msg = if on {
+        ClientRadioMessage::StartMicTx
+    } else {
+        ClientRadioMessage::StopMicTx
+    };
+    let _ = shared.cmd_tx.send(ControlCommand::RadioMessage(msg));
+}
+
+/// On disconnect: stop RX streaming and unkey if we left TX on.
+fn end_session(shared: &TciShared) {
+    shared.rx_audio.set_enabled(false);
+    if shared.ui_state.lock().map(|s| s.cat_ptt).unwrap_or(false) {
+        set_ptt(shared, false);
+    }
+}
+
+// ── Helpers: mode mapping, resample, downmix ─────────────────────────────────
+
+fn tci_mode_to_demod(m: &str) -> Option<DemodMode> {
+    match m.to_ascii_lowercase().as_str() {
+        "usb" => Some(DemodMode::Usb),
+        "digu" | "pktusb" => Some(DemodMode::DgtU), // data-USB (FT8)
+        "lsb" | "digl" | "pktlsb" => Some(DemodMode::Lsb),
+        "cw" | "cwu" => Some(DemodMode::Cwu),
+        "cwr" | "cwl" => Some(DemodMode::Cwl),
+        "am" | "sam" | "dsb" => Some(DemodMode::Am),
+        "nfm" | "fm" => Some(DemodMode::Nfm),
+        "wfm" => Some(DemodMode::Wfm),
+        _ => None,
+    }
+}
+
+fn demod_to_tci_mode(mode: DemodMode) -> &'static str {
+    match mode {
+        DemodMode::Usb => "usb",
+        DemodMode::DgtU => "digu",
+        DemodMode::Lsb => "lsb",
+        DemodMode::Cwu => "cw",
+        DemodMode::Cwl => "cwr",
+        DemodMode::Am => "am",
+        DemodMode::Nfm => "nfm",
+        DemodMode::Wfm => "wfm",
+    }
+}
+
+/// Downmix interleaved frames to mono (no-op for 1 channel).
+fn downmix(samples: &[f32], channels: u32) -> Vec<f32> {
+    if channels <= 1 {
+        return samples.to_vec();
+    }
+    let ch = channels as usize;
+    samples
+        .chunks(ch)
+        .map(|f| f.iter().sum::<f32>() / f.len() as f32)
+        .collect()
+}
+
+/// Stateless linear resampler.  SPIKE: resets phase per call, so block-boundary
+/// error is one interpolation step (~negligible for FT8); carry phase if needed.
+fn resample(input: &[f32], from_hz: f32, to_hz: f32) -> Vec<f32> {
+    if input.is_empty() || (from_hz - to_hz).abs() < 1.0 {
+        return input.to_vec();
+    }
+    let step = from_hz / to_hz; // input advance per output sample
+    let mut out = Vec::with_capacity(((input.len() as f32) * (to_hz / from_hz)) as usize + 1);
+    let mut pos = 0.0f32;
+    while (pos as usize) + 1 < input.len() {
+        let i = pos as usize;
+        let frac = pos - i as f32;
+        out.push(input[i] + (input[i + 1] - input[i]) * frac);
+        pos += step;
+    }
+    out
+}

--- a/rigflow-client/src/tci_server.rs
+++ b/rigflow-client/src/tci_server.rs
@@ -24,7 +24,7 @@
 //! JTDX; items flagged `SPIKE:` below are the first things to verify/adjust.
 
 use std::collections::VecDeque;
-use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
@@ -63,6 +63,13 @@ const TCI_HEADER_LEN: usize = 64;
 const TCI_SAMPLE_FLOAT32: u32 = 3; // TciSampleType::FLOAT32
 const TCI_STREAM_RX_AUDIO: u32 = 1; // TciStreamType::RX_AUDIO_STREAM
 const TCI_STREAM_TX_AUDIO: u32 = 2; // TciStreamType::TX_AUDIO_STREAM
+const TCI_STREAM_TX_CHRONO: u32 = 3; // TciStreamType::TxChrono (TX clock)
+
+/// Safety ceiling on mono samples requested per `TxChrono`.  WSJT-X allocates
+/// `length*2` floats in `data[8192]` and returns `length/2` mono samples, so the
+/// chrono's float `length` = mono*2 must stay ≤ 8192 → mono ≤ 2048.  The pump
+/// otherwise paces to wall-clock time.
+const TX_CHRONO_MAX_MONO: u32 = 2048;
 
 /// RX-audio tap fed by the media thread (`net::udp`) and drained by the TCI
 /// connection task.  No-op unless a client has requested `audio_start`.  Lives
@@ -125,6 +132,9 @@ struct TciShared {
     rx_audio: Arc<TciRxAudio>,
     /// Negotiated TCI audio sample rate (`audio_samplerate`), default 48 kHz.
     audio_rate_hz: AtomicU32,
+    /// True while keyed (PTT on).  The connection loop sends `TxChrono` frames
+    /// while this is set — WSJT-X only streams TX audio in reply to chronos.
+    tx_active: AtomicBool,
 }
 
 /// The TCI WebSocket server.
@@ -147,6 +157,7 @@ impl TciServer {
                 mic_shared,
                 rx_audio,
                 audio_rate_hz: AtomicU32::new(DEFAULT_AUDIO_RATE_HZ),
+                tx_active: AtomicBool::new(false),
             }),
         }
     }
@@ -197,9 +208,18 @@ async fn handle_connection(
     }
 
     // RX audio is flushed on a fixed cadence; ~20 ms keeps latency low and frames
-    // a sensible size (~960 samples at 48 kHz).
+    // a sensible size (~960 samples at 48 kHz).  The same tick clocks TxChrono.
     let mut flush = tokio::time::interval(Duration::from_millis(20));
     let mut rx_frames_sent = 0u64;
+
+    // TxChrono pacing: while keyed, request TX samples at exactly real-time so the
+    // FT8 waveform plays at the right speed.  `tx_start`/`tx_samples_requested`
+    // lock the cumulative request count to wall-clock, self-correcting timer
+    // jitter (sending too fast time-compresses the on-air signal → no decode).
+    let mut tx_was_active = false;
+    let mut tx_start = tokio::time::Instant::now();
+    let mut tx_samples_requested: u64 = 0;
+    let mut tx_chronos_sent = 0u64;
 
     loop {
         tokio::select! {
@@ -238,6 +258,39 @@ async fn handle_connection(
                         }
                     }
                 }
+
+                // TxChrono pump: while keyed, request TX audio at real-time rate.
+                // WSJT-X streams TX audio ONLY in reply to these frames.
+                let tx_now = shared.tx_active.load(Ordering::Relaxed);
+                if tx_now {
+                    let rate = shared.audio_rate_hz.load(Ordering::Relaxed).max(1);
+                    if !tx_was_active {
+                        tx_start = tokio::time::Instant::now();
+                        tx_samples_requested = 0;
+                        tx_chronos_sent = 0;
+                        log::info!("[tci] TX keyed — starting TxChrono pump @ {rate} Hz");
+                    }
+                    // Mono samples that should have been delivered by now.
+                    let target = (tx_start.elapsed().as_secs_f64() * rate as f64) as u64;
+                    if target > tx_samples_requested {
+                        // WSJT-X returns length/2 mono samples per chrono (it fills
+                        // `length` interleaved-stereo floats), so request 2× the
+                        // float length for the mono samples we still owe — else the
+                        // modulator is fed at half real-time (bursty underruns).
+                        let need = (target - tx_samples_requested).min(TX_CHRONO_MAX_MONO as u64);
+                        sink.send(Message::binary(encode_tx_chrono(rate, (need * 2) as u32))).await?;
+                        tx_samples_requested += need;
+                        tx_chronos_sent += 1;
+                        if tx_chronos_sent == 1 || tx_chronos_sent % 50 == 0 {
+                            log::debug!(
+                                "[tci] sent {tx_chronos_sent} TxChrono frames ({need} mono samples last)"
+                            );
+                        }
+                    }
+                } else if tx_was_active {
+                    log::info!("[tci] TX unkeyed — TxChrono pump stopped ({tx_chronos_sent} sent)");
+                }
+                tx_was_active = tx_now;
             }
         }
     }
@@ -258,6 +311,13 @@ fn handshake_lines(shared: &TciShared) -> Vec<String> {
         "vfo_limits:0,500000000;".to_string(),
         "if_limits:-24000,24000;".to_string(),
         "modulations_list:am,sam,dsb,lsb,usb,cw,nfm,digl,digu,wfm;".to_string(),
+        // Audio rates the real ExpertSDR/Thetis init burst announces.  WSJT-X
+        // configures its audio engine — including the TX-audio encoder — from
+        // the server-announced `audio_samplerate`.  Omitting it lets RX stream
+        // (each frame carries its own rate) but leaves WSJT-X with no TX rate,
+        // so it keys PTT but never streams transmit audio (zero-power symptom).
+        format!("iq_samplerate:{RX_SERVER_RATE_HZ};"),
+        format!("audio_samplerate:{DEFAULT_AUDIO_RATE_HZ};"),
         format!("dds:0,{freq};"),
         format!("vfo:0,0,{freq};"),
         "if:0,0,0;".to_string(),
@@ -356,31 +416,79 @@ fn handle_text_command(cmd: &str, shared: &TciShared) -> Option<String> {
     }
 }
 
+/// Diagnostic counters for inbound binary frames: total seen, and those passed
+/// to the modulator.  Used to pinpoint "keys but zero power" (no TX audio).
+static TX_FRAMES_SEEN: AtomicU64 = AtomicU64::new(0);
+static TX_FRAMES_FED: AtomicU64 = AtomicU64::new(0);
+
 /// Decode an inbound TX-audio `Data_Stream` and feed it to the mic-TX ring.
 fn handle_tx_audio(buf: &[u8], shared: &TciShared) {
     if buf.len() < TCI_HEADER_LEN {
+        log::debug!("[tci] TX frame too short: {} bytes", buf.len());
         return;
     }
     let u32_at = |i: usize| u32::from_le_bytes([buf[i], buf[i + 1], buf[i + 2], buf[i + 3]]);
     let sample_rate = u32_at(4);
-    let length = u32_at(20) as usize; // field 5 (sample count)
-    let data_type = u32_at(24); // field 6 (TciStreamType)
-    let channels = u32_at(28).max(1); // field 7
+    // field 5 = number of VALID floats (interleaved stereo); the buffer on the
+    // wire is length*2 floats but only the first `length` are real audio — the
+    // tail is uninitialised heap (NaN/Inf garbage), so never read past `length`.
+    let length = u32_at(20) as usize;
+    let data_type = u32_at(24); // field 6 (TciStreamType); field 7+ = reserved
+
+    let seen = TX_FRAMES_SEEN.fetch_add(1, Ordering::Relaxed) + 1;
+    if seen == 1 || seen % 50 == 0 {
+        log::info!(
+            "[tci] TX frame #{seen}: {} bytes, data_type={data_type}, rate={sample_rate}, \
+             length={length} (expect data_type={TCI_STREAM_TX_AUDIO})",
+            buf.len()
+        );
+    }
 
     if data_type != TCI_STREAM_TX_AUDIO {
-        return; // ignore IQ / chrono / unexpected streams
+        // Prime suspect for "keys but zero power": WSJT-X stamps TX audio with a
+        // stream-type value we drop.  Surface it loudly (rate-limited).
+        if seen == 1 || seen % 50 == 0 {
+            log::warn!(
+                "[tci] dropping TX frame: data_type={data_type} != {TCI_STREAM_TX_AUDIO} \
+                 (no audio reaches the modulator → zero RF)"
+            );
+        }
+        return;
     }
 
+    // Read only the first `length` floats (the valid, interleaved-stereo region)
+    // and downmix to mono — yielding length/2 samples per chrono.  Sanitise any
+    // stray non-finite value so garbage never reaches the modulator / HL2 DAC.
     let avail = (buf.len() - TCI_HEADER_LEN) / 4;
-    let n = length.min(avail);
-    let mut samples = Vec::with_capacity(n);
-    for i in 0..n {
+    let valid = length.min(avail);
+    let mut samples = Vec::with_capacity(valid);
+    for i in 0..valid {
         let o = TCI_HEADER_LEN + i * 4;
-        samples.push(f32::from_le_bytes([buf[o], buf[o + 1], buf[o + 2], buf[o + 3]]));
+        let s = f32::from_le_bytes([buf[o], buf[o + 1], buf[o + 2], buf[o + 3]]);
+        samples.push(if s.is_finite() { s } else { 0.0 });
     }
 
-    let mono = downmix(&samples, channels);
+    let mono = downmix(&samples, 2); // WSJT-X TX audio is interleaved stereo
     let out = resample(&mono, sample_rate as f32, TX_SERVER_RATE_HZ as f32);
+
+    // Log signal level so we can tell "no frames" from "silent frames" from
+    // "frames not streaming" (push_tx is a no-op unless tx_streaming is set).
+    let fed = TX_FRAMES_FED.fetch_add(1, Ordering::Relaxed) + 1;
+    if fed == 1 || fed % 50 == 0 {
+        let peak = out.iter().fold(0.0f32, |m, &s| m.max(s.abs()));
+        let rms = if out.is_empty() {
+            0.0
+        } else {
+            (out.iter().map(|&s| s * s).sum::<f32>() / out.len() as f32).sqrt()
+        };
+        log::info!(
+            "[tci] TX audio fed #{fed}: {} samples, peak={peak:.3}, rms={rms:.4}, \
+             streaming={}",
+            out.len(),
+            shared.mic_shared.tx_streaming()
+        );
+    }
+
     shared.mic_shared.push_tx(&out);
 }
 
@@ -441,6 +549,29 @@ fn encode_data_stream(sample_rate: u32, stream_type: u32, channels: u32, samples
     for s in samples {
         v.extend_from_slice(&s.to_le_bytes());
     }
+    v
+}
+
+/// Encode a `TxChrono` frame: a 64-byte header (no audio payload) that requests
+/// `length` per-channel samples of TX audio.  WSJT-X replies with one
+/// `TxAudioStream` frame of `length * 2` interleaved-stereo floats per chrono;
+/// `length` (and `sample_rate`/`format`) are echoed back into that reply.
+fn encode_tx_chrono(sample_rate: u32, length: u32) -> Vec<u8> {
+    let mut v = Vec::with_capacity(TCI_HEADER_LEN);
+    let header: [u32; 8] = [
+        0,                    // receiver
+        sample_rate,          // sample_rate
+        TCI_SAMPLE_FLOAT32,   // data_format
+        0,                    // codec
+        0,                    // crc
+        length,               // length (per-channel samples requested)
+        TCI_STREAM_TX_CHRONO, // data_type = TxChrono
+        0,                    // reserved
+    ];
+    for field in header {
+        v.extend_from_slice(&field.to_le_bytes());
+    }
+    v.extend_from_slice(&[0u8; 32]); // pad header to 64 bytes (no data field)
     v
 }
 
@@ -533,6 +664,9 @@ fn set_ptt(shared: &TciShared, on: bool) {
     if let Ok(mut s) = shared.ui_state.lock() {
         s.cat_ptt = on;
     }
+    // Gate the TxChrono pump in the connection loop (WSJT-X only sends TX audio
+    // in reply to chronos, so we must clock it for the duration of the over).
+    shared.tx_active.store(on, Ordering::Relaxed);
     if on {
         shared.mic_shared.set_external_tx_source(true);
         shared.mic_shared.set_tx_streaming(true);

--- a/rigflow-client/src/ui/app_wsjtx_setup.rs
+++ b/rigflow-client/src/ui/app_wsjtx_setup.rs
@@ -8,9 +8,10 @@
 use super::app::RigflowApp;
 use crate::digital_audio::{DIGITAL_INPUT_NAME, DIGITAL_RX_NAME};
 use crate::rigctl_server::DEFAULT_RIGCTL_PORT;
+use crate::tci_server::DEFAULT_TCI_PORT;
 use eframe::egui;
 
-const RIGCTL_HOST: &str = "127.0.0.1";
+const LOCALHOST: &str = "127.0.0.1";
 const OK_GREEN: egui::Color32 = egui::Color32::from_rgb(100, 200, 100);
 const BAD_RED: egui::Color32 = egui::Color32::from_rgb(210, 130, 130);
 
@@ -28,7 +29,7 @@ impl RigflowApp {
         }
 
         // Snapshot what we need so the window closure never touches `self`.
-        let (rx_avail, rx_reason, in_avail, in_reason, rigctl_status, rx_active) = {
+        let (rx_avail, rx_reason, in_avail, in_reason, rigctl_status, rx_active, tci_status) = {
             let state = self.state.lock().unwrap();
             (
                 state.digital_rx_available,
@@ -37,20 +38,51 @@ impl RigflowApp {
                 state.digital_input_reason.clone(),
                 state.rigctl_status.clone(),
                 state.digital_rx.is_active(),
+                state.tci_status.clone(),
             )
         };
 
-        let network_server = format!("{RIGCTL_HOST}:{DEFAULT_RIGCTL_PORT}");
+        let network_server = format!("{LOCALHOST}:{DEFAULT_RIGCTL_PORT}");
+        let tci_server = format!("{LOCALHOST}:{DEFAULT_TCI_PORT}");
 
         egui::Window::new("WSJT-X / FT8 Setup")
             .open(&mut open)
             .resizable(true)
             .default_width(480.0)
             .show(ctx, |ui| {
-                ui.label("Set these in WSJT-X (File → Settings) to talk to Rigflow:");
-                ui.add_space(6.0);
+                // macOS has no virtual audio device, so digital is TCI-only there.
+                // Linux offers both: virtual audio (any app) or TCI (TCI-capable apps).
+                if cfg!(target_os = "macos") {
+                    ui.label("Set these in WSJT-X (File → Settings) to talk to Rigflow over TCI:");
+                    ui.add_space(6.0);
+                    tci_grid(ui, &tci_server, tci_status.as_deref());
+                    ui.add_space(6.0);
+                    ui.label(
+                        egui::RichText::new(
+                            "No virtual audio device (BlackHole) or microphone permission is \
+                             needed — TCI carries CAT, PTT, and audio over one connection.",
+                        )
+                        .small()
+                        .weak(),
+                    );
+                    return;
+                }
 
-                egui::Grid::new("wsjtx_setup_grid")
+                ui.label("Pick one method and set it in WSJT-X (File → Settings):");
+                ui.add_space(8.0);
+
+                // ── Method 1: PipeWire/Pulse virtual audio (any digital app) ──
+                ui.heading("Method 1 — Virtual audio");
+                ui.label(
+                    egui::RichText::new(
+                        "Works with any digital app (FLDigi, JS8Call, any WSJT-X version).",
+                    )
+                    .small()
+                    .weak(),
+                );
+                ui.add_space(4.0);
+
+                egui::Grid::new("wsjtx_pw_grid")
                     .num_columns(4)
                     .spacing([10.0, 6.0])
                     .show(ui, |ui| {
@@ -81,9 +113,7 @@ impl RigflowApp {
                         info_row(ui, "Radio → Mode", "Data/Pkt");
                     });
 
-                ui.add_space(8.0);
-                ui.separator();
-
+                ui.add_space(6.0);
                 // RX routing is automatic (enabled in Data mode); show its status.
                 ui.horizontal(|ui| {
                     ui.label("RX routing:");
@@ -96,8 +126,6 @@ impl RigflowApp {
                         ui.colored_label(egui::Color32::GRAY, "Inactive");
                     }
                 });
-
-                ui.add_space(6.0);
                 ui.label(
                     egui::RichText::new(
                         "Acquire a radio and select the Data mode — RX routing turns on \
@@ -106,6 +134,20 @@ impl RigflowApp {
                     .small()
                     .weak(),
                 );
+
+                ui.add_space(8.0);
+                ui.separator();
+                ui.add_space(8.0);
+
+                // ── Method 2: TCI (TCI-capable apps; same path macOS uses) ──
+                ui.heading("Method 2 — TCI");
+                ui.label(
+                    egui::RichText::new("Simpler, for TCI-capable apps (WSJT-X 2.7+, JTDX, MSHV).")
+                        .small()
+                        .weak(),
+                );
+                ui.add_space(4.0);
+                tci_grid(ui, &tci_server, tci_status.as_deref());
             });
 
         // Reflect the window's close affordance back into state.
@@ -113,6 +155,27 @@ impl RigflowApp {
             state.show_wsjtx_setup_window = open;
         }
     }
+}
+
+/// The TCI configuration rows, shared by macOS and the Linux "Method 2".  The
+/// `Use TCI Audio` checkbox is what makes WSJT-X carry audio over the connection;
+/// the server status chip shows whether the TCI port is bound.
+fn tci_grid(ui: &mut egui::Ui, server: &str, tci_status: Option<&str>) {
+    egui::Grid::new("wsjtx_tci_grid")
+        .num_columns(4)
+        .spacing([10.0, 6.0])
+        .show(ui, |ui| {
+            info_row(ui, "Radio → Rig", "TCI");
+            value_row(
+                ui,
+                "Radio → TCI Server",
+                server,
+                Some((tci_status.is_none(), tci_status, "Listening")),
+            );
+            info_row(ui, "Radio → Use TCI Audio", "✓ (checked)");
+            info_row(ui, "Audio → Input / Output", "TCI");
+            info_row(ui, "Radio → Mode", "Data/Pkt");
+        });
 }
 
 /// A row with a copyable value and a live status chip:

--- a/rigflow-client/src/ui/panels/radio_control.rs
+++ b/rigflow-client/src/ui/panels/radio_control.rs
@@ -1155,13 +1155,18 @@ fn apply_mode_preferences(state: &mut UiState, mode: DemodMode) {
     // RX-routing tie: entering Data-USB enables RX Digital Output (so external
     // digital apps like WSJT-X can record); leaving it disables routing.  Only
     // the transition into/out of Data-USB touches routing — switching among
-    // voice modes leaves it exactly as the user set it.
-    let was_dgt = state.last_demod_mode_for_controls == Some(DemodMode::DgtU);
-    let is_dgt = mode == DemodMode::DgtU;
-    if is_dgt && !was_dgt {
-        state.digital_rx.set_enabled(true);
-    } else if was_dgt && !is_dgt {
-        state.digital_rx.set_enabled(false);
+    // voice modes leaves it exactly as the user set it.  Linux-only: this drives
+    // the PipeWire virtual-audio path; on macOS digital RX flows over the
+    // always-on TCI tap instead, so there is nothing to toggle here.
+    #[cfg(target_os = "linux")]
+    {
+        let was_dgt = state.last_demod_mode_for_controls == Some(DemodMode::DgtU);
+        let is_dgt = mode == DemodMode::DgtU;
+        if is_dgt && !was_dgt {
+            state.digital_rx.set_enabled(true);
+        } else if was_dgt && !is_dgt {
+            state.digital_rx.set_enabled(false);
+        }
     }
 
     state.last_demod_mode_for_controls = Some(mode);

--- a/rigflow-client/src/ui/state.rs
+++ b/rigflow-client/src/ui/state.rs
@@ -244,6 +244,10 @@ pub struct UiState {
     /// could not bind its port (e.g. 4532 already in use); `None` when bound OK.
     pub rigctl_status: Option<String>,
 
+    /// TCI server status.  `Some(reason)` when the server could not bind its port
+    /// (e.g. 40001 already in use); `None` when bound OK.  Mirrors `rigctl_status`.
+    pub tci_status: Option<String>,
+
     /// Digital Audio Interface (Phase 2): RX audio router to
     /// `RigflowDigitalOutput`.  Shared with the media thread; the UI toggles it.
     pub digital_rx: Arc<crate::digital_rx::DigitalRxOutput>,
@@ -505,6 +509,7 @@ impl Default for UiState {
             digital_rx_reason: None,
             digital_input_reason: None,
             rigctl_status: None,
+            tci_status: None,
             digital_rx: crate::digital_rx::DigitalRxOutput::new(),
             tci_rx_audio: crate::tci_server::TciRxAudio::new(),
             tx_audio_diag: TxAudioDiag::default(),
@@ -651,41 +656,47 @@ pub fn collect_problems(s: &UiState) -> Vec<Problem> {
     }
     // Digital audio interface (PipeWire/pactl) — collapse the endpoints into one
     // line with the first captured reason (they usually share a root cause).
-    let mut digital_down: Vec<&str> = Vec::new();
-    let mut digital_reason: Option<&String> = None;
-    for (available, reason, name) in [
-        (
-            s.digital_output_available,
-            &s.digital_output_reason,
-            "RigflowDigitalOutput",
-        ),
-        (
-            s.digital_rx_available,
-            &s.digital_rx_reason,
-            "RigflowDigitalRX",
-        ),
-        (
-            s.digital_input_available,
-            &s.digital_input_reason,
-            "RigflowDigitalInput",
-        ),
-    ] {
-        if !available {
-            digital_down.push(name);
-            if digital_reason.is_none() {
-                digital_reason = reason.as_ref();
+    // PipeWire/Pulse only exists on Linux; on other platforms these endpoints are
+    // intentionally unavailable (digital uses the TCI server, not virtual audio),
+    // so they are not a problem to report.
+    #[cfg(target_os = "linux")]
+    {
+        let mut digital_down: Vec<&str> = Vec::new();
+        let mut digital_reason: Option<&String> = None;
+        for (available, reason, name) in [
+            (
+                s.digital_output_available,
+                &s.digital_output_reason,
+                "RigflowDigitalOutput",
+            ),
+            (
+                s.digital_rx_available,
+                &s.digital_rx_reason,
+                "RigflowDigitalRX",
+            ),
+            (
+                s.digital_input_available,
+                &s.digital_input_reason,
+                "RigflowDigitalInput",
+            ),
+        ] {
+            if !available {
+                digital_down.push(name);
+                if digital_reason.is_none() {
+                    digital_reason = reason.as_ref();
+                }
             }
         }
-    }
-    if !digital_down.is_empty() {
-        let reason = digital_reason
-            .map(String::as_str)
-            .unwrap_or("unavailable (PipeWire/pactl not running?)");
-        warnings.push(Problem {
-            severity: ProblemSeverity::Warning,
-            source: "Digital Audio",
-            detail: format!("{} unavailable: {reason}", digital_down.join(", ")),
-        });
+        if !digital_down.is_empty() {
+            let reason = digital_reason
+                .map(String::as_str)
+                .unwrap_or("unavailable (PipeWire/pactl not running?)");
+            warnings.push(Problem {
+                severity: ProblemSeverity::Warning,
+                source: "Digital Audio",
+                detail: format!("{} unavailable: {reason}", digital_down.join(", ")),
+            });
+        }
     }
     // Microphone fallback / unavailable (already shown in Radio Control; also
     // aggregated here).

--- a/rigflow-client/src/ui/state.rs
+++ b/rigflow-client/src/ui/state.rs
@@ -248,6 +248,10 @@ pub struct UiState {
     /// `RigflowDigitalOutput`.  Shared with the media thread; the UI toggles it.
     pub digital_rx: Arc<crate::digital_rx::DigitalRxOutput>,
 
+    /// TCI server RX-audio tap.  Shared with the media thread (push) and the TCI
+    /// server task (drain → WebSocket).  No-op until a TCI client streams.
+    pub tci_rx_audio: Arc<crate::tci_server::TciRxAudio>,
+
     /// Live TX-audio diagnostics for SSB mic transmit (zero unless keyed).
     pub tx_audio_diag: TxAudioDiag,
 
@@ -502,6 +506,7 @@ impl Default for UiState {
             digital_input_reason: None,
             rigctl_status: None,
             digital_rx: crate::digital_rx::DigitalRxOutput::new(),
+            tci_rx_audio: crate::tci_server::TciRxAudio::new(),
             tx_audio_diag: TxAudioDiag::default(),
             two_tone_enabled: false,
             two_tone_a_hz: 700.0,

--- a/rigflow-server/src/dsp/audio/deemphasis.rs
+++ b/rigflow-server/src/dsp/audio/deemphasis.rs
@@ -1,4 +1,4 @@
-use log::info;
+use log::debug;
 
 /// First-order deemphasis filter for FM audio.
 ///
@@ -39,7 +39,7 @@ impl DeemphasisFilter {
     /// - `sample_rate_hz`: audio sample rate
     /// - `tau_seconds`: time constant (e.g. 75e-6 for 75 µs)
     pub fn new(sample_rate_hz: f32, tau_seconds: f32) -> Self {
-        info!(
+        debug!(
             "DeemphasisFilter: new: sample_rate_hz = {}, tau_seconds = {}",
             sample_rate_hz, tau_seconds
         );

--- a/rigflow-server/src/dsp/pipeline.rs
+++ b/rigflow-server/src/dsp/pipeline.rs
@@ -1,6 +1,6 @@
 use std::f32::consts::PI;
 
-use log::info;
+use log::debug;
 use num_complex::Complex32;
 
 use crate::dsp::audio::agc::Agc;
@@ -274,7 +274,7 @@ impl DspPipeline {
     }
 
     fn rebuild_audio_path_for_mode(&mut self) {
-        info!(
+        debug!(
             "rebuild_audio_path_for_mode: demod={:?} deemphasis_mode={:?} tau={:?}",
             self.mode,
             self.deemphasis_mode,
@@ -337,11 +337,11 @@ impl DspPipeline {
     }
 
     pub fn set_deemphasis_mode(&mut self, mode: DeemphasisMode) {
-        info!("pipeline set_deemphasis_mode: {:?}", mode);
+        debug!("pipeline set_deemphasis_mode: {:?}", mode);
         self.deemphasis_mode = mode;
         self.rebuild_audio_path_for_mode();
         self.reset_audio_state();
-        info!(
+        debug!(
             "pipeline deemphasis after rebuild: mode={:?} tau={:?}",
             self.deemphasis_mode,
             Self::deemphasis_tau_for(self.mode, self.deemphasis_mode)
@@ -571,7 +571,7 @@ impl DspPipeline {
     }
 
     pub fn set_ssb_pitch_hz(&mut self, pitch_hz: f32) {
-        info!("pipeline set_ssb_pitch_hz: {}", pitch_hz);
+        debug!("pipeline set_ssb_pitch_hz: {}", pitch_hz);
         self.ssb_pitch_hz = pitch_hz;
         self.rebuild_ssb_filters(self.ssb_bandwidth_hz, self.ssb_fir_taps);
         self.reset_audio_state();

--- a/rigflow-server/src/net/websocket.rs
+++ b/rigflow-server/src/net/websocket.rs
@@ -188,7 +188,7 @@ async fn handle_radio_message(
     msg: ClientRadioMessage,
     local_tx: &mpsc::UnboundedSender<ServerRadioMessage>,
 ) {
-    info!("WEBSOCKET: handle_radio_message: msg = {:?}", msg);
+    debug!("WEBSOCKET: handle_radio_message: msg = {:?}", msg);
     match msg {
         ClientRadioMessage::ListRadios => {
             let radios = app_state
@@ -1438,7 +1438,7 @@ fn log_runtime_changed(msg: &ServerRadioMessage) {
         ..
     } = msg
     {
-        info!(
+        debug!(
             "[websocket] RuntimeChanged radio={} center={:?} target={:?} demod={:?} sideband={:?} ssb_pitch={:?} cw_pitch={:?} filter_bandwidth={:?} deemphasis_mode={:?} source_control={:?}",
             radio_id.0,
             center_freq_hz,

--- a/rigflow-server/src/plugins/ft8_decoder.rs
+++ b/rigflow-server/src/plugins/ft8_decoder.rs
@@ -10,7 +10,8 @@ impl RadioPlugin for FT8Decoder {
 
     fn on_event(&mut self, event: ServerEvent) {
         if let ServerEvent::AudioFrame(_) = event {
-            println!("FT8 plugin received audio frame");
+            // Per-frame: trace only, and through the log framework (not stdout).
+            log::trace!("FT8 plugin received audio frame");
         }
     }
 }

--- a/rigflow-server/src/radio/worker.rs
+++ b/rigflow-server/src/radio/worker.rs
@@ -1860,7 +1860,11 @@ fn spawn_capture_thread(
 
                 if pending {
                     let mic_usb = match control_snapshot.demod_mode {
-                        DemodMode::Usb => Some(true),
+                        // DgtU (data-USB) keys on the USB sideband — WSJT-X/FT8
+                        // sets this mode when its Radio "Mode" is Data/Pkt.  The
+                        // RX pipeline already treats DgtU as USB everywhere; the
+                        // TX gate must match or digital TX is silently dropped.
+                        DemodMode::Usb | DemodMode::DgtU => Some(true),
                         DemodMode::Lsb => Some(false),
                         _ => None,
                     };

--- a/rigflow-server/src/source/hermeslite2.rs
+++ b/rigflow-server/src/source/hermeslite2.rs
@@ -765,7 +765,7 @@ impl IqSource for HermesLite2Source {
 
     fn set_center_frequency(&mut self, center_freq_hz: f32) -> Result<(), String> {
         self.center_freq_hz = center_freq_hz;
-        info!("HL2: NCO → {} Hz", center_freq_hz as u32);
+        debug!("HL2: NCO → {} Hz", center_freq_hz as u32);
         // send_gain_cc carries both the NCO freq and the current gain code so
         // the gain register is always in sync after every tune.
         self.send_gain_cc()
@@ -790,7 +790,7 @@ impl IqSource for HermesLite2Source {
     fn set_gain_db(&mut self, gain_db: f32) -> Result<(), String> {
         // code = gain_db + 12: code 0 = -12 dB, code 60 = +48 dB
         self.lna_gain_code = (gain_db + 12.0).round().clamp(0.0, 60.0) as u8;
-        info!(
+        debug!(
             "HL2: LNA gain → {:.1} dB (code {})",
             gain_db, self.lna_gain_code
         );


### PR DESCRIPTION
 macOS FT8 over TCI + release pipeline                                                                                                                                                          
                                                                                                                                                                                                 
  Adds a cross-platform TCI server so macOS can run FT8 with no BlackHole and no microphone permission, gets FT8 transmit working end-to-end over TCI, makes the FT8 setup platform-aware, and   
  stands up the binary release pipeline (with the macOS client included). 7 commits; ~1.4k lines across client, server, docs, and CI.                                                            
                                                                                                                                                                                                 
  What's included                                                                                                                                                                                
                                                                                                                                                                                                 
  TCI server (new) — rigflow-client/src/tci_server.rs                                                                                                                                            
  - WebSocket TCI server on ws://127.0.0.1:40001 carrying CAT + PTT + RX/TX audio over one localhost connection. Cross-platform and additive — the Linux PipeWire path and rigctld are           
  untouched.                                                                                                                                                                                     
  - Reuses existing seams: dds/vfo→freq, modulation→mode, trx→PTT (like rigctl_server); RX taps the decoded-audio point in net/udp; TX claims the mic-TX ring (MicShared::push_tx) → existing    
  STREAM_TYPE_MIC_AUDIO UDP path.                                                                                                                                                                
  - Confirmed transmitting + decoding FT8 on air on both Linux and macOS.                                                                                                                        
                                                                                                                                                                                                 
  FT8 transmit fixes (the hard part)                                                                                                                                                             
  - Server: the SSB mic-TX gate dropped DgtU (data-USB, WSJT-X's FT8 mode) — now accepts Usb | DgtU (radio/worker.rs). This is why the rig wouldn't key.                                         
  - TX is pull-driven: WSJT-X only streams audio in reply to TxChrono frames — added a wall-clock-paced chrono pump.                                                                             
  - Sizing/decoding: chrono length is a total float budget (WSJT-X returns length/2 interleaved-stereo samples, uninitialized tail); fixed the request math (was a 2× underrun → bursty TX) and  
  the decode (read only valid floats, downmix, sanitize non-finite). Unit-tested.                                                                                                                
                                                                                                                                                                                                 
  Platform-aware FT8 setup + macOS PipeWire gating                                                                                                                                               
  - The WSJT-X/FT8 Setup window now shows TCI-only on macOS and both methods on Linux; macOS no longer attempts pactl (digital_audio/digital_tx gated to Linux; status-bar warning gated). New   
  tci_status surfaces the TCI bind state.                                                                                                                                                        
                                                                                                                                                                                                 
  Logging audit                                                                                                                                                                                  
  - Demoted hot-path info! logs (per-message WebSocket, per-drag control writes) to debug; fixed a per-frame println! in the FT8 plugin stub.                                                    
                                                                                                                                                                                                 
  Docs                                                                                                                                                                                           
  - FT8 transports clarified per platform (Linux: PipeWire or TCI; macOS: TCI only, experimental).                                                                                               
  - Installation guide restructured to lead with prebuilt binaries (run ./rigflow-server, no Rust needed).                                                                                       
                                                                                                                                                                                                 
  Release pipeline (new)                                                                                                                                                                         
  - .github/workflows/release.yml: tag-triggered build of Linux x86-64, Linux ARM64, and macOS arm64 (client only); per-component tar.gz + SHA256SUMS → draft GitHub Release. workflow_dispatch  
  = no-publish dry run.                                                                                                                                                                          
  - ci.yml: added a macOS client build job so the new cfg(target_os = "macos") paths can't bit-rot.                                                                                              
                                                                                                                                                                                                 
  Scope / decisions                                                                                                                                                                              
                                                                                                                                                                                                 
  - macOS = client only (server stays Linux/Pi), Apple Silicon arm64, shipped unsigned (documented Gatekeeper first-launch step).                                                                
  - Out of scope: notarization/signing, universal/Intel macOS, macOS server, Windows.                                                                                                            
                                                                                                  
 Testing                                                                                                                                                                                        
                                                                                                                                                                                                 
  - FT8 TX + RX verified on air over TCI on Linux and macOS.                                                                                                                                     
  - cargo test -p rigflow-core -p rigflow-server green; added TCI wire-format unit tests.                                                                                                        
  - ⚠️  The client can't be built in CI's old config; this PR's new macOS CI job is the first time the client compiles on macOS in CI — watch that run, as it may surface cfg(target_os =         
  "macos") issues from the recent gating. Recommend a release.yml workflow_dispatch dry run before tagging.   