### PR TITLE
Logger

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -639,6 +639,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block2"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
+dependencies = [
+ "objc2 0.6.4",
+]
+
+[[package]]
 name = "blocking"
 version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1080,6 +1089,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
  "bitflags 2.11.0",
+ "block2 0.6.2",
+ "libc",
  "objc2 0.6.4",
 ]
 
@@ -2806,7 +2817,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4e89ad9e3d7d297152b17d39ed92cd50ca8063a89a9fa569046d41568891eff"
 dependencies = [
  "bitflags 2.11.0",
- "block2",
+ "block2 0.5.1",
  "libc",
  "objc2 0.5.2",
  "objc2-core-data",
@@ -2822,6 +2833,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
 dependencies = [
  "bitflags 2.11.0",
+ "block2 0.6.2",
  "objc2 0.6.4",
  "objc2-core-foundation",
  "objc2-core-graphics",
@@ -2835,7 +2847,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74dd3b56391c7a0596a295029734d3c1c5e7e510a4cb30245f8221ccea96b009"
 dependencies = [
  "bitflags 2.11.0",
- "block2",
+ "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-core-location",
  "objc2-foundation 0.2.2",
@@ -2847,7 +2859,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5ff520e9c33812fd374d8deecef01d4a840e7b41862d849513de77e44aa4889"
 dependencies = [
- "block2",
+ "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-foundation 0.2.2",
 ]
@@ -2859,7 +2871,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "617fbf49e071c178c0b24c080767db52958f716d9eabdf0890523aeae54773ef"
 dependencies = [
  "bitflags 2.11.0",
- "block2",
+ "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-foundation 0.2.2",
 ]
@@ -2894,7 +2906,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55260963a527c99f1819c4f8e3b47fe04f9650694ef348ffd2227e8196d34c80"
 dependencies = [
- "block2",
+ "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-foundation 0.2.2",
  "objc2-metal",
@@ -2906,7 +2918,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "000cfee34e683244f284252ee206a27953279d370e309649dc3ee317b37e5781"
 dependencies = [
- "block2",
+ "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-contacts",
  "objc2-foundation 0.2.2",
@@ -2925,7 +2937,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ee638a5da3799329310ad4cfa62fbf045d5f56e3ef5ba4149e7452dcf89d5a8"
 dependencies = [
  "bitflags 2.11.0",
- "block2",
+ "block2 0.5.1",
  "dispatch",
  "libc",
  "objc2 0.5.2",
@@ -2959,7 +2971,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1a1ae721c5e35be65f01a03b6d2ac13a54cb4fa70d8a5da293d7b0020261398"
 dependencies = [
- "block2",
+ "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-app-kit 0.2.2",
  "objc2-foundation 0.2.2",
@@ -2972,7 +2984,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd0cba1276f6023976a406a14ffa85e1fdd19df6b0f737b063b95f6c8c7aadd6"
 dependencies = [
  "bitflags 2.11.0",
- "block2",
+ "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-foundation 0.2.2",
 ]
@@ -2984,7 +2996,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e42bee7bff906b14b167da2bac5efe6b6a07e6f7c0a21a7308d40c960242dc7a"
 dependencies = [
  "bitflags 2.11.0",
- "block2",
+ "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-foundation 0.2.2",
  "objc2-metal",
@@ -3007,7 +3019,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8bb46798b20cd6b91cbd113524c490f1686f4c4e8f49502431415f3512e2b6f"
 dependencies = [
  "bitflags 2.11.0",
- "block2",
+ "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-cloud-kit",
  "objc2-core-data",
@@ -3027,7 +3039,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44fa5f9748dbfe1ca6c0b79ad20725a11eca7c2218bceb4b005cb1be26273bfe"
 dependencies = [
- "block2",
+ "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-foundation 0.2.2",
 ]
@@ -3039,7 +3051,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76cfcbf642358e8689af64cee815d139339f3ed8ad05103ed5eaf73db8d84cb3"
 dependencies = [
  "bitflags 2.11.0",
- "block2",
+ "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-core-location",
  "objc2-foundation 0.2.2",
@@ -3241,6 +3253,12 @@ dependencies = [
  "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "pollster"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f3a9f18d041e6d0e102a0a46750538147e5e8992d3b4873aaafee2520b00ce3"
 
 [[package]]
 name = "portable-atomic"
@@ -3499,6 +3517,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19b30a45b0cd0bcca8037f3d0dc3421eaf95327a17cad11964fb8179b4fc4832"
 
 [[package]]
+name = "rfd"
+version = "0.17.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20dafead71c16a34e1ff357ddefc8afc11e7d51d6d2b9fbd07eaa48e3e540220"
+dependencies = [
+ "block2 0.6.2",
+ "dispatch2",
+ "js-sys",
+ "libc",
+ "log",
+ "objc2 0.6.4",
+ "objc2-app-kit 0.3.2",
+ "objc2-core-foundation",
+ "objc2-foundation 0.3.2",
+ "percent-encoding",
+ "pollster",
+ "raw-window-handle",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "rigflow-client"
 version = "0.1.5"
 dependencies = [
@@ -3511,6 +3553,7 @@ dependencies = [
  "hound",
  "log",
  "minifb",
+ "rfd",
  "rigflow-core",
  "rigflow-log",
  "rigflow-protocol",
@@ -5355,7 +5398,7 @@ dependencies = [
  "android-activity",
  "atomic-waker",
  "bitflags 2.11.0",
- "block2",
+ "block2 0.5.1",
  "bytemuck",
  "calloop 0.13.0",
  "cfg_aliases",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -795,6 +795,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "chrono"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
+dependencies = [
+ "iana-time-zone",
+ "num-traits",
+ "windows-link",
+]
+
+[[package]]
 name = "clang-sys"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1383,6 +1394,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1794,6 +1817,15 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
@@ -1806,6 +1838,15 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
+name = "hashlink"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+dependencies = [
+ "hashbrown 0.14.5",
+]
 
 [[package]]
 name = "heck"
@@ -1916,6 +1957,30 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tower-service",
+]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core 0.58.0",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -2286,6 +2351,17 @@ dependencies = [
  "libc",
  "plain",
  "redox_syscall 0.7.3",
+]
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -3436,6 +3512,7 @@ dependencies = [
  "log",
  "minifb",
  "rigflow-core",
+ "rigflow-log",
  "rigflow-protocol",
  "serde",
  "serde_json",
@@ -3447,6 +3524,16 @@ dependencies = [
 name = "rigflow-core"
 version = "0.1.5"
 dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "rigflow-log"
+version = "0.1.5"
+dependencies = [
+ "chrono",
+ "rusqlite",
  "serde",
  "serde_json",
 ]
@@ -3525,6 +3612,20 @@ checksum = "ab9f9ff05b63a786553a4c02943b74b34a988448671001e9a27e2f0565cc05a4"
 dependencies = [
  "libc",
  "libusb1-sys",
+]
+
+[[package]]
+name = "rusqlite"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
+dependencies = [
+ "bitflags 2.11.0",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -117,6 +117,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -630,6 +641,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-padding"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "block2"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -756,6 +776,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cbc"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -812,6 +841,16 @@ dependencies = [
  "iana-time-zone",
  "num-traits",
  "windows-link",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
 ]
 
 [[package]]
@@ -1061,6 +1100,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
 
 [[package]]
+name = "dbus"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ab69f03cc8c4340c9c8e315114e1658e6775a9b16a04357973aa21cec22b32e"
+dependencies = [
+ "libc",
+ "libdbus-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "dbus-secret-service"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "708b509edf7889e53d7efb0ffadd994cc6c2345ccb62f55cfd6b0682165e4fa6"
+dependencies = [
+ "aes",
+ "block-padding",
+ "cbc",
+ "dbus",
+ "fastrand",
+ "hkdf",
+ "num",
+ "once_cell",
+ "sha2",
+ "zeroize",
+]
+
+[[package]]
 name = "difflib"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1074,6 +1142,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -1884,6 +1953,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfa686283ad6dd069f105e5ab091b04c62850d3e4cf5d67debad1933f55023df"
 
 [[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
+
+[[package]]
 name = "hound"
 version = "3.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2148,6 +2235,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "block-padding",
+ "generic-array",
+]
+
+[[package]]
 name = "instant"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2308,6 +2405,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "keyring"
+version = "3.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eebcc3aff044e5944a8fbaf69eb277d11986064cba30c468730e8b9909fb551c"
+dependencies = [
+ "dbus-secret-service",
+ "log",
+ "secret-service",
+ "security-framework 2.11.1",
+ "security-framework 3.7.0",
+ "zeroize",
+]
+
+[[package]]
 name = "khronos-egl"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2341,6 +2452,15 @@ name = "libc"
 version = "0.2.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+
+[[package]]
+name = "libdbus-sys"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "328c4789d42200f1eeec05bd86c9c13c7f091d2ba9a6ea35acdf51f31bc0f043"
+dependencies = [
+ "pkg-config",
+]
 
 [[package]]
 name = "libloading"
@@ -2717,6 +2837,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
 
 [[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-complex"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2742,6 +2886,27 @@ version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c92800bd69a1eac91786bcfe9da64a897eb72911b8dc3095decbd07429e8048b"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
  "num-traits",
 ]
 
@@ -3551,6 +3716,7 @@ dependencies = [
  "env_logger",
  "futures-util",
  "hound",
+ "keyring",
  "log",
  "minifb",
  "rfd",
@@ -3561,6 +3727,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tokio-tungstenite",
+ "ureq",
 ]
 
 [[package]]
@@ -3633,6 +3800,20 @@ dependencies = [
  "tokio-tungstenite",
  "url",
  "uuid",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3733,6 +3914,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.23.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c54fcab019b409d04215d3a17cb438fd7fbf192ee61461f20f4fe18704bc138"
+dependencies = [
+ "log",
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3799,6 +4015,61 @@ dependencies = [
  "cfg-if",
  "libc",
  "version-compare",
+]
+
+[[package]]
+name = "secret-service"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4d35ad99a181be0a60ffcbe85d680d98f87bdc4d7644ade319b87076b9dbfd4"
+dependencies = [
+ "aes",
+ "cbc",
+ "futures-util",
+ "generic-array",
+ "hkdf",
+ "num",
+ "once_cell",
+ "rand",
+ "serde",
+ "sha2",
+ "zbus",
+]
+
+[[package]]
+name = "security-framework"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+dependencies = [
+ "bitflags 2.11.0",
+ "core-foundation 0.9.4",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags 2.11.0",
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -3889,6 +4160,17 @@ name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -4106,6 +4388,12 @@ dependencies = [
  "rustversion",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -4487,6 +4775,28 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "ureq"
+version = "2.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
+dependencies = [
+ "base64",
+ "flate2",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-pki-types",
+ "url",
+ "webpki-roots 0.26.11",
+]
 
 [[package]]
 name = "url"
@@ -4916,6 +5226,24 @@ dependencies = [
  "objc2-foundation 0.3.2",
  "url",
  "web-sys",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.9",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -5777,6 +6105,26 @@ dependencies = [
  "quote",
  "syn 2.0.117",
  "synstructure",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "rigflow-protocol",
     "rigflow-core",
     "rigflow-probe",
+    "rigflow-log",
 ]
 resolver = "2"
 

--- a/rigflow-client/Cargo.toml
+++ b/rigflow-client/Cargo.toml
@@ -24,3 +24,4 @@ tokio-tungstenite = "0.24"
 rigflow-protocol = { path = "../rigflow-protocol" }
 rigflow-core = { path = "../rigflow-core" }
 rigflow-log = { path = "../rigflow-log" }
+rfd = { version = "0.17.2", default-features = false, features = ["xdg-portal"] }

--- a/rigflow-client/Cargo.toml
+++ b/rigflow-client/Cargo.toml
@@ -23,3 +23,4 @@ tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "time"
 tokio-tungstenite = "0.24"
 rigflow-protocol = { path = "../rigflow-protocol" }
 rigflow-core = { path = "../rigflow-core" }
+rigflow-log = { path = "../rigflow-log" }

--- a/rigflow-client/Cargo.toml
+++ b/rigflow-client/Cargo.toml
@@ -25,3 +25,12 @@ rigflow-protocol = { path = "../rigflow-protocol" }
 rigflow-core = { path = "../rigflow-core" }
 rigflow-log = { path = "../rigflow-log" }
 rfd = { version = "0.17.2", default-features = false, features = ["xdg-portal"] }
+# LoTW confirmation download (blocking HTTPS on the export worker thread).
+ureq = "2"
+# Credential storage: OS keyring (macOS Keychain / Linux Secret Service via
+# pure-Rust zbus), with a file fallback handled in logging/credentials.rs.
+keyring = { version = "3", default-features = false, features = [
+    "apple-native",
+    "sync-secret-service",
+    "crypto-rust",
+] }

--- a/rigflow-client/src/logging/capture.rs
+++ b/rigflow-client/src/logging/capture.rs
@@ -1,0 +1,93 @@
+//! Build a `rigflow_log::CapturedRadioState` from the live `UiState`.
+//!
+//! The TX frequency mirrors the server's authoritative
+//! `effective_tx_freq_hz` (`rigflow-server` worker): split → the TX VFO's
+//! target, plus XIT. The math is done in `f64` because `UiState` frequencies are
+//! `f32` (exact only below ~16.7 MHz); the addition at least isn't further
+//! degraded. For WSJT-X QSOs the exact ADIF frequency is preferred over this.
+
+use rigflow_core::dsp::modes::DemodMode;
+use rigflow_core::radio::vfo::VfoSelect;
+use rigflow_log::{CapturedRadioState, Receiver};
+
+use crate::ui::state::UiState;
+
+/// Effective transmit frequency (Hz): `(split ? tx_vfo target : A target) + XIT`.
+pub fn effective_tx_freq_hz(s: &UiState) -> u64 {
+    let base = if s.split_enabled {
+        match s.tx_vfo {
+            VfoSelect::A => s.target_freq_hz,
+            VfoSelect::B => s.vfo_b_target_freq_hz,
+        }
+    } else {
+        s.target_freq_hz
+    } as f64;
+    let off = if s.xit_enabled {
+        s.xit_offset_hz as f64
+    } else {
+        0.0
+    };
+    (base + off).round().max(0.0) as u64
+}
+
+/// Effective transmit mode: VFO B's mode on a split-to-B, else VFO A's.
+pub fn effective_tx_mode(s: &UiState) -> DemodMode {
+    if s.split_enabled && s.tx_vfo == VfoSelect::B {
+        s.vfo_b_demod_mode
+    } else {
+        s.demod_mode
+    }
+}
+
+/// Map a demod mode to its ADIF `MODE`. USB/LSB → SSB; CWU/CWL → CW; a data
+/// mode (`DgtU`) defaults to FT8 (the entry form leaves it editable).
+pub fn demod_to_adif_mode(m: DemodMode) -> &'static str {
+    match m {
+        DemodMode::Usb | DemodMode::Lsb => "SSB",
+        DemodMode::Cwu | DemodMode::Cwl => "CW",
+        DemodMode::Am => "AM",
+        DemodMode::Nfm | DemodMode::Wfm => "FM",
+        DemodMode::DgtU => "FT8",
+    }
+}
+
+/// Default signal report for a mode (RST): 599 for CW, a nominal FT8 report for
+/// data, 59 otherwise. A default only — editable in the entry form.
+pub fn default_rst(m: DemodMode) -> &'static str {
+    match m {
+        DemodMode::Cwu | DemodMode::Cwl => "599",
+        DemodMode::DgtU => "-05",
+        _ => "59",
+    }
+}
+
+/// Snapshot the live radio state for split-frequency derivation.
+///
+/// Receivers: VFO A is always present; VFO B is added under split or dual-watch.
+/// `is_tx` is set from the effective-TX rule (never VFO-A-blindly) so the
+/// `FREQ_RX` search excludes the transmit receiver.
+pub fn capture_radio_state(s: &UiState) -> CapturedRadioState {
+    let tx_freq_hz = effective_tx_freq_hz(s);
+    let tx_mode = demod_to_adif_mode(effective_tx_mode(s)).to_string();
+
+    let mut receivers = Vec::with_capacity(2);
+    let a_is_tx = !s.split_enabled || s.tx_vfo == VfoSelect::A;
+    receivers.push(Receiver {
+        freq_hz: s.target_freq_hz.max(0.0) as u64,
+        is_tx: a_is_tx,
+    });
+    if s.split_enabled || s.dual_watch_enabled {
+        let b_is_tx = s.split_enabled && s.tx_vfo == VfoSelect::B;
+        receivers.push(Receiver {
+            freq_hz: s.vfo_b_target_freq_hz.max(0.0) as u64,
+            is_tx: b_is_tx,
+        });
+    }
+
+    CapturedRadioState {
+        tx_freq_hz,
+        tx_mode,
+        split_active: s.split_enabled,
+        receivers,
+    }
+}

--- a/rigflow-client/src/logging/credentials.rs
+++ b/rigflow-client/src/logging/credentials.rs
@@ -1,0 +1,146 @@
+//! Per-service credential storage for online sync (currently LoTW).
+//!
+//! Tries the OS keyring first (macOS Keychain / Linux Secret Service). When that
+//! is unavailable — common on a minimal Linux box with no Secret Service daemon —
+//! it falls back to a per-operator file with owner-only (`0600`) permissions.
+//! The backend actually used is reported so the UI can say where the secret went.
+//!
+//! Login and password are stored together as one secret (`login\npassword`); the
+//! login isn't secret, but pairing them keeps one source of truth and one place
+//! to clear. Nothing here logs or returns the password.
+
+use std::path::Path;
+
+/// A LoTW login pair.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct Credential {
+    pub login: String,
+    pub password: String,
+}
+
+/// Which store a credential lives in, for a one-line UI note.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Backend {
+    Keyring,
+    File,
+}
+
+impl Backend {
+    pub fn note(self) -> &'static str {
+        match self {
+            Backend::Keyring => "saved in the OS keyring",
+            Backend::File => "OS keyring unavailable — saved in a local file (owner-only)",
+        }
+    }
+}
+
+/// The keyring "service" namespace (distinct from a ham *service* like LoTW).
+const KEYRING_APP: &str = "rigflow";
+
+/// Keyring account key for `(service, operator)`, e.g. `lotw:KK7TCY`.
+fn account(service: &str, operator: &str) -> String {
+    format!("{service}:{operator}")
+}
+
+fn file_path(dir: &Path, service: &str) -> std::path::PathBuf {
+    dir.join(format!("{service}.cred"))
+}
+
+fn pack(c: &Credential) -> String {
+    format!("{}\n{}", c.login, c.password)
+}
+
+fn unpack(s: &str) -> Credential {
+    let s = s.strip_suffix('\n').unwrap_or(s);
+    let (login, password) = s.split_once('\n').unwrap_or((s, ""));
+    Credential {
+        login: login.to_string(),
+        password: password.to_string(),
+    }
+}
+
+/// Store `cred` for `service` under `operator`. Returns which backend took it.
+/// Prefers the keyring; on any keyring failure, writes the owner-only file.
+pub fn store(
+    service: &str,
+    operator: &str,
+    cred: &Credential,
+    file_dir: &Path,
+) -> Result<Backend, String> {
+    if let Ok(entry) = keyring::Entry::new(KEYRING_APP, &account(service, operator))
+        && entry.set_password(&pack(cred)).is_ok()
+    {
+        // Don't leave a stale plaintext copy once the keyring holds it.
+        let _ = std::fs::remove_file(file_path(file_dir, service));
+        return Ok(Backend::Keyring);
+    }
+    let path = file_path(file_dir, service);
+    std::fs::write(&path, pack(cred).as_bytes()).map_err(|e| format!("saving credential: {e}"))?;
+    set_owner_only(&path);
+    Ok(Backend::File)
+}
+
+/// Load a stored credential, if any, and where it came from.
+pub fn load(service: &str, operator: &str, file_dir: &Path) -> Option<(Credential, Backend)> {
+    if let Ok(entry) = keyring::Entry::new(KEYRING_APP, &account(service, operator))
+        && let Ok(secret) = entry.get_password()
+    {
+        return Some((unpack(&secret), Backend::Keyring));
+    }
+    std::fs::read_to_string(file_path(file_dir, service))
+        .ok()
+        .map(|s| (unpack(&s), Backend::File))
+}
+
+/// Forget a stored credential from whichever backend holds it.
+pub fn clear(service: &str, operator: &str, file_dir: &Path) {
+    if let Ok(entry) = keyring::Entry::new(KEYRING_APP, &account(service, operator)) {
+        let _ = entry.delete_credential();
+    }
+    let _ = std::fs::remove_file(file_path(file_dir, service));
+}
+
+#[cfg(unix)]
+fn set_owner_only(path: &Path) {
+    use std::os::unix::fs::PermissionsExt;
+    let _ = std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600));
+}
+#[cfg(not(unix))]
+fn set_owner_only(_path: &Path) {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pack_unpack_round_trips() {
+        let c = Credential {
+            login: "KK7TCY".into(),
+            password: "s3cr3t pass".into(),
+        };
+        assert_eq!(unpack(&pack(&c)), c);
+    }
+
+    #[test]
+    fn file_fallback_round_trips_and_is_owner_only() {
+        let dir = std::env::temp_dir().join(format!("rigflow-cred-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        // Force the file path directly (the keyring may or may not exist in CI).
+        let c = Credential {
+            login: "KK7TCY".into(),
+            password: "pw".into(),
+        };
+        let path = file_path(&dir, "lotw");
+        std::fs::write(&path, pack(&c).as_bytes()).unwrap();
+        set_owner_only(&path);
+        let got = unpack(&std::fs::read_to_string(&path).unwrap());
+        assert_eq!(got, c);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mode = std::fs::metadata(&path).unwrap().permissions().mode();
+            assert_eq!(mode & 0o777, 0o600);
+        }
+        std::fs::remove_dir_all(&dir).ok();
+    }
+}

--- a/rigflow-client/src/logging/eqsl.rs
+++ b/rigflow-client/src/logging/eqsl.rs
@@ -32,30 +32,33 @@ pub fn download(user: &str, password: &str) -> Result<String, String> {
         .into_string()
         .map_err(|e| format!("reading the eQSL response: {e}"))?;
 
-    if let Some(rel) = find_adif_link(&page) {
-        let url = format!("{BASE}{rel}");
+    if let Some(href) = find_adif_link(&page) {
         return a
-            .get(&url)
+            .get(&resolve(&href))
             .call()
             .map_err(redact)?
             .into_string()
             .map_err(|e| format!("downloading the eQSL ADIF: {e}"));
     }
-    // eQSL says so in prose when the inbox is empty.
+    // A successful build with no cards, or an empty inbox: not an error.
     let low = page.to_ascii_lowercase();
-    if low.contains("no ") && low.contains("adif") {
+    if low.contains("has been built") || (low.contains("no ") && low.contains("adif")) {
         return Ok(String::new());
     }
     Err(error_hint(&page))
 }
 
 /// Upload a batch of QSOs to eQSL. Best-effort count parse; the reply is prose.
+///
+/// Credentials use eQSL's own field names `EQSL_USER` / `EQSL_PSWD` (not
+/// `UserName`/`Password` — that's the download endpoint), with the batch in
+/// `ADIFData`.
 pub fn upload(user: &str, password: &str, adif: &str) -> Result<UploadReport, String> {
     let body = agent()
         .post(&format!("{BASE}/qslcard/importADIF.cfm"))
         .send_form(&[
-            ("UserName", user),
-            ("Password", password),
+            ("EQSL_USER", user),
+            ("EQSL_PSWD", password),
             ("ADIFData", adif),
         ])
         .map_err(redact)?
@@ -64,14 +67,37 @@ pub fn upload(user: &str, password: &str, adif: &str) -> Result<UploadReport, St
     parse_upload(&body)
 }
 
-/// Pull the generated ADIF path out of the DownloadInBox HTML. eQSL links it as
-/// `…downloadedfiles/NAME.adi`; return it rooted at `/qslcard/`.
+/// The `href` of the built ADIF from the DownloadInBox HTML — read from the page
+/// rather than reconstructed, because eQSL moved `DownloadedFiles` out of the
+/// `qslcard/` folder in 2019, so a hard-coded path 404s. Returns the raw href
+/// (absolute URL, `/`-rooted, or relative); [`resolve`] turns it into a URL.
 fn find_adif_link(html: &str) -> Option<String> {
-    const KEY: &str = "downloadedfiles/";
-    let start = html.find(KEY)?;
-    let tail = &html[start..];
-    let end = tail.find(".adi")? + 4;
-    Some(format!("/qslcard/{}", &tail[..end]))
+    let lower = html.to_ascii_lowercase();
+    let mut from = 0;
+    while let Some(rel) = lower[from..].find(".adi") {
+        let end = from + rel + 4;
+        // Walk back to the quote that opened this href value.
+        if let Some(q) = html[..end].rfind(['"', '\'']) {
+            let href = &html[q + 1..end];
+            if !href.is_empty() && !href.contains('<') && !href.contains('>') {
+                return Some(href.to_string());
+            }
+        }
+        from = end;
+    }
+    None
+}
+
+/// Turn a page href into an absolute URL against eQSL's host.
+fn resolve(href: &str) -> String {
+    if href.starts_with("http://") || href.starts_with("https://") {
+        href.to_string()
+    } else if let Some(rooted) = href.strip_prefix('/') {
+        format!("{BASE}/{rooted}")
+    } else {
+        // Relative to /qslcard/ (where DownloadInBox.cfm lives), so "../x" climbs out.
+        format!("{BASE}/qslcard/{href}")
+    }
 }
 
 /// Best-effort read of the eQSL import reply. eQSL reports like "Result: N out
@@ -133,13 +159,33 @@ mod tests {
 
     #[test]
     fn finds_the_adif_link() {
-        let html =
-            r#"<html><a href="/qslcard/downloadedfiles/AB1CD_inbox.adi">Download</a></html>"#;
+        // The real href reads straight from the page (case-insensitive tag).
+        let html = r#"Your ADIF log file has been built.
+            <A HREF="/downloadedfiles/AB1CD_inbox.adi">ADI</A>
+            <a href="/downloadedfiles/AB1CD_inbox.txt">TXT</a>"#;
         assert_eq!(
             find_adif_link(html).as_deref(),
-            Some("/qslcard/downloadedfiles/AB1CD_inbox.adi")
+            Some("/downloadedfiles/AB1CD_inbox.adi")
         );
         assert_eq!(find_adif_link("<html>no link</html>"), None);
+    }
+
+    #[test]
+    fn resolves_hrefs_against_the_host() {
+        // The post-2019 relocated path lives above qslcard/, so a /-rooted href
+        // must NOT get a qslcard prefix (that was the 404 bug).
+        assert_eq!(
+            resolve("/downloadedfiles/x.adi"),
+            "https://www.eqsl.cc/downloadedfiles/x.adi"
+        );
+        assert_eq!(
+            resolve("https://www.eqsl.cc/downloadedfiles/x.adi"),
+            "https://www.eqsl.cc/downloadedfiles/x.adi"
+        );
+        assert_eq!(
+            resolve("../downloadedfiles/x.adi"),
+            "https://www.eqsl.cc/qslcard/../downloadedfiles/x.adi"
+        );
     }
 
     #[test]

--- a/rigflow-client/src/logging/eqsl.rs
+++ b/rigflow-client/src/logging/eqsl.rs
@@ -1,0 +1,152 @@
+//! eQSL.cc sync — download received QSLs (confirmations) and upload QSOs.
+//! Username + password auth.
+//!
+//! Download is two-step: `DownloadInBox.cfm` builds an ADIF and returns an HTML
+//! page linking to it; we follow the link. Upload posts the ADIF batch to
+//! `ImportADIF.cfm`. The exact form fields and reply wording are eQSL-specific
+//! and centralized in the small helpers here for easy adjustment after a live
+//! run — see the module-level verification note in [`super::services`].
+
+use std::time::Duration;
+
+use super::services::UploadReport;
+
+const BASE: &str = "https://www.eqsl.cc";
+
+fn agent() -> ureq::Agent {
+    ureq::AgentBuilder::new()
+        .timeout(Duration::from_secs(90))
+        .build()
+}
+
+/// Download the received-QSL inbox as ADIF (empty string if there's nothing new).
+pub fn download(user: &str, password: &str) -> Result<String, String> {
+    let a = agent();
+    let page = a
+        .get(&format!("{BASE}/qslcard/DownloadInBox.cfm"))
+        .query("UserName", user)
+        .query("Password", password)
+        .query("QSLDetail", "1")
+        .call()
+        .map_err(redact)?
+        .into_string()
+        .map_err(|e| format!("reading the eQSL response: {e}"))?;
+
+    if let Some(rel) = find_adif_link(&page) {
+        let url = format!("{BASE}{rel}");
+        return a
+            .get(&url)
+            .call()
+            .map_err(redact)?
+            .into_string()
+            .map_err(|e| format!("downloading the eQSL ADIF: {e}"));
+    }
+    // eQSL says so in prose when the inbox is empty.
+    let low = page.to_ascii_lowercase();
+    if low.contains("no ") && low.contains("adif") {
+        return Ok(String::new());
+    }
+    Err(error_hint(&page))
+}
+
+/// Upload a batch of QSOs to eQSL. Best-effort count parse; the reply is prose.
+pub fn upload(user: &str, password: &str, adif: &str) -> Result<UploadReport, String> {
+    let body = agent()
+        .post(&format!("{BASE}/qslcard/importADIF.cfm"))
+        .send_form(&[
+            ("UserName", user),
+            ("Password", password),
+            ("ADIFData", adif),
+        ])
+        .map_err(redact)?
+        .into_string()
+        .map_err(|e| format!("reading the eQSL response: {e}"))?;
+    parse_upload(&body)
+}
+
+/// Pull the generated ADIF path out of the DownloadInBox HTML. eQSL links it as
+/// `…downloadedfiles/NAME.adi`; return it rooted at `/qslcard/`.
+fn find_adif_link(html: &str) -> Option<String> {
+    const KEY: &str = "downloadedfiles/";
+    let start = html.find(KEY)?;
+    let tail = &html[start..];
+    let end = tail.find(".adi")? + 4;
+    Some(format!("/qslcard/{}", &tail[..end]))
+}
+
+/// Best-effort read of the eQSL import reply. eQSL reports like "Result: N out
+/// of M records added" with rejects called out; if we can't find numbers we keep
+/// the whole (trimmed) message so the operator sees what eQSL said.
+fn parse_upload(body: &str) -> Result<UploadReport, String> {
+    let low = body.to_ascii_lowercase();
+    if low.contains("error") && !low.contains("added") {
+        return Err(error_hint(body));
+    }
+    let accepted = number_before(&low, "record").unwrap_or(0);
+    let rejected = number_before(&low, "rejected").unwrap_or(0);
+    Ok(UploadReport {
+        accepted,
+        rejected,
+        message: first_meaningful_line(body),
+    })
+}
+
+/// The integer immediately preceding the first occurrence of `word`.
+fn number_before(haystack: &str, word: &str) -> Option<usize> {
+    let at = haystack.find(word)?;
+    haystack[..at]
+        .rsplit(|c: char| !c.is_ascii_digit())
+        .find(|s| !s.is_empty())
+        .and_then(|s| s.parse().ok())
+}
+
+fn first_meaningful_line(body: &str) -> String {
+    body.lines()
+        .map(str::trim)
+        .find(|l| !l.is_empty() && !l.starts_with('<'))
+        .unwrap_or("")
+        .chars()
+        .take(200)
+        .collect()
+}
+
+fn error_hint(body: &str) -> String {
+    let line = first_meaningful_line(body);
+    if line.is_empty() {
+        "eQSL returned an unexpected response — check your username and password.".into()
+    } else {
+        format!("eQSL: {line}")
+    }
+}
+
+/// No URL (it carries the password) in a transport error.
+fn redact(e: ureq::Error) -> String {
+    match e {
+        ureq::Error::Status(code, _) => format!("eQSL returned HTTP {code}."),
+        ureq::Error::Transport(t) => format!("could not reach eQSL: {}", t.kind()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn finds_the_adif_link() {
+        let html =
+            r#"<html><a href="/qslcard/downloadedfiles/AB1CD_inbox.adi">Download</a></html>"#;
+        assert_eq!(
+            find_adif_link(html).as_deref(),
+            Some("/qslcard/downloadedfiles/AB1CD_inbox.adi")
+        );
+        assert_eq!(find_adif_link("<html>no link</html>"), None);
+    }
+
+    #[test]
+    fn parses_an_upload_count() {
+        let r = parse_upload("Result: 3 out of 3 records added").unwrap();
+        assert_eq!(r.accepted, 3);
+        let err = parse_upload("Error: bad login").unwrap_err();
+        assert!(err.to_lowercase().contains("bad login"));
+    }
+}

--- a/rigflow-client/src/logging/eqsl.rs
+++ b/rigflow-client/src/logging/eqsl.rs
@@ -48,23 +48,35 @@ pub fn download(user: &str, password: &str) -> Result<String, String> {
     Err(error_hint(&page))
 }
 
-/// Upload a batch of QSOs to eQSL. Best-effort count parse; the reply is prose.
+/// Upload QSOs to eQSL as one batch (eQSL takes a whole ADIF at once, unlike
+/// QRZ). Returns the ids sent — eQSL doesn't report per-record outcomes, so on a
+/// non-error reply they are all treated as landed — plus a best-effort tally.
 ///
 /// Credentials use eQSL's own field names `EQSL_USER` / `EQSL_PSWD` (not
-/// `UserName`/`Password` — that's the download endpoint), with the batch in
-/// `ADIFData`.
-pub fn upload(user: &str, password: &str, adif: &str) -> Result<UploadReport, String> {
+/// `UserName`/`Password` — that's the download endpoint), with the batch (header
+/// + records) in `ADIFData`.
+pub fn upload(
+    user: &str,
+    password: &str,
+    records: &[(i64, String)],
+) -> Result<(Vec<i64>, UploadReport), String> {
+    let mut adif = rigflow_log::adif::adif_header();
+    for (_, rec) in records {
+        adif.push_str(rec);
+    }
     let body = agent()
         .post(&format!("{BASE}/qslcard/importADIF.cfm"))
         .send_form(&[
             ("EQSL_USER", user),
             ("EQSL_PSWD", password),
-            ("ADIFData", adif),
+            ("ADIFData", &adif),
         ])
         .map_err(redact)?
         .into_string()
         .map_err(|e| format!("reading the eQSL response: {e}"))?;
-    parse_upload(&body)
+    let report = parse_upload(&body)?;
+    let ids = records.iter().map(|(id, _)| *id).collect();
+    Ok((ids, report))
 }
 
 /// The `href` of the built ADIF from the DownloadInBox HTML — read from the page

--- a/rigflow-client/src/logging/export.rs
+++ b/rigflow-client/src/logging/export.rs
@@ -1,17 +1,22 @@
-//! Client-side ADIF export: the dialog's draft state and the worker thread.
+//! Client-side contact filtering and ADIF export: the drafts and the worker.
 //!
-//! Export runs **off the UI thread**. `rigflow_log::Exporter` opens its own
-//! read-only SQLite connection, so a 200k-QSO export streams to disk on a worker
-//! while the app's read-write `LogStore` keeps logging contacts on the UI thread
-//! — WAL gives concurrent readers for free. The worker never writes, so it also
-//! cannot advance an incremental bookmark: it reports `max_qso_id` back and the
-//! UI thread advances the bookmark on the store it owns (and only for an
-//! incremental, non-dry-run export). See `rigflow_log::export`.
+//! **One filter, two consumers.** [`QsoFilterDraft`] builds the `ExportFilter`
+//! that drives *both* the contact-view list and the export file, so what the
+//! operator sees listed is what they get written. The filter lives with the
+//! contact view (the `Filter…` window); the export window only chooses the
+//! *output* shape.
 //!
-//! The live match count in the dialog is a *dry run* through the same filter, so
-//! the number the operator sees is the number they get. Those counts are
-//! debounced (see [`COUNT_DEBOUNCE`]) because the `extra`-JSON-backed filters
-//! (continent, zones, contest id, the `MY_*` snapshot) are unindexed full scans.
+//! **Incremental is not a filter.** [`ExportDraft::incremental`] answers "what
+//! haven't I exported yet", which is a fact about export progress, not about a
+//! contact — so it lives in the export window and is ANDed onto the shared
+//! filter at export time only. It would make no sense as a view filter (the list
+//! would start hiding contacts for reasons unrelated to the contacts). The export
+//! window shows the arithmetic, so the operator still knows what they're getting.
+//!
+//! All database work runs on the worker thread ([`spawn_export_worker`]) against
+//! a read-only connection. The filters read the `extra` JSON blob, which is
+//! unindexed — a full scan on every keystroke would stutter the UI thread that
+//! owns the `LogStore`.
 
 use std::collections::BTreeSet;
 use std::path::PathBuf;
@@ -19,16 +24,21 @@ use std::sync::mpsc::{Receiver, Sender, channel};
 use std::time::Duration;
 
 use rigflow_log::export::{
-    ExportFilter, ExportOptions, ExportSummary, Exporter, FieldProfile, FilterError, GridPrecision,
-    QslStatusFilter, Sort,
+    ContactPage, ExportFilter, ExportOptions, ExportSummary, Exporter, FieldProfile, FilterError,
+    GridPrecision, QslStatusFilter, Sort,
 };
 use rigflow_log::normalize::{self, ModeClass};
 
-/// How long the dialog waits after the last edit before running a count.
-pub const COUNT_DEBOUNCE: Duration = Duration::from_millis(250);
+/// How long the UI waits after the last edit before re-querying.
+pub const QUERY_DEBOUNCE: Duration = Duration::from_millis(250);
 
-/// Which set of fields a record carries — the draft's flattened form of
-/// [`FieldProfile`] (egui radio buttons want a `Copy` discriminant).
+/// Rows the contact view holds. The view reports the *total* match count
+/// separately, so this cap is visible ("showing 500 of 1,483") rather than a
+/// silent truncation that would quietly break the see-what-you-export promise.
+pub const VIEW_ROW_LIMIT: usize = 500;
+
+/// Which set of fields an exported record carries — the draft's flattened form
+/// of [`FieldProfile`] (egui radio buttons want a `Copy` discriminant).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum ProfileChoice {
     #[default]
@@ -37,13 +47,12 @@ pub enum ProfileChoice {
     Custom,
 }
 
-/// The export dialog's editable state.
+/// The shared contact filter: what the contact view lists, and what an export
+/// writes. Edited in the `Filter…` window, owned by the contact view.
 ///
-/// This lives on `RigflowApp`, **not** in `UiState`: only the export window
-/// touches it, and `UiState` is cloned every frame by `snapshot_state()`.
+/// Deliberately does **not** carry `since_last_export` — see the module docs.
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
-pub struct ExportDraft {
-    // ── filters ──────────────────────────────────────────────────────────
+pub struct QsoFilterDraft {
     pub date_from: String,
     pub date_to: String,
     /// Selected ADIF bands (checkbox grid over `normalize::known_bands`).
@@ -66,56 +75,76 @@ pub struct ExportDraft {
     pub not_uploaded_to: String,
     /// Service name for "confirmed by …". Empty = off.
     pub confirmed_by: String,
-    /// Only QSOs I haven't yet received a QSL for (`QSL_RCVD` != Y).
+    /// Only contacts whose QSL has come back (`QSL_RCVD` = Y).
     pub qsl_rcvd_yes: bool,
-
-    // ── incremental ──────────────────────────────────────────────────────
-    /// Export only what's new since this profile's bookmark.
-    pub incremental: bool,
-    /// Bookmark profile name (blank → the default profile).
-    pub profile: String,
-
-    // ── output ───────────────────────────────────────────────────────────
-    pub output_path: String,
-    pub profile_choice: ProfileChoice,
-    /// Comma-separated ADIF fields for [`ProfileChoice::Custom`].
-    pub custom_fields: String,
-    pub include_extra: bool,
-    pub sort_reverse: bool,
 }
 
-impl ExportDraft {
-    /// A fresh draft, pre-filled with a sensible destination.
-    pub fn new(default_path: PathBuf) -> ExportDraft {
-        ExportDraft {
-            output_path: default_path.to_string_lossy().into_owned(),
-            include_extra: true,
-            ..Default::default()
-        }
+impl QsoFilterDraft {
+    /// Whether any constraint is set. Drives the "filters are active" summary —
+    /// a filtered list that doesn't *say* it's filtered is a footgun.
+    pub fn is_active(&self) -> bool {
+        *self != QsoFilterDraft::default()
     }
 
-    /// The bookmark profile this draft names (blank → the default).
-    pub fn profile_name(&self) -> String {
-        let p = self.profile.trim();
-        if p.is_empty() {
-            rigflow_log::export::DEFAULT_EXPORT_PROFILE.to_string()
-        } else {
-            p.to_string()
+    /// Short human summary of the active constraints, for the chip under the
+    /// contact-view toolbar (e.g. `20m, 40m · SSB · from 20260701`).
+    pub fn summary(&self) -> String {
+        let mut parts: Vec<String> = Vec::new();
+        if !self.bands.is_empty() {
+            let mut b = self.bands.iter().cloned().collect::<Vec<_>>();
+            b.sort();
+            parts.push(b.join(", "));
         }
+        if !self.mode_classes.is_empty() {
+            parts.push(
+                self.mode_classes
+                    .iter()
+                    .map(|c| c.as_str())
+                    .collect::<Vec<_>>()
+                    .join(", "),
+            );
+        }
+        for (label, v) in [
+            ("", &self.modes),
+            ("submode ", &self.submodes),
+            ("call ", &self.call_pattern),
+            ("dxcc ", &self.dxcc),
+            ("grid ", &self.gridsquare),
+            ("my grid ", &self.my_gridsquare),
+            ("contest ", &self.contest_id),
+        ] {
+            let v = v.trim();
+            if !v.is_empty() {
+                parts.push(format!("{label}{v}"));
+            }
+        }
+        if !self.date_from.trim().is_empty() {
+            parts.push(format!("from {}", self.date_from.trim()));
+        }
+        if !self.date_to.trim().is_empty() {
+            parts.push(format!("to {}", self.date_to.trim()));
+        }
+        if !self.not_uploaded_to.trim().is_empty() {
+            parts.push(format!("not on {}", self.not_uploaded_to.trim()));
+        }
+        if !self.confirmed_by.trim().is_empty() {
+            parts.push(format!("confirmed by {}", self.confirmed_by.trim()));
+        }
+        if self.qsl_rcvd_yes {
+            parts.push("QSL received".into());
+        }
+        parts.join(" · ")
     }
 
-    /// Translate the draft into an [`ExportFilter`].
-    ///
-    /// Returns the *validated* filter, so a malformed one is reported in the
-    /// dialog (as a red line under the count) instead of running a query that
-    /// silently matches nothing.
-    pub fn to_filter(&self) -> Result<ExportFilter, FilterError> {
+    /// Build the shared [`ExportFilter`]. `incremental` (from the export window)
+    /// is ANDed on here, and only there — the view always passes `None`.
+    pub fn to_filter(&self, incremental: Option<String>) -> Result<ExportFilter, FilterError> {
         let f = ExportFilter {
             date_from: opt(&self.date_from),
             date_to: opt(&self.date_to),
             datetime_from: None,
             datetime_to: None,
-            since_last_export: self.incremental.then(|| self.profile_name()),
+            since_last_export: incremental,
 
             bands: (!self.bands.is_empty()).then(|| self.bands.iter().cloned().collect()),
             match_either_band: self.match_either_band,
@@ -164,7 +193,66 @@ impl ExportDraft {
         Ok(f)
     }
 
-    /// Translate the draft into [`ExportOptions`].
+    /// Every band the checkbox grid offers.
+    pub fn all_bands() -> Vec<&'static str> {
+        normalize::known_bands().collect()
+    }
+}
+
+/// A "have I worked this station?" lookup: matches the whole log by callsign,
+/// **ignoring the view filter** — the question is about the log, not about what
+/// the operator happens to be looking at. A 20m-filtered view must not hide the
+/// 40m QSO with the station being checked.
+pub fn call_lookup_filter(call: &str) -> Result<ExportFilter, FilterError> {
+    let f = ExportFilter {
+        call_exact: opt(call),
+        ..Default::default()
+    };
+    f.validate()?;
+    Ok(f)
+}
+
+/// The export window's state: **output shape only**, plus incremental.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct ExportDraft {
+    pub output_path: String,
+    pub profile_choice: ProfileChoice,
+    /// Comma-separated ADIF fields for [`ProfileChoice::Custom`].
+    pub custom_fields: String,
+    pub include_extra: bool,
+    pub sort_reverse: bool,
+
+    /// Export only what's new since this stream's bookmark. Not a view filter.
+    pub incremental: bool,
+    /// Bookmark stream name (blank → the default stream).
+    pub profile: String,
+}
+
+impl ExportDraft {
+    pub fn new(default_path: PathBuf) -> ExportDraft {
+        ExportDraft {
+            output_path: default_path.to_string_lossy().into_owned(),
+            include_extra: true,
+            ..Default::default()
+        }
+    }
+
+    /// The bookmark stream this draft names (blank → the default).
+    pub fn profile_name(&self) -> String {
+        let p = self.profile.trim();
+        if p.is_empty() {
+            rigflow_log::export::DEFAULT_EXPORT_PROFILE.to_string()
+        } else {
+            p.to_string()
+        }
+    }
+
+    /// `Some(stream)` when this export is incremental — what gets ANDed onto the
+    /// shared filter at export time.
+    pub fn incremental_profile(&self) -> Option<String> {
+        self.incremental.then(|| self.profile_name())
+    }
+
     pub fn to_options(&self) -> Result<ExportOptions, FilterError> {
         let field_profile = match self.profile_choice {
             ProfileChoice::Full => FieldProfile::Full,
@@ -187,11 +275,6 @@ impl ExportDraft {
         opts.validate()?;
         Ok(opts)
     }
-
-    /// Every band the checkbox grid offers.
-    pub fn all_bands() -> Vec<&'static str> {
-        normalize::known_bands().collect()
-    }
 }
 
 fn opt(s: &str) -> Option<String> {
@@ -199,8 +282,8 @@ fn opt(s: &str) -> Option<String> {
     (!s.is_empty()).then(|| s.to_string())
 }
 
-/// Split a comma-separated field into a list, or `None` if it's blank. An empty
-/// list would be rejected by `validate()`, so blank must mean "no constraint".
+/// Split a comma-separated field into a list, or `None` if blank. An empty list
+/// would be rejected by `validate()`, so blank must mean "no constraint".
 fn csv(s: &str) -> Option<Vec<String>> {
     let v: Vec<String> = s
         .split(',')
@@ -212,14 +295,32 @@ fn csv(s: &str) -> Option<Vec<String>> {
 
 // ─────────────────────────────────────────────────────────── worker ──────
 
-/// Work handed to the export thread. Both variants carry the database path, so
+/// Work handed to the export thread. Every variant carries the database path, so
 /// the worker holds no per-operator state and an operator switch needs no
 /// teardown.
 pub enum ExportJob {
-    /// Dry run: count the matches, write nothing.
+    /// The contact view's page: rows + total match count.
+    Query {
+        db_path: PathBuf,
+        filter: Box<ExportFilter>,
+        /// Echoed back so a reply for a filter the operator has already edited
+        /// past is dropped instead of flashing stale rows on screen.
+        seq: u64,
+    },
+    /// "Have I worked this station?" — the whole log, by callsign.
+    CallLookup {
+        db_path: PathBuf,
+        call: String,
+        filter: Box<ExportFilter>,
+        seq: u64,
+    },
+    /// How many contacts an *incremental* export would write. Only needed when
+    /// the export's set differs from the visible list (i.e. incremental is on);
+    /// otherwise the view's own total already answers it.
     Count {
         db_path: PathBuf,
         filter: Box<ExportFilter>,
+        seq: u64,
     },
     /// Write the file.
     Write {
@@ -231,14 +332,28 @@ pub enum ExportJob {
 
 /// What the worker reports back.
 pub enum ExportEvent {
-    Count(Result<usize, String>),
+    Contacts {
+        seq: u64,
+        result: Result<Box<ContactPage>, String>,
+    },
+    CallMatches {
+        seq: u64,
+        call: String,
+        result: Result<Box<ContactPage>, String>,
+    },
+    Count {
+        seq: u64,
+        result: Result<usize, String>,
+    },
     Done(Result<Box<ExportSummary>, String>),
 }
 
-/// Spawn the export worker. One thread for the app's lifetime.
+/// Spawn the worker. One thread for the app's lifetime.
 ///
-/// Counts are **coalesced**: while the operator types, several count jobs can
-/// queue up, and only the newest is worth running. Writes are never dropped.
+/// Queries are **coalesced**: while the operator types, several jobs can queue up
+/// and only the newest of each kind is worth running — an older one's answer is
+/// already stale, and running it only delays the one that matters. Writes are
+/// never dropped.
 pub fn spawn_export_worker() -> (Sender<ExportJob>, Receiver<ExportEvent>) {
     let (job_tx, job_rx) = channel::<ExportJob>();
     let (evt_tx, evt_rx) = channel::<ExportEvent>();
@@ -247,15 +362,17 @@ pub fn spawn_export_worker() -> (Sender<ExportJob>, Receiver<ExportEvent>) {
         .name("export".into())
         .spawn(move || {
             while let Ok(job) = job_rx.recv() {
-                // Drain whatever else is queued: run every Write, but only the
-                // last Count — an older count's answer is already stale.
-                let mut pending_count: Option<ExportJob> = None;
+                let mut latest_query: Option<ExportJob> = None;
+                let mut latest_lookup: Option<ExportJob> = None;
+                let mut latest_count: Option<ExportJob> = None;
                 let mut jobs = vec![job];
                 jobs.extend(job_rx.try_iter());
 
                 for job in jobs {
                     match job {
-                        c @ ExportJob::Count { .. } => pending_count = Some(c),
+                        q @ ExportJob::Query { .. } => latest_query = Some(q),
+                        l @ ExportJob::CallLookup { .. } => latest_lookup = Some(l),
+                        c @ ExportJob::Count { .. } => latest_count = Some(c),
                         w @ ExportJob::Write { .. } => {
                             if evt_tx.send(run(w)).is_err() {
                                 return; // app gone
@@ -263,10 +380,13 @@ pub fn spawn_export_worker() -> (Sender<ExportJob>, Receiver<ExportEvent>) {
                         }
                     }
                 }
-                if let Some(c) = pending_count
-                    && evt_tx.send(run(c)).is_err()
+                for job in [latest_query, latest_lookup, latest_count]
+                    .into_iter()
+                    .flatten()
                 {
-                    return;
+                    if evt_tx.send(run(job)).is_err() {
+                        return;
+                    }
                 }
             }
         })
@@ -277,11 +397,40 @@ pub fn spawn_export_worker() -> (Sender<ExportJob>, Receiver<ExportEvent>) {
 
 fn run(job: ExportJob) -> ExportEvent {
     match job {
-        ExportJob::Count { db_path, filter } => ExportEvent::Count(
-            Exporter::open(&db_path)
+        ExportJob::Query {
+            db_path,
+            filter,
+            seq,
+        } => ExportEvent::Contacts {
+            seq,
+            result: Exporter::open(&db_path)
+                .and_then(|ex| ex.page(&filter, VIEW_ROW_LIMIT, Sort::Reverse))
+                .map(Box::new)
+                .map_err(|e| e.to_string()),
+        },
+        ExportJob::CallLookup {
+            db_path,
+            call,
+            filter,
+            seq,
+        } => ExportEvent::CallMatches {
+            seq,
+            call,
+            result: Exporter::open(&db_path)
+                .and_then(|ex| ex.page(&filter, VIEW_ROW_LIMIT, Sort::Reverse))
+                .map(Box::new)
+                .map_err(|e| e.to_string()),
+        },
+        ExportJob::Count {
+            db_path,
+            filter,
+            seq,
+        } => ExportEvent::Count {
+            seq,
+            result: Exporter::open(&db_path)
                 .and_then(|ex| ex.count(&filter))
                 .map_err(|e| e.to_string()),
-        ),
+        },
         ExportJob::Write {
             db_path,
             filter,

--- a/rigflow-client/src/logging/export.rs
+++ b/rigflow-client/src/logging/export.rs
@@ -23,11 +23,13 @@ use std::path::PathBuf;
 use std::sync::mpsc::{Receiver, Sender, channel};
 use std::time::Duration;
 
+use rigflow_log::dedupe::DEFAULT_WINDOW_SECS;
 use rigflow_log::display;
 use rigflow_log::export::{
     ContactPage, ExportFilter, ExportOptions, ExportSummary, Exporter, FieldProfile, FilterError,
     GridPrecision, QslStatusFilter, Sort,
 };
+use rigflow_log::import::ImportPlan;
 use rigflow_log::normalize::{self, ModeClass};
 
 /// How long the UI waits after the last edit before re-querying.
@@ -339,6 +341,10 @@ pub enum ExportJob {
         filter: Box<ExportFilter>,
         options: Box<ExportOptions>,
     },
+    /// Read an ADIF file and work out what importing it *would* do — parse,
+    /// normalize, validate, dedupe. Read-only, so it runs here rather than on the
+    /// UI thread; a big file is slow to parse and the operator keeps logging.
+    PlanImport { db_path: PathBuf, file: PathBuf },
 }
 
 /// What the worker reports back.
@@ -357,6 +363,12 @@ pub enum ExportEvent {
         result: Result<usize, String>,
     },
     Done(Result<Box<ExportSummary>, String>),
+    /// The import preview. The plan carries the parsed contacts, so committing it
+    /// needs no second parse — the operator confirms exactly what was planned.
+    ImportPlanned {
+        file: PathBuf,
+        result: Result<Box<ImportPlan>, String>,
+    },
 }
 
 /// Spawn the worker. One thread for the app's lifetime.
@@ -384,7 +396,8 @@ pub fn spawn_export_worker() -> (Sender<ExportJob>, Receiver<ExportEvent>) {
                         q @ ExportJob::Query { .. } => latest_query = Some(q),
                         l @ ExportJob::CallLookup { .. } => latest_lookup = Some(l),
                         c @ ExportJob::Count { .. } => latest_count = Some(c),
-                        w @ ExportJob::Write { .. } => {
+                        // Never coalesced: each is an explicit operator action.
+                        w @ (ExportJob::Write { .. } | ExportJob::PlanImport { .. }) => {
                             if evt_tx.send(run(w)).is_err() {
                                 return; // app gone
                             }
@@ -452,5 +465,16 @@ fn run(job: ExportJob) -> ExportEvent {
                 .map(Box::new)
                 .map_err(|e| e.to_string()),
         ),
+        ExportJob::PlanImport { db_path, file } => {
+            let result = std::fs::read_to_string(&file)
+                .map_err(|e| format!("{}: {e}", file.display()))
+                .and_then(|text| {
+                    Exporter::open(&db_path)
+                        .and_then(|ex| ex.plan_import(&text, DEFAULT_WINDOW_SECS))
+                        .map_err(|e| e.to_string())
+                })
+                .map(Box::new);
+            ExportEvent::ImportPlanned { file, result }
+        }
     }
 }

--- a/rigflow-client/src/logging/export.rs
+++ b/rigflow-client/src/logging/export.rs
@@ -1,0 +1,296 @@
+//! Client-side ADIF export: the dialog's draft state and the worker thread.
+//!
+//! Export runs **off the UI thread**. `rigflow_log::Exporter` opens its own
+//! read-only SQLite connection, so a 200k-QSO export streams to disk on a worker
+//! while the app's read-write `LogStore` keeps logging contacts on the UI thread
+//! — WAL gives concurrent readers for free. The worker never writes, so it also
+//! cannot advance an incremental bookmark: it reports `max_qso_id` back and the
+//! UI thread advances the bookmark on the store it owns (and only for an
+//! incremental, non-dry-run export). See `rigflow_log::export`.
+//!
+//! The live match count in the dialog is a *dry run* through the same filter, so
+//! the number the operator sees is the number they get. Those counts are
+//! debounced (see [`COUNT_DEBOUNCE`]) because the `extra`-JSON-backed filters
+//! (continent, zones, contest id, the `MY_*` snapshot) are unindexed full scans.
+
+use std::collections::BTreeSet;
+use std::path::PathBuf;
+use std::sync::mpsc::{Receiver, Sender, channel};
+use std::time::Duration;
+
+use rigflow_log::export::{
+    ExportFilter, ExportOptions, ExportSummary, Exporter, FieldProfile, FilterError, GridPrecision,
+    QslStatusFilter, Sort,
+};
+use rigflow_log::normalize::{self, ModeClass};
+
+/// How long the dialog waits after the last edit before running a count.
+pub const COUNT_DEBOUNCE: Duration = Duration::from_millis(250);
+
+/// Which set of fields a record carries — the draft's flattened form of
+/// [`FieldProfile`] (egui radio buttons want a `Copy` discriminant).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum ProfileChoice {
+    #[default]
+    Full,
+    Core,
+    Custom,
+}
+
+/// The export dialog's editable state.
+///
+/// This lives on `RigflowApp`, **not** in `UiState`: only the export window
+/// touches it, and `UiState` is cloned every frame by `snapshot_state()`.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct ExportDraft {
+    // ── filters ──────────────────────────────────────────────────────────
+    pub date_from: String,
+    pub date_to: String,
+    /// Selected ADIF bands (checkbox grid over `normalize::known_bands`).
+    pub bands: BTreeSet<String>,
+    /// Also match `band_rx` — the rare split-across-bands QSO.
+    pub match_either_band: bool,
+    pub mode_classes: BTreeSet<ModeClass>,
+    /// Comma-separated exact canonical modes (`SSB, CW, FT8`).
+    pub modes: String,
+    /// Comma-separated submodes (`FT4, PSK31`).
+    pub submodes: String,
+    pub call_pattern: String,
+    /// Comma-separated DXCC entity codes.
+    pub dxcc: String,
+    pub gridsquare: String,
+    pub grid_precision: GridPrecision,
+    pub my_gridsquare: String,
+    pub contest_id: String,
+    /// Service name for "not yet uploaded to …" (e.g. `lotw`). Empty = off.
+    pub not_uploaded_to: String,
+    /// Service name for "confirmed by …". Empty = off.
+    pub confirmed_by: String,
+    /// Only QSOs I haven't yet received a QSL for (`QSL_RCVD` != Y).
+    pub qsl_rcvd_yes: bool,
+
+    // ── incremental ──────────────────────────────────────────────────────
+    /// Export only what's new since this profile's bookmark.
+    pub incremental: bool,
+    /// Bookmark profile name (blank → the default profile).
+    pub profile: String,
+
+    // ── output ───────────────────────────────────────────────────────────
+    pub output_path: String,
+    pub profile_choice: ProfileChoice,
+    /// Comma-separated ADIF fields for [`ProfileChoice::Custom`].
+    pub custom_fields: String,
+    pub include_extra: bool,
+    pub sort_reverse: bool,
+}
+
+impl ExportDraft {
+    /// A fresh draft, pre-filled with a sensible destination.
+    pub fn new(default_path: PathBuf) -> ExportDraft {
+        ExportDraft {
+            output_path: default_path.to_string_lossy().into_owned(),
+            include_extra: true,
+            ..Default::default()
+        }
+    }
+
+    /// The bookmark profile this draft names (blank → the default).
+    pub fn profile_name(&self) -> String {
+        let p = self.profile.trim();
+        if p.is_empty() {
+            rigflow_log::export::DEFAULT_EXPORT_PROFILE.to_string()
+        } else {
+            p.to_string()
+        }
+    }
+
+    /// Translate the draft into an [`ExportFilter`].
+    ///
+    /// Returns the *validated* filter, so a malformed one is reported in the
+    /// dialog (as a red line under the count) instead of running a query that
+    /// silently matches nothing.
+    pub fn to_filter(&self) -> Result<ExportFilter, FilterError> {
+        let f = ExportFilter {
+            date_from: opt(&self.date_from),
+            date_to: opt(&self.date_to),
+            datetime_from: None,
+            datetime_to: None,
+            since_last_export: self.incremental.then(|| self.profile_name()),
+
+            bands: (!self.bands.is_empty()).then(|| self.bands.iter().cloned().collect()),
+            match_either_band: self.match_either_band,
+            freq_from: None,
+            freq_to: None,
+            modes: csv(&self.modes),
+            submodes: csv(&self.submodes),
+            mode_classes: (!self.mode_classes.is_empty())
+                .then(|| self.mode_classes.iter().copied().collect()),
+
+            call_exact: None,
+            call_pattern: opt(&self.call_pattern),
+            call_prefix: None,
+            dxcc: csv(&self.dxcc).map(|v| v.iter().filter_map(|s| s.parse().ok()).collect()),
+            continent: None,
+            cq_zone: None,
+            itu_zone: None,
+            gridsquare: opt(&self.gridsquare),
+            grid_precision: self.grid_precision,
+            state: None,
+            country: None,
+
+            station_ids: None,
+            my_gridsquare: opt(&self.my_gridsquare),
+            operator: None,
+            station_callsign: None,
+
+            uploaded_to: None,
+            not_uploaded_to: opt(&self.not_uploaded_to).map(|s| vec![s]),
+            confirmed_by: opt(&self.confirmed_by).map(|s| vec![s]),
+            not_confirmed_by: None,
+            qsl_sent: None,
+            qsl_rcvd: self.qsl_rcvd_yes.then(|| QslStatusFilter {
+                service: None,
+                statuses: vec!["Y".into()],
+            }),
+
+            contest_ids: opt(&self.contest_id).map(|s| vec![s]),
+
+            // Multi-select in the contact view is deferred; the filter API
+            // supports an explicit id list already, there is just no UI to build
+            // one yet.
+            qso_ids: None,
+        };
+        f.validate()?;
+        Ok(f)
+    }
+
+    /// Translate the draft into [`ExportOptions`].
+    pub fn to_options(&self) -> Result<ExportOptions, FilterError> {
+        let field_profile = match self.profile_choice {
+            ProfileChoice::Full => FieldProfile::Full,
+            ProfileChoice::Core => FieldProfile::Core,
+            ProfileChoice::Custom => {
+                FieldProfile::Custom(csv(&self.custom_fields).unwrap_or_default())
+            }
+        };
+        let opts = ExportOptions {
+            output_path: PathBuf::from(self.output_path.trim()),
+            field_profile,
+            include_extra: self.include_extra,
+            adif_version: rigflow_log::export::DEFAULT_ADIF_VERSION.to_string(),
+            sort: if self.sort_reverse {
+                Sort::Reverse
+            } else {
+                Sort::Chronological
+            },
+        };
+        opts.validate()?;
+        Ok(opts)
+    }
+
+    /// Every band the checkbox grid offers.
+    pub fn all_bands() -> Vec<&'static str> {
+        normalize::known_bands().collect()
+    }
+}
+
+fn opt(s: &str) -> Option<String> {
+    let s = s.trim();
+    (!s.is_empty()).then(|| s.to_string())
+}
+
+/// Split a comma-separated field into a list, or `None` if it's blank. An empty
+/// list would be rejected by `validate()`, so blank must mean "no constraint".
+fn csv(s: &str) -> Option<Vec<String>> {
+    let v: Vec<String> = s
+        .split(',')
+        .map(|p| p.trim().to_string())
+        .filter(|p| !p.is_empty())
+        .collect();
+    (!v.is_empty()).then_some(v)
+}
+
+// ─────────────────────────────────────────────────────────── worker ──────
+
+/// Work handed to the export thread. Both variants carry the database path, so
+/// the worker holds no per-operator state and an operator switch needs no
+/// teardown.
+pub enum ExportJob {
+    /// Dry run: count the matches, write nothing.
+    Count {
+        db_path: PathBuf,
+        filter: Box<ExportFilter>,
+    },
+    /// Write the file.
+    Write {
+        db_path: PathBuf,
+        filter: Box<ExportFilter>,
+        options: Box<ExportOptions>,
+    },
+}
+
+/// What the worker reports back.
+pub enum ExportEvent {
+    Count(Result<usize, String>),
+    Done(Result<Box<ExportSummary>, String>),
+}
+
+/// Spawn the export worker. One thread for the app's lifetime.
+///
+/// Counts are **coalesced**: while the operator types, several count jobs can
+/// queue up, and only the newest is worth running. Writes are never dropped.
+pub fn spawn_export_worker() -> (Sender<ExportJob>, Receiver<ExportEvent>) {
+    let (job_tx, job_rx) = channel::<ExportJob>();
+    let (evt_tx, evt_rx) = channel::<ExportEvent>();
+
+    std::thread::Builder::new()
+        .name("export".into())
+        .spawn(move || {
+            while let Ok(job) = job_rx.recv() {
+                // Drain whatever else is queued: run every Write, but only the
+                // last Count — an older count's answer is already stale.
+                let mut pending_count: Option<ExportJob> = None;
+                let mut jobs = vec![job];
+                jobs.extend(job_rx.try_iter());
+
+                for job in jobs {
+                    match job {
+                        c @ ExportJob::Count { .. } => pending_count = Some(c),
+                        w @ ExportJob::Write { .. } => {
+                            if evt_tx.send(run(w)).is_err() {
+                                return; // app gone
+                            }
+                        }
+                    }
+                }
+                if let Some(c) = pending_count
+                    && evt_tx.send(run(c)).is_err()
+                {
+                    return;
+                }
+            }
+        })
+        .expect("spawn export worker");
+
+    (job_tx, evt_rx)
+}
+
+fn run(job: ExportJob) -> ExportEvent {
+    match job {
+        ExportJob::Count { db_path, filter } => ExportEvent::Count(
+            Exporter::open(&db_path)
+                .and_then(|ex| ex.count(&filter))
+                .map_err(|e| e.to_string()),
+        ),
+        ExportJob::Write {
+            db_path,
+            filter,
+            options,
+        } => ExportEvent::Done(
+            Exporter::open(&db_path)
+                .and_then(|ex| ex.export(&filter, &options))
+                .map(Box::new)
+                .map_err(|e| e.to_string()),
+        ),
+    }
+}

--- a/rigflow-client/src/logging/export.rs
+++ b/rigflow-client/src/logging/export.rs
@@ -23,6 +23,7 @@ use std::path::PathBuf;
 use std::sync::mpsc::{Receiver, Sender, channel};
 use std::time::Duration;
 
+use rigflow_log::display;
 use rigflow_log::export::{
     ContactPage, ExportFilter, ExportOptions, ExportSummary, Exporter, FieldProfile, FilterError,
     GridPrecision, QslStatusFilter, Sort,
@@ -119,10 +120,16 @@ impl QsoFilterDraft {
             }
         }
         if !self.date_from.trim().is_empty() {
-            parts.push(format!("from {}", self.date_from.trim()));
+            parts.push(format!(
+                "from {}",
+                display::date(&display::date_to_adif(&self.date_from))
+            ));
         }
         if !self.date_to.trim().is_empty() {
-            parts.push(format!("to {}", self.date_to.trim()));
+            parts.push(format!(
+                "to {}",
+                display::date(&display::date_to_adif(&self.date_to))
+            ));
         }
         if !self.not_uploaded_to.trim().is_empty() {
             parts.push(format!("not on {}", self.not_uploaded_to.trim()));
@@ -140,8 +147,12 @@ impl QsoFilterDraft {
     /// is ANDed on here, and only there — the view always passes `None`.
     pub fn to_filter(&self, incremental: Option<String>) -> Result<ExportFilter, FilterError> {
         let f = ExportFilter {
-            date_from: opt(&self.date_from),
-            date_to: opt(&self.date_to),
+            // The UI *shows* dates as `2026-07-12`, so an operator will type that
+            // here. Accept it (and `2026/07/12`) and hand the store the
+            // ADIF-native form; anything else falls through to `validate()` for a
+            // proper error rather than being silently mangled.
+            date_from: opt(&self.date_from).map(|s| display::date_to_adif(&s)),
+            date_to: opt(&self.date_to).map(|s| display::date_to_adif(&s)),
             datetime_from: None,
             datetime_to: None,
             since_last_export: incremental,

--- a/rigflow-client/src/logging/export.rs
+++ b/rigflow-client/src/logging/export.rs
@@ -80,6 +80,11 @@ pub struct QsoFilterDraft {
     pub confirmed_by: String,
     /// Only contacts whose QSL has come back (`QSL_RCVD` = Y).
     pub qsl_rcvd_yes: bool,
+    /// An explicit row selection from the contact view (`None` = no selection).
+    /// ANDs with the rest; the view sets it on an otherwise-clear draft so a
+    /// selection stands alone. Not surfaced in the Filter window — it's driven by
+    /// the checkboxes, not typed.
+    pub qso_ids: Option<Vec<i64>>,
 }
 
 impl QsoFilterDraft {
@@ -142,6 +147,13 @@ impl QsoFilterDraft {
         if self.qsl_rcvd_yes {
             parts.push("QSL received".into());
         }
+        if let Some(ids) = &self.qso_ids {
+            parts.push(format!(
+                "{} selected contact{}",
+                ids.len(),
+                if ids.len() == 1 { "" } else { "s" }
+            ));
+        }
         parts.join(" · ")
     }
 
@@ -197,10 +209,10 @@ impl QsoFilterDraft {
 
             contest_ids: opt(&self.contest_id).map(|s| vec![s]),
 
-            // Multi-select in the contact view is deferred; the filter API
-            // supports an explicit id list already, there is just no UI to build
-            // one yet.
-            qso_ids: None,
+            // A contact-view multi-selection. ANDs with any other constraint —
+            // "these rows, further narrowed" — though the UI sets a selection on
+            // an otherwise-clear draft, so in practice it stands alone.
+            qso_ids: self.qso_ids.clone(),
         };
         f.validate()?;
         Ok(f)

--- a/rigflow-client/src/logging/export.rs
+++ b/rigflow-client/src/logging/export.rs
@@ -32,6 +32,8 @@ use rigflow_log::export::{
 use rigflow_log::import::ImportPlan;
 use rigflow_log::normalize::{self, ModeClass};
 
+use crate::logging::services::{Direction, Service};
+
 /// How long the UI waits after the last edit before re-querying.
 pub const QUERY_DEBOUNCE: Duration = Duration::from_millis(250);
 
@@ -357,10 +359,13 @@ pub enum ExportJob {
     /// normalize, validate, dedupe. Read-only, so it runs here rather than on the
     /// UI thread; a big file is slow to parse and the operator keeps logging.
     PlanImport { db_path: PathBuf, file: PathBuf },
-    /// Download the LoTW confirmation report over HTTPS and plan applying it. The
-    /// network I/O and the read-only plan both run here, off the UI thread; the
-    /// UI commits the returned plan and advances the sync marker.
-    LotwSync {
+    /// Sync with an online QSL service — download (fetch + plan) or upload (gather
+    /// + push). The network I/O and the read-only DB work both run here, off the
+    /// UI thread; the UI applies the result (commit + marker, or mark-uploaded).
+    /// `password` carries the API key for a key-authed service (QRZ).
+    ServiceSync {
+        service: Service,
+        direction: Direction,
         db_path: PathBuf,
         login: String,
         password: String,
@@ -390,13 +395,27 @@ pub enum ExportEvent {
         file: PathBuf,
         result: Result<Box<ImportPlan>, String>,
     },
-    /// A LoTW download, planned. The UI auto-commits it (confirmations only touch
-    /// `qso_service`, never insert contacts) and, on success, saves `marker` as
-    /// the next incremental position.
-    LotwSynced {
-        result: Result<Box<ImportPlan>, String>,
-        /// `APP_LoTW_LASTQSL` from the report header, if present.
+    /// A service sync finished. The UI applies it: a download auto-commits and
+    /// advances the marker; an upload marks the pushed QSOs uploaded. The
+    /// [`SyncOutcome`] carries whether it was a download or upload.
+    ServiceSynced {
+        service: Service,
+        result: Result<SyncOutcome, String>,
+    },
+}
+
+/// What a completed [`ExportJob::ServiceSync`] produced.
+pub enum SyncOutcome {
+    /// A download: the planned confirmations to auto-commit, and the next marker.
+    Downloaded {
+        plan: Box<ImportPlan>,
         marker: Option<String>,
+    },
+    /// An upload: the QSO ids that were pushed (to stamp `uploaded_at`) and the
+    /// service's report.
+    Uploaded {
+        ids: Vec<i64>,
+        report: crate::logging::services::UploadReport,
     },
 }
 
@@ -428,7 +447,7 @@ pub fn spawn_export_worker() -> (Sender<ExportJob>, Receiver<ExportEvent>) {
                         // Never coalesced: each is an explicit operator action.
                         w @ (ExportJob::Write { .. }
                         | ExportJob::PlanImport { .. }
-                        | ExportJob::LotwSync { .. }) => {
+                        | ExportJob::ServiceSync { .. }) => {
                             if evt_tx.send(run(w)).is_err() {
                                 return; // app gone
                             }
@@ -507,30 +526,73 @@ fn run(job: ExportJob) -> ExportEvent {
                 .map(Box::new);
             ExportEvent::ImportPlanned { file, result }
         }
-        ExportJob::LotwSync {
+        ExportJob::ServiceSync {
+            service,
+            direction,
             db_path,
             login,
             password,
             since,
         } => {
-            let outcome = crate::logging::lotw::fetch_report(&login, &password, since.as_deref())
-                .and_then(|adif| {
-                    let marker = crate::logging::lotw::extract_lastqsl(&adif);
-                    let plan = Exporter::open(&db_path)
-                        .and_then(|ex| ex.plan_import(&adif, DEFAULT_WINDOW_SECS))
-                        .map_err(|e| e.to_string())?;
-                    Ok((Box::new(plan), marker))
-                });
-            match outcome {
-                Ok((plan, marker)) => ExportEvent::LotwSynced {
-                    result: Ok(plan),
-                    marker,
-                },
-                Err(e) => ExportEvent::LotwSynced {
-                    result: Err(e),
-                    marker: None,
-                },
-            }
+            let result = match direction {
+                Direction::Download => {
+                    run_download(&db_path, service, &login, &password, since.as_deref())
+                }
+                Direction::Upload => run_upload(&db_path, service, &login, &password),
+            };
+            ExportEvent::ServiceSynced { service, result }
         }
     }
+}
+
+/// Download a service's ADIF and plan applying it (read-only). The UI commits.
+fn run_download(
+    db_path: &std::path::Path,
+    service: Service,
+    login: &str,
+    password: &str,
+    since: Option<&str>,
+) -> Result<SyncOutcome, String> {
+    let (adif, marker) = crate::logging::services::download(service, login, password, since)?;
+    let plan = Exporter::open(db_path)
+        .and_then(|ex| ex.plan_import(&adif, DEFAULT_WINDOW_SECS))
+        .map_err(|e| e.to_string())?;
+    Ok(SyncOutcome::Downloaded {
+        plan: Box::new(plan),
+        marker,
+    })
+}
+
+/// Gather every QSO not yet uploaded to `service`, build an ADIF batch, and push
+/// it. Returns the pushed ids so the UI can stamp `uploaded_at`.
+fn run_upload(
+    db_path: &std::path::Path,
+    service: Service,
+    login: &str,
+    password: &str,
+) -> Result<SyncOutcome, String> {
+    let ex = Exporter::open(db_path).map_err(|e| e.to_string())?;
+    let filter = ExportFilter {
+        not_uploaded_to: Some(vec![service.key().to_string()]),
+        ..Default::default()
+    };
+    let rows = ex.all_matching(&filter).map_err(|e| e.to_string())?;
+    if rows.is_empty() {
+        return Ok(SyncOutcome::Uploaded {
+            ids: Vec::new(),
+            report: crate::logging::services::UploadReport {
+                message: "nothing new to upload".into(),
+                ..Default::default()
+            },
+        });
+    }
+    let mut adif = rigflow_log::adif::adif_header();
+    for lq in &rows {
+        adif.push_str(&rigflow_log::adif::write_record(
+            &rigflow_log::adif::qso_to_record(&lq.qso),
+        ));
+    }
+    let report = crate::logging::services::upload(service, login, password, &adif)?;
+    let ids = rows.iter().map(|r| r.id).collect();
+    Ok(SyncOutcome::Uploaded { ids, report })
 }

--- a/rigflow-client/src/logging/export.rs
+++ b/rigflow-client/src/logging/export.rs
@@ -345,6 +345,15 @@ pub enum ExportJob {
     /// normalize, validate, dedupe. Read-only, so it runs here rather than on the
     /// UI thread; a big file is slow to parse and the operator keeps logging.
     PlanImport { db_path: PathBuf, file: PathBuf },
+    /// Download the LoTW confirmation report over HTTPS and plan applying it. The
+    /// network I/O and the read-only plan both run here, off the UI thread; the
+    /// UI commits the returned plan and advances the sync marker.
+    LotwSync {
+        db_path: PathBuf,
+        login: String,
+        password: String,
+        since: Option<String>,
+    },
 }
 
 /// What the worker reports back.
@@ -368,6 +377,14 @@ pub enum ExportEvent {
     ImportPlanned {
         file: PathBuf,
         result: Result<Box<ImportPlan>, String>,
+    },
+    /// A LoTW download, planned. The UI auto-commits it (confirmations only touch
+    /// `qso_service`, never insert contacts) and, on success, saves `marker` as
+    /// the next incremental position.
+    LotwSynced {
+        result: Result<Box<ImportPlan>, String>,
+        /// `APP_LoTW_LASTQSL` from the report header, if present.
+        marker: Option<String>,
     },
 }
 
@@ -397,7 +414,9 @@ pub fn spawn_export_worker() -> (Sender<ExportJob>, Receiver<ExportEvent>) {
                         l @ ExportJob::CallLookup { .. } => latest_lookup = Some(l),
                         c @ ExportJob::Count { .. } => latest_count = Some(c),
                         // Never coalesced: each is an explicit operator action.
-                        w @ (ExportJob::Write { .. } | ExportJob::PlanImport { .. }) => {
+                        w @ (ExportJob::Write { .. }
+                        | ExportJob::PlanImport { .. }
+                        | ExportJob::LotwSync { .. }) => {
                             if evt_tx.send(run(w)).is_err() {
                                 return; // app gone
                             }
@@ -475,6 +494,31 @@ fn run(job: ExportJob) -> ExportEvent {
                 })
                 .map(Box::new);
             ExportEvent::ImportPlanned { file, result }
+        }
+        ExportJob::LotwSync {
+            db_path,
+            login,
+            password,
+            since,
+        } => {
+            let outcome = crate::logging::lotw::fetch_report(&login, &password, since.as_deref())
+                .and_then(|adif| {
+                    let marker = crate::logging::lotw::extract_lastqsl(&adif);
+                    let plan = Exporter::open(&db_path)
+                        .and_then(|ex| ex.plan_import(&adif, DEFAULT_WINDOW_SECS))
+                        .map_err(|e| e.to_string())?;
+                    Ok((Box::new(plan), marker))
+                });
+            match outcome {
+                Ok((plan, marker)) => ExportEvent::LotwSynced {
+                    result: Ok(plan),
+                    marker,
+                },
+                Err(e) => ExportEvent::LotwSynced {
+                    result: Err(e),
+                    marker: None,
+                },
+            }
         }
     }
 }

--- a/rigflow-client/src/logging/export.rs
+++ b/rigflow-client/src/logging/export.rs
@@ -370,6 +370,9 @@ pub enum ExportJob {
         login: String,
         password: String,
         since: Option<String>,
+        /// Upload only: re-send QSOs already marked uploaded (ignore the
+        /// `not_uploaded_to` filter). The service dedups any real duplicates.
+        force: bool,
     },
 }
 
@@ -533,12 +536,13 @@ fn run(job: ExportJob) -> ExportEvent {
             login,
             password,
             since,
+            force,
         } => {
             let result = match direction {
                 Direction::Download => {
                     run_download(&db_path, service, &login, &password, since.as_deref())
                 }
-                Direction::Upload => run_upload(&db_path, service, &login, &password),
+                Direction::Upload => run_upload(&db_path, service, &login, &password, force),
             };
             ExportEvent::ServiceSynced { service, result }
         }
@@ -554,8 +558,11 @@ fn run_download(
     since: Option<&str>,
 ) -> Result<SyncOutcome, String> {
     let (adif, marker) = crate::logging::services::download(service, login, password, since)?;
+    // A service download is definitionally "these QSOs are confirmed by this
+    // service", so plan it as that service's confirmations — needed for QRZ,
+    // whose FETCH carries no per-record confirmation field.
     let plan = Exporter::open(db_path)
-        .and_then(|ex| ex.plan_import(&adif, DEFAULT_WINDOW_SECS))
+        .and_then(|ex| ex.plan_download(&adif, DEFAULT_WINDOW_SECS))
         .map_err(|e| e.to_string())?;
     Ok(SyncOutcome::Downloaded {
         plan: Box::new(plan),
@@ -563,18 +570,27 @@ fn run_download(
     })
 }
 
-/// Gather every QSO not yet uploaded to `service`, build an ADIF batch, and push
-/// it. Returns the pushed ids so the UI can stamp `uploaded_at`.
+/// Gather QSOs to upload to `service` — everything not yet uploaded, or (when
+/// `force`) the whole log — build the ADIF, and push it. Returns the pushed ids
+/// so the UI can stamp `uploaded_at`.
 fn run_upload(
     db_path: &std::path::Path,
     service: Service,
     login: &str,
     password: &str,
+    force: bool,
 ) -> Result<SyncOutcome, String> {
     let ex = Exporter::open(db_path).map_err(|e| e.to_string())?;
-    let filter = ExportFilter {
-        not_uploaded_to: Some(vec![service.key().to_string()]),
-        ..Default::default()
+    let filter = if force {
+        // Everything: the service dedups any real duplicates. Recovers from a log
+        // wrongly marked uploaded (e.g. by an upload that reported success but
+        // didn't actually land).
+        ExportFilter::default()
+    } else {
+        ExportFilter {
+            not_uploaded_to: Some(vec![service.key().to_string()]),
+            ..Default::default()
+        }
     };
     let rows = ex.all_matching(&filter).map_err(|e| e.to_string())?;
     if rows.is_empty() {
@@ -586,13 +602,17 @@ fn run_upload(
             },
         });
     }
-    let mut adif = rigflow_log::adif::adif_header();
-    for lq in &rows {
-        adif.push_str(&rigflow_log::adif::write_record(
-            &rigflow_log::adif::qso_to_record(&lq.qso),
-        ));
-    }
-    let report = crate::logging::services::upload(service, login, password, &adif)?;
-    let ids = rows.iter().map(|r| r.id).collect();
+    // One ADIF record per QSO, paired with its id. Each service assembles these
+    // as its API wants (eQSL one batch, QRZ one INSERT per record).
+    let records: Vec<(i64, String)> = rows
+        .iter()
+        .map(|lq| {
+            (
+                lq.id,
+                rigflow_log::adif::write_record(&rigflow_log::adif::qso_to_record(&lq.qso)),
+            )
+        })
+        .collect();
+    let (ids, report) = crate::logging::services::upload(service, login, password, &records)?;
     Ok(SyncOutcome::Uploaded { ids, report })
 }

--- a/rigflow-client/src/logging/lifecycle.rs
+++ b/rigflow-client/src/logging/lifecycle.rs
@@ -20,11 +20,16 @@ impl RigflowApp {
             return;
         }
 
-        // Operator changed (or first frame): tear down and rebuild.
+        // Operator changed (or first frame): tear down and rebuild. The contact
+        // view, its filter results, and any open call lookup all belonged to the
+        // previous operator's log — none of it survives the switch.
         self.log = None;
         self.worked_before = WorkedBefore::default();
         self.contacts_cache.clear();
+        self.contacts_total = 0;
         self.contacts_cache_dirty = true;
+        self.call_lookup_hits = None;
+        self.filter_error.clear();
 
         if !op.trim().is_empty() {
             if let Err(e) = self.persistence_store.ensure_operator_data_layout(&op) {
@@ -124,18 +129,6 @@ impl RigflowApp {
             }
         }
         self.log_contact(qso);
-    }
-
-    /// Refresh the cached contact list for the contact-view window.
-    pub(crate) fn refresh_contacts_cache(&mut self) {
-        match self.log.as_ref() {
-            Some(store) => match store.query_contacts(500) {
-                Ok(rows) => self.contacts_cache = rows,
-                Err(e) => self.set_log_status(format!("query failed: {e}")),
-            },
-            None => self.contacts_cache.clear(),
-        }
-        self.contacts_cache_dirty = false;
     }
 
     pub(crate) fn set_log_status(&self, msg: String) {

--- a/rigflow-client/src/logging/lifecycle.rs
+++ b/rigflow-client/src/logging/lifecycle.rs
@@ -1,0 +1,146 @@
+//! Per-operator `LogStore` lifecycle and the insert/query paths.
+//!
+//! The store is single-owner: `RigflowApp` holds it and is the only thread that
+//! touches the `rusqlite::Connection`. On an operator switch we drop the old
+//! store (closing the connection, checkpointing WAL) and open the new
+//! operator's database, rebuilding the worked-before index.
+
+use rigflow_log::store::WorkedBefore;
+
+use crate::ui::app::RigflowApp;
+use crate::ui::state::UiState;
+
+impl RigflowApp {
+    /// Open / reopen the contact-log store to match the current operator.
+    /// A no-op while the operator is unchanged. Empty operator → no store
+    /// (logging is inert until an operator is set), mirroring recording.
+    pub(crate) fn sync_log_state(&mut self, snapshot: &UiState) {
+        let op = snapshot.operator_id.clone();
+        if self.log_open_for.as_deref() == Some(op.as_str()) {
+            return;
+        }
+
+        // Operator changed (or first frame): tear down and rebuild.
+        self.log = None;
+        self.worked_before = WorkedBefore::default();
+        self.contacts_cache.clear();
+        self.contacts_cache_dirty = true;
+
+        if !op.trim().is_empty() {
+            if let Err(e) = self.persistence_store.ensure_operator_data_layout(&op) {
+                self.set_log_status(format!("log dir: {e}"));
+            } else {
+                let db = self.persistence_store.qso_log_db_path(&op);
+                let adi = self.persistence_store.qso_log_journal_path(&op);
+                match rigflow_log::LogStore::open(&db, &adi) {
+                    Ok(store) => {
+                        self.worked_before = store.load_worked_before().unwrap_or_default();
+                        self.log = Some(store);
+                    }
+                    Err(e) => self.set_log_status(format!("log open failed: {e}")),
+                }
+            }
+        }
+        self.log_open_for = Some(op);
+    }
+
+    /// Log one contact through the store: insert (DB commit → journal append),
+    /// then update the worked-before index and flag the contact cache stale.
+    /// The `MY_*` station snapshot is applied inside the store.
+    pub(crate) fn log_contact(&mut self, qso: rigflow_log::Qso) {
+        let mut qso = qso;
+        qso.normalize();
+
+        let (op, name, profile) = {
+            let s = self.state.lock().unwrap();
+            (
+                s.operator_id.clone(),
+                s.operator_name.clone(),
+                s.station_profile.clone(),
+            )
+        };
+        let station = profile.to_log_station(&op, &name);
+
+        let Some(store) = self.log.as_mut() else {
+            self.set_log_status("no operator selected — contact not logged".to_string());
+            return;
+        };
+        match store.insert(&qso, &station) {
+            Ok(outcome) => {
+                self.worked_before.record(&qso);
+                self.contacts_cache_dirty = true;
+                let note = if outcome.journal_appended {
+                    String::new()
+                } else {
+                    " (journal not written)".to_string()
+                };
+                self.set_log_status(format!("logged {}{}", qso.call, note));
+            }
+            Err(e) => self.set_log_status(format!("log failed: {e}")),
+        }
+    }
+
+    /// Drain decoded WSJT-X events and ingest them into the active operator's
+    /// log. Called at the top of `update()`.
+    pub(crate) fn drain_wsjtx_events(&mut self, ctx: &eframe::egui::Context) {
+        let mut adifs = Vec::new();
+        while let Ok(ev) = self.wsjtx_rx.try_recv() {
+            match ev {
+                crate::logging::wsjtx_listener::LogEvent::LoggedAdif(adif) => adifs.push(adif),
+            }
+        }
+        if adifs.is_empty() {
+            return;
+        }
+        for adif in adifs {
+            match rigflow_log::adif::parse_adif_to_qsos(&adif) {
+                Ok(qsos) => {
+                    for qso in qsos {
+                        self.ingest_external_qso(qso);
+                    }
+                }
+                Err(e) => self.set_log_status(format!("WSJT-X ADIF parse: {e}")),
+            }
+        }
+        // The app free-runs repaints, but request one anyway so an idle window
+        // reflects the new contact immediately.
+        ctx.request_repaint();
+    }
+
+    /// Ingest an externally-sourced QSO (WSJT-X, file import). Unlike manual
+    /// entry, this **skips** a near-duplicate rather than warning — there is no
+    /// operator watching to dismiss a warning, and WSJT-X can resend a QSO.
+    pub(crate) fn ingest_external_qso(&mut self, qso: rigflow_log::Qso) {
+        let mut qso = qso;
+        qso.normalize();
+        if let Some(store) = self.log.as_ref() {
+            match store.find_duplicates(&qso, rigflow_log::dedupe::DEFAULT_WINDOW_SECS) {
+                Ok(dups) if !dups.is_empty() => {
+                    self.set_log_status(format!("skipped duplicate {}", qso.call));
+                    return;
+                }
+                Ok(_) => {}
+                Err(e) => self.set_log_status(format!("dedupe check: {e}")),
+            }
+        }
+        self.log_contact(qso);
+    }
+
+    /// Refresh the cached contact list for the contact-view window.
+    pub(crate) fn refresh_contacts_cache(&mut self) {
+        match self.log.as_ref() {
+            Some(store) => match store.query_contacts(500) {
+                Ok(rows) => self.contacts_cache = rows,
+                Err(e) => self.set_log_status(format!("query failed: {e}")),
+            },
+            None => self.contacts_cache.clear(),
+        }
+        self.contacts_cache_dirty = false;
+    }
+
+    pub(crate) fn set_log_status(&self, msg: String) {
+        if let Ok(mut s) = self.state.lock() {
+            s.log_status = msg;
+        }
+    }
+}

--- a/rigflow-client/src/logging/lotw.rs
+++ b/rigflow-client/src/logging/lotw.rs
@@ -1,0 +1,116 @@
+//! LoTW (ARRL Logbook of the World) confirmation **download**.
+//!
+//! Download-only: fetch the QSL confirmation report over HTTPS and hand the ADIF
+//! to the shared import pipeline ([`rigflow_log::import`]). This needs only a
+//! username + password. *Upload* is deliberately out of scope — LoTW upload
+//! requires a TQSL-signed file and a certificate, a different and much larger
+//! problem than a signed-in GET.
+
+use std::time::Duration;
+
+/// The confirmation-report endpoint.
+const REPORT_URL: &str = "https://lotw.arrl.org/lotwuser/lotwreport.adi";
+
+/// Fetch the LoTW confirmation report as ADIF text.
+///
+/// `since` is the incremental marker (`qso_qslsince`) — the `APP_LoTW_LASTQSL`
+/// timestamp from the previous run, so only newer confirmations come back.
+/// `None` pulls the whole confirmed set (a first sync). Only confirmed QSOs are
+/// requested (`qso_qsl=yes`), with detail so each record carries `QSL_RCVD` /
+/// `QSLRDATE` for the importer to read.
+///
+/// The password travels as a query parameter (over TLS); it is never placed in
+/// the returned error string — see [`redact_error`].
+pub fn fetch_report(login: &str, password: &str, since: Option<&str>) -> Result<String, String> {
+    let agent = ureq::AgentBuilder::new()
+        .timeout(Duration::from_secs(60))
+        .build();
+    let mut req = agent
+        .get(REPORT_URL)
+        .query("login", login)
+        .query("password", password)
+        .query("qso_query", "1")
+        .query("qso_qsl", "yes")
+        .query("qso_qsldetail", "yes");
+    if let Some(s) = since {
+        req = req.query("qso_qslsince", s);
+    }
+    let resp = req.call().map_err(redact_error)?;
+    let body = resp
+        .into_string()
+        .map_err(|e| format!("reading the LoTW response: {e}"))?;
+    validate(body)
+}
+
+/// LoTW answers a bad login with an HTML/plain error page (often HTTP 200), not
+/// ADIF. A real report always contains an `<eoh>` header terminator, so use that
+/// as the success test and surface a trimmed first line otherwise.
+fn validate(body: String) -> Result<String, String> {
+    if body.to_ascii_lowercase().contains("<eoh>") {
+        return Ok(body);
+    }
+    let snippet: String = body
+        .trim()
+        .lines()
+        .next()
+        .unwrap_or("")
+        .chars()
+        .take(200)
+        .collect();
+    if snippet.is_empty() {
+        Err("LoTW returned an empty response — check your username and password.".into())
+    } else {
+        Err(format!(
+            "LoTW did not return a log (check your username and password). It said: {snippet}"
+        ))
+    }
+}
+
+/// Turn a `ureq` transport error into a message with **no URL in it** — the URL
+/// carries the password as a query parameter, so its `Display` must never reach
+/// the user or a log.
+fn redact_error(e: ureq::Error) -> String {
+    match e {
+        ureq::Error::Status(code, _) => format!("LoTW returned HTTP {code}."),
+        ureq::Error::Transport(t) => format!("could not reach LoTW: {}", t.kind()),
+    }
+}
+
+/// Pull the `APP_LoTW_LASTQSL` timestamp from a report header — the marker to
+/// pass as `qso_qslsince` next run. `None` if absent (an empty report has none;
+/// the caller then keeps its previous marker). Length-prefixed parse, so a value
+/// containing spaces (it does: `YYYY-MM-DD HH:MM:SS`) is read whole.
+pub fn extract_lastqsl(adif: &str) -> Option<String> {
+    const KEY: &str = "<APP_LoTW_LASTQSL:";
+    let at = adif.find(KEY)? + KEY.len();
+    let rest = &adif[at..];
+    let gt = rest.find('>')?;
+    let len: usize = rest[..gt].split(':').next()?.trim().parse().ok()?;
+    let vstart = at + gt + 1;
+    adif.get(vstart..vstart + len).map(|s| s.trim().to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extracts_the_lastqsl_marker() {
+        let hdr = "ARRL Logbook of the World Status Report\n\
+                   <PROGRAMID:4>LoTW\n<APP_LoTW_LASTQSL:19>2026-07-23 20:45:06\n<eoh>\n";
+        assert_eq!(extract_lastqsl(hdr).as_deref(), Some("2026-07-23 20:45:06"));
+    }
+
+    #[test]
+    fn no_marker_when_absent() {
+        assert_eq!(extract_lastqsl("<PROGRAMID:4>LoTW\n<eoh>\n"), None);
+    }
+
+    #[test]
+    fn validate_accepts_a_real_report_and_rejects_an_error_page() {
+        assert!(validate("<PROGRAMID:4>LoTW\n<eoh>\n<CALL:4>W1AW<eor>".into()).is_ok());
+        let err = validate("Username/password incorrect".into()).unwrap_err();
+        assert!(err.contains("username and password"));
+        assert!(validate("   ".into()).is_err());
+    }
+}

--- a/rigflow-client/src/logging/mod.rs
+++ b/rigflow-client/src/logging/mod.rs
@@ -6,6 +6,7 @@
 //! window, contact-view window, Station panel) live under `ui/`.
 
 pub mod capture;
+pub mod export;
 pub mod lifecycle;
 pub mod wsjtx_listener;
 

--- a/rigflow-client/src/logging/mod.rs
+++ b/rigflow-client/src/logging/mod.rs
@@ -1,0 +1,37 @@
+//! Client-side contact logging: the thin wiring around the `rigflow-log` crate.
+//!
+//! `capture` turns the live `UiState` into a `rigflow_log::CapturedRadioState`
+//! (mirroring the server's effective-TX formula). `lifecycle` owns the
+//! per-operator `LogStore` and the insert/query paths. The egui surfaces (entry
+//! window, contact-view window, Station panel) live under `ui/`.
+
+pub mod capture;
+pub mod lifecycle;
+pub mod wsjtx_listener;
+
+/// Editable draft behind the manual log-entry window. The frozen-at-open
+/// capture (date/time/freq/mode/split) sits alongside the operator-typed fields
+/// so the logged time and frequency reflect when the entry opened, not when the
+/// operator finally hits save. Not persisted.
+#[derive(Debug, Clone, Default)]
+pub struct LogEntryDraft {
+    // Operator-entered fields.
+    pub call: String,
+    pub rst_sent: String,
+    pub rst_rcvd: String,
+    pub name: String,
+    pub comment: String,
+    pub gridsquare: String,
+    /// ADIF mode — editable (a DgtU capture defaults to FT8 but the operator may
+    /// be running JS8/etc.).
+    pub mode: String,
+    /// Derived `FREQ_RX` shown editable as a plain Hz string ("" = simplex).
+    pub freq_rx_hz_str: String,
+
+    // Frozen at open.
+    pub qso_date: String,
+    pub time_on: String,
+    pub tx_freq_hz: u64,
+    pub split_active: bool,
+    pub derived_freq_rx_hz: Option<u64>,
+}

--- a/rigflow-client/src/logging/mod.rs
+++ b/rigflow-client/src/logging/mod.rs
@@ -7,9 +7,12 @@
 
 pub mod capture;
 pub mod credentials;
+pub mod eqsl;
 pub mod export;
 pub mod lifecycle;
 pub mod lotw;
+pub mod qrz;
+pub mod services;
 pub mod wsjtx_listener;
 
 /// Editable draft behind the manual log-entry window. The frozen-at-open

--- a/rigflow-client/src/logging/mod.rs
+++ b/rigflow-client/src/logging/mod.rs
@@ -6,8 +6,10 @@
 //! window, contact-view window, Station panel) live under `ui/`.
 
 pub mod capture;
+pub mod credentials;
 pub mod export;
 pub mod lifecycle;
+pub mod lotw;
 pub mod wsjtx_listener;
 
 /// Editable draft behind the manual log-entry window. The frozen-at-open

--- a/rigflow-client/src/logging/qrz.rs
+++ b/rigflow-client/src/logging/qrz.rs
@@ -1,10 +1,12 @@
 //! QRZ Logbook API sync — FETCH the logbook (download) and INSERT QSOs (upload).
 //! Auth is a per-logbook **API key** (not your QRZ login).
 //!
-//! The API speaks `KEY=VALUE&KEY=VALUE` (form request, url-encoded reply). The
-//! reply's `RESULT` is `OK` / `FAIL` / `AUTH`, with `COUNT`, `ADIF`, `REASON`.
-//! See the module-level verification note in [`super::services`]: exact behavior
-//! (bulk INSERT, dupe handling) needs a run against a real logbook key.
+//! The API speaks `KEY=VALUE&KEY=VALUE`. The reply's `RESULT` is `OK` / `FAIL` /
+//! `REPLACE` / `AUTH`, with `COUNT`, `ADIF`, `REASON`. Two gotchas learned on air:
+//! the FETCH `ADIF` payload is **HTML-entity-encoded** (`&lt;`/`&gt;`) so it can't
+//! be `&`-split with the metadata (see [`parse_reply`]); and INSERT is **one
+//! record per call**, so [`insert`] loops. Confirmation is per-record via
+//! `APP_QRZLOG_STATUS = C`, handled in the importer.
 
 use std::collections::HashMap;
 use std::time::Duration;
@@ -19,57 +21,121 @@ fn agent() -> ureq::Agent {
         .build()
 }
 
-/// FETCH the whole logbook as ADIF (empty string if the logbook is empty).
+/// FETCH the whole logbook as ADIF (empty string if the logbook is empty). The
+/// caller decides which records are confirmations from their per-record
+/// `APP_QRZLOG_STATUS` (a `STATUS:CONFIRMED` OPTION does not reliably filter, and
+/// QRZ's default FETCH already returns ADIF).
 pub fn fetch(api_key: &str) -> Result<String, String> {
     let body = agent()
         .post(API)
-        .send_form(&[
-            ("KEY", api_key),
-            ("ACTION", "FETCH"),
-            ("OPTION", "TYPE:ADIF"),
-        ])
+        .send_form(&[("KEY", api_key), ("ACTION", "FETCH")])
         .map_err(redact)?
         .into_string()
         .map_err(|e| format!("reading the QRZ response: {e}"))?;
-    let f = parse_kv(&body);
+    let (f, adif) = parse_reply(&body);
     match f.get("RESULT").map(String::as_str) {
-        Some("OK") | Some("PARTIAL") => Ok(f.get("ADIF").cloned().unwrap_or_default()),
+        Some("OK") | Some("PARTIAL") => Ok(adif.unwrap_or_default()),
         _ => Err(error_hint(&f)),
     }
 }
 
-/// INSERT a batch of QSOs. QRZ accepts multiple records in one ADIF and answers
-/// with a count; a fully-duplicate batch comes back FAIL/DUPLICATE, which we
-/// treat as "already there" (accepted), not an error.
-pub fn insert(api_key: &str, adif: &str) -> Result<UploadReport, String> {
-    let body = agent()
-        .post(API)
-        .send_form(&[("KEY", api_key), ("ACTION", "INSERT"), ("ADIF", adif)])
-        .map_err(redact)?
-        .into_string()
-        .map_err(|e| format!("reading the QRZ response: {e}"))?;
-    let f = parse_kv(&body);
-    let count = f.get("COUNT").and_then(|c| c.parse::<usize>().ok());
-    match f.get("RESULT").map(String::as_str) {
-        Some("OK") => Ok(UploadReport {
-            accepted: count.unwrap_or(0),
-            rejected: 0,
-            message: f.get("REASON").cloned().unwrap_or_default(),
-        }),
-        // A duplicate isn't a failure to us — the QSO is on QRZ already.
-        Some("FAIL")
-            if f.get("REASON")
-                .map(|r| r.to_ascii_uppercase().contains("DUPLICATE"))
-                .unwrap_or(false) =>
-        {
-            Ok(UploadReport {
-                accepted: count.unwrap_or(0),
-                rejected: 0,
-                message: "already on QRZ (duplicate)".into(),
-            })
-        }
-        _ => Err(error_hint(&f)),
+/// Split a QRZ reply into its metadata fields and (if present) its ADIF payload.
+///
+/// The metadata is `KEY=VALUE&KEY=VALUE`, but the ADIF payload — always the last
+/// field — is **HTML-entity-encoded** (`&lt;`/`&gt;`), so it's riddled with `&`
+/// and cannot go through the `&`-splitting [`parse_kv`]. It's split off at `ADIF=`
+/// and HTML-decoded on its own; everything before it parses normally.
+fn parse_reply(body: &str) -> (HashMap<String, String>, Option<String>) {
+    match body.find("ADIF=") {
+        Some(i) => (
+            parse_kv(&body[..i]),
+            Some(html_decode(&body[i + "ADIF=".len()..])),
+        ),
+        None => (parse_kv(body), None),
     }
+}
+
+/// Decode the HTML entities QRZ uses in the ADIF payload. `&amp;` last so
+/// `&amp;lt;` decodes to `&lt;`, not `<`.
+fn html_decode(s: &str) -> String {
+    s.replace("&lt;", "<")
+        .replace("&gt;", ">")
+        .replace("&quot;", "\"")
+        .replace("&#39;", "'")
+        .replace("&amp;", "&")
+}
+
+/// INSERT QSOs into the logbook. **QRZ's INSERT takes exactly one record per
+/// call** (a single ADIF record, no header/EOH), so this loops. Returns the ids
+/// that landed (inserted, replaced, or already-present duplicates), to stamp
+/// `uploaded_at`, plus a tally.
+///
+/// A duplicate (`FAIL` with a duplicate reason) counts as landed — the QSO is on
+/// QRZ already; we do not send `OPTION=REPLACE`, which would clobber a confirmed
+/// QSO with our unconfirmed copy. An `AUTH` result (bad key / no privilege) is
+/// fatal and stops the run rather than hammering the API once per record.
+pub fn insert(
+    api_key: &str,
+    records: &[(i64, String)],
+) -> Result<(Vec<i64>, UploadReport), String> {
+    let a = agent();
+    let mut landed: Vec<i64> = Vec::new();
+    let mut rejected = 0usize;
+    let mut last_msg = String::new();
+
+    for (id, rec) in records {
+        // A network blip on one record shouldn't abort the whole batch, nor mark
+        // it uploaded: count it rejected and move on.
+        let resp =
+            match a
+                .post(API)
+                .send_form(&[("KEY", api_key), ("ACTION", "INSERT"), ("ADIF", rec)])
+            {
+                Ok(r) => r,
+                Err(_) => {
+                    rejected += 1;
+                    continue;
+                }
+            };
+        let body = match resp.into_string() {
+            Ok(b) => b,
+            Err(_) => {
+                rejected += 1;
+                continue;
+            }
+        };
+        let f = parse_kv(&body);
+        match f.get("RESULT").map(String::as_str) {
+            Some("OK") | Some("REPLACE") => landed.push(*id),
+            Some("FAIL") if is_duplicate(&f) => landed.push(*id),
+            // Bad key / insufficient privilege applies to every record — stop.
+            Some("AUTH") => return Err(error_hint(&f)),
+            _ => {
+                rejected += 1;
+                last_msg = f
+                    .get("REASON")
+                    .cloned()
+                    .unwrap_or_else(|| "rejected".into());
+            }
+        }
+    }
+    Ok((
+        landed,
+        UploadReport {
+            accepted: 0, // per-id success is tracked by `landed`; the UI uses that
+            rejected,
+            message: last_msg,
+        },
+    ))
+}
+
+/// A QRZ FAIL that means "already in the logbook".
+fn is_duplicate(f: &HashMap<String, String>) -> bool {
+    ["REASON", "STATUS"].iter().any(|k| {
+        f.get(*k)
+            .map(|v| v.to_ascii_uppercase().contains("DUPLICATE"))
+            .unwrap_or(false)
+    })
 }
 
 /// Parse `KEY=VALUE&KEY=VALUE`, url-decoding each value. Keys upper-cased.
@@ -139,23 +205,34 @@ mod tests {
     }
 
     #[test]
-    fn parses_a_fetch_reply() {
-        let body = "RESULT=OK&COUNT=2&ADIF=%3Ccall%3A4%3EW1AW%3Ceor%3E";
-        let f = parse_kv(body);
+    fn parses_a_fetch_reply_with_html_encoded_adif() {
+        // QRZ's real shape: metadata first, then an HTML-entity-encoded ADIF whose
+        // `&lt;`/`&gt;` would shred a naive `&`-split.
+        let body =
+            "COUNT=1&RESULT=OK&ADIF=&lt;call:4&gt;W1AW&lt;app_qrzlog_status:1&gt;C&lt;eor&gt;";
+        let (f, adif) = parse_reply(body);
         assert_eq!(f.get("RESULT").unwrap(), "OK");
-        assert_eq!(f.get("ADIF").unwrap(), "<call:4>W1AW<eor>");
+        assert_eq!(f.get("COUNT").unwrap(), "1");
+        assert_eq!(
+            adif.as_deref(),
+            Some("<call:4>W1AW<app_qrzlog_status:1>C<eor>")
+        );
     }
 
     #[test]
-    fn insert_treats_a_duplicate_as_accepted() {
-        // Parsed the same way the live reply is; a duplicate is not an error.
-        let f = parse_kv("RESULT=FAIL&COUNT=1&REASON=Unable to add QSO STATUS=DUPLICATE");
+    fn a_reply_with_no_adif_has_none() {
+        let (f, adif) = parse_reply("RESULT=FAIL&REASON=Bad+key");
         assert_eq!(f.get("RESULT").unwrap(), "FAIL");
-        assert!(
-            f.get("REASON")
-                .unwrap()
-                .to_ascii_uppercase()
-                .contains("DUPLICATE")
-        );
+        assert_eq!(adif, None);
+    }
+
+    #[test]
+    fn recognizes_a_duplicate_fail() {
+        // A duplicate is "already on QRZ", counted as landed, not an error.
+        assert!(is_duplicate(&parse_kv(
+            "RESULT=FAIL&REASON=Unable to add QSO STATUS=DUPLICATE"
+        )));
+        assert!(is_duplicate(&parse_kv("RESULT=FAIL&STATUS=DUPLICATE")));
+        assert!(!is_duplicate(&parse_kv("RESULT=FAIL&REASON=Bad ADIF")));
     }
 }

--- a/rigflow-client/src/logging/qrz.rs
+++ b/rigflow-client/src/logging/qrz.rs
@@ -1,0 +1,161 @@
+//! QRZ Logbook API sync — FETCH the logbook (download) and INSERT QSOs (upload).
+//! Auth is a per-logbook **API key** (not your QRZ login).
+//!
+//! The API speaks `KEY=VALUE&KEY=VALUE` (form request, url-encoded reply). The
+//! reply's `RESULT` is `OK` / `FAIL` / `AUTH`, with `COUNT`, `ADIF`, `REASON`.
+//! See the module-level verification note in [`super::services`]: exact behavior
+//! (bulk INSERT, dupe handling) needs a run against a real logbook key.
+
+use std::collections::HashMap;
+use std::time::Duration;
+
+use super::services::UploadReport;
+
+const API: &str = "https://logbook.qrz.com/api";
+
+fn agent() -> ureq::Agent {
+    ureq::AgentBuilder::new()
+        .timeout(Duration::from_secs(90))
+        .build()
+}
+
+/// FETCH the whole logbook as ADIF (empty string if the logbook is empty).
+pub fn fetch(api_key: &str) -> Result<String, String> {
+    let body = agent()
+        .post(API)
+        .send_form(&[
+            ("KEY", api_key),
+            ("ACTION", "FETCH"),
+            ("OPTION", "TYPE:ADIF"),
+        ])
+        .map_err(redact)?
+        .into_string()
+        .map_err(|e| format!("reading the QRZ response: {e}"))?;
+    let f = parse_kv(&body);
+    match f.get("RESULT").map(String::as_str) {
+        Some("OK") | Some("PARTIAL") => Ok(f.get("ADIF").cloned().unwrap_or_default()),
+        _ => Err(error_hint(&f)),
+    }
+}
+
+/// INSERT a batch of QSOs. QRZ accepts multiple records in one ADIF and answers
+/// with a count; a fully-duplicate batch comes back FAIL/DUPLICATE, which we
+/// treat as "already there" (accepted), not an error.
+pub fn insert(api_key: &str, adif: &str) -> Result<UploadReport, String> {
+    let body = agent()
+        .post(API)
+        .send_form(&[("KEY", api_key), ("ACTION", "INSERT"), ("ADIF", adif)])
+        .map_err(redact)?
+        .into_string()
+        .map_err(|e| format!("reading the QRZ response: {e}"))?;
+    let f = parse_kv(&body);
+    let count = f.get("COUNT").and_then(|c| c.parse::<usize>().ok());
+    match f.get("RESULT").map(String::as_str) {
+        Some("OK") => Ok(UploadReport {
+            accepted: count.unwrap_or(0),
+            rejected: 0,
+            message: f.get("REASON").cloned().unwrap_or_default(),
+        }),
+        // A duplicate isn't a failure to us — the QSO is on QRZ already.
+        Some("FAIL")
+            if f.get("REASON")
+                .map(|r| r.to_ascii_uppercase().contains("DUPLICATE"))
+                .unwrap_or(false) =>
+        {
+            Ok(UploadReport {
+                accepted: count.unwrap_or(0),
+                rejected: 0,
+                message: "already on QRZ (duplicate)".into(),
+            })
+        }
+        _ => Err(error_hint(&f)),
+    }
+}
+
+/// Parse `KEY=VALUE&KEY=VALUE`, url-decoding each value. Keys upper-cased.
+fn parse_kv(body: &str) -> HashMap<String, String> {
+    body.split('&')
+        .filter_map(|pair| pair.split_once('='))
+        .map(|(k, v)| (k.trim().to_ascii_uppercase(), percent_decode(v)))
+        .collect()
+}
+
+/// Minimal `application/x-www-form-urlencoded` decode: `+`→space, `%XX`→byte.
+fn percent_decode(s: &str) -> String {
+    let bytes = s.as_bytes();
+    let mut out: Vec<u8> = Vec::with_capacity(bytes.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        match bytes[i] {
+            b'+' => {
+                out.push(b' ');
+                i += 1;
+            }
+            b'%' if i + 2 < bytes.len() => {
+                let hi = (bytes[i + 1] as char).to_digit(16);
+                let lo = (bytes[i + 2] as char).to_digit(16);
+                match (hi, lo) {
+                    (Some(h), Some(l)) => {
+                        out.push((h * 16 + l) as u8);
+                        i += 3;
+                    }
+                    _ => {
+                        out.push(b'%');
+                        i += 1;
+                    }
+                }
+            }
+            b => {
+                out.push(b);
+                i += 1;
+            }
+        }
+    }
+    String::from_utf8_lossy(&out).into_owned()
+}
+
+fn error_hint(f: &HashMap<String, String>) -> String {
+    match f.get("REASON").or_else(|| f.get("RESULT")) {
+        Some(r) if !r.is_empty() => format!("QRZ: {r}"),
+        _ => "QRZ returned an unexpected response — check your API key.".into(),
+    }
+}
+
+fn redact(e: ureq::Error) -> String {
+    match e {
+        ureq::Error::Status(code, _) => format!("QRZ returned HTTP {code}."),
+        ureq::Error::Transport(t) => format!("could not reach QRZ: {}", t.kind()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn decodes_form_values() {
+        assert_eq!(percent_decode("W1AW%20test+de"), "W1AW test de");
+        assert_eq!(percent_decode("no-escapes"), "no-escapes");
+    }
+
+    #[test]
+    fn parses_a_fetch_reply() {
+        let body = "RESULT=OK&COUNT=2&ADIF=%3Ccall%3A4%3EW1AW%3Ceor%3E";
+        let f = parse_kv(body);
+        assert_eq!(f.get("RESULT").unwrap(), "OK");
+        assert_eq!(f.get("ADIF").unwrap(), "<call:4>W1AW<eor>");
+    }
+
+    #[test]
+    fn insert_treats_a_duplicate_as_accepted() {
+        // Parsed the same way the live reply is; a duplicate is not an error.
+        let f = parse_kv("RESULT=FAIL&COUNT=1&REASON=Unable to add QSO STATUS=DUPLICATE");
+        assert_eq!(f.get("RESULT").unwrap(), "FAIL");
+        assert!(
+            f.get("REASON")
+                .unwrap()
+                .to_ascii_uppercase()
+                .contains("DUPLICATE")
+        );
+    }
+}

--- a/rigflow-client/src/logging/qrz.rs
+++ b/rigflow-client/src/logging/qrz.rs
@@ -21,22 +21,98 @@ fn agent() -> ureq::Agent {
         .build()
 }
 
-/// FETCH the whole logbook as ADIF (empty string if the logbook is empty). The
-/// caller decides which records are confirmations from their per-record
-/// `APP_QRZLOG_STATUS` (a `STATUS:CONFIRMED` OPTION does not reliably filter, and
-/// QRZ's default FETCH already returns ADIF).
+/// Records requested per FETCH page. QRZ caps a single fetch, so we page.
+const PAGE: usize = 250;
+/// Backstop on the page loop, in case the cursor ever fails to advance.
+const MAX_PAGES: usize = 400;
+
+/// FETCH the **confirmed** QSOs as ADIF (empty string if there are none).
+///
+/// Only `STATUS:CONFIRMED` — the confirmed set is a small fraction of a logbook,
+/// so we never pull the whole thing. Confirmed records come back in ascending
+/// `APP_QRZLOG_LOGID` order, so we page with `AFTERLOGID` (the largest logid of
+/// the previous page) until a page comes back empty. **This is intra-fetch paging,
+/// not a cross-sync cursor**: a confirmation lands on an arbitrarily old record,
+/// so each sync re-pulls the full confirmed set and relies on the import being
+/// idempotent. Which records are confirmations is still decided per-record by the
+/// importer (`APP_QRZLOG_STATUS = C`).
 pub fn fetch(api_key: &str) -> Result<String, String> {
-    let body = agent()
-        .post(API)
-        .send_form(&[("KEY", api_key), ("ACTION", "FETCH")])
-        .map_err(redact)?
-        .into_string()
-        .map_err(|e| format!("reading the QRZ response: {e}"))?;
-    let (f, adif) = parse_reply(&body);
-    match f.get("RESULT").map(String::as_str) {
-        Some("OK") | Some("PARTIAL") => Ok(adif.unwrap_or_default()),
-        _ => Err(error_hint(&f)),
+    let a = agent();
+    let mut out = String::new();
+    let mut after: u64 = 0;
+
+    for _ in 0..MAX_PAGES {
+        let option = format!("STATUS:CONFIRMED,MAX:{PAGE},AFTERLOGID:{after}");
+        // GET is QRZ's preferred method for FETCH; ureq url-encodes each query
+        // value (like curl's --data-urlencode). redact() keeps the key — now in
+        // the URL — out of any error string.
+        let body = a
+            .get(API)
+            .query("KEY", api_key)
+            .query("ACTION", "FETCH")
+            .query("OPTION", &option)
+            .call()
+            .map_err(redact)?
+            .into_string()
+            .map_err(|e| format!("reading the QRZ response: {e}"))?;
+        let (f, adif) = parse_reply(&body);
+        match f.get("RESULT").map(String::as_str) {
+            Some("OK") | Some("PARTIAL") => {}
+            // A failure on the very first page is a real error (bad key, bad
+            // option); later it just means we've paged past the last record.
+            _ if out.is_empty() => return Err(error_hint(&f)),
+            _ => break,
+        }
+        let Some(adif) = adif.filter(|s| !s.trim().is_empty()) else {
+            break;
+        };
+        let (count, max_logid) = page_stats(&adif);
+        if count == 0 {
+            break;
+        }
+        out.push_str(&adif);
+        if !out.ends_with('\n') {
+            out.push('\n');
+        }
+        // Stop when the cursor can't advance (last page, or a stuck cursor).
+        if max_logid <= after {
+            break;
+        }
+        after = max_logid;
     }
+    Ok(out)
+}
+
+/// Records in one ADIF page (`<eor>` count) and the largest `APP_QRZLOG_LOGID` in
+/// it — the `AFTERLOGID` cursor for the next page. `0` when a page carries no
+/// logid, which stops paging (its `<=` cursor check trips).
+fn page_stats(adif: &str) -> (usize, u64) {
+    let lower = adif.to_ascii_lowercase();
+    let count = lower.matches("<eor>").count();
+    const KEY: &str = "<app_qrzlog_logid:";
+    let mut max_logid = 0u64;
+    let mut from = 0;
+    while let Some(i) = lower[from..].find(KEY) {
+        let start = from + i + KEY.len();
+        let Some(gt) = lower[start..].find('>') else {
+            break;
+        };
+        let len: usize = lower[start..start + gt]
+            .split(':')
+            .next()
+            .unwrap_or("")
+            .trim()
+            .parse()
+            .unwrap_or(0);
+        let vstart = start + gt + 1;
+        if let Some(v) = lower.get(vstart..vstart + len)
+            && let Ok(id) = v.trim().parse::<u64>()
+        {
+            max_logid = max_logid.max(id);
+        }
+        from = vstart + len.max(1);
+    }
+    (count, max_logid)
 }
 
 /// Split a QRZ reply into its metadata fields and (if present) its ADIF payload.
@@ -224,6 +300,17 @@ mod tests {
         let (f, adif) = parse_reply("RESULT=FAIL&REASON=Bad+key");
         assert_eq!(f.get("RESULT").unwrap(), "FAIL");
         assert_eq!(adif, None);
+    }
+
+    #[test]
+    fn page_stats_counts_records_and_finds_the_max_logid() {
+        // Decoded ADIF (what parse_reply hands us), two records, ascending logid.
+        let adif = "<call:4>W1AW<app_qrzlog_logid:3>100<eor>\n\
+                    <call:4>K5ZD<app_qrzlog_logid:10>1482539906<eor>\n";
+        assert_eq!(page_stats(adif), (2, 1_482_539_906));
+        // A record with no logid → count 1, cursor 0 (which stops paging).
+        assert_eq!(page_stats("<call:4>W1AW<eor>"), (1, 0));
+        assert_eq!(page_stats(""), (0, 0));
     }
 
     #[test]

--- a/rigflow-client/src/logging/services.rs
+++ b/rigflow-client/src/logging/services.rs
@@ -112,18 +112,21 @@ pub fn download(
     }
 }
 
-/// Upload an ADIF batch to a service. `password` carries the API key for QRZ.
+/// Upload QSOs to a service. `records` is `(qso_id, single-record ADIF)`; each
+/// service assembles them as its API wants (eQSL one batch, QRZ one call per
+/// record). Returns the ids that actually landed — so only those get stamped
+/// `uploaded_at` — plus a tally. `password` carries the API key for QRZ.
 pub fn upload(
     service: Service,
     login: &str,
     password: &str,
-    adif: &str,
-) -> Result<UploadReport, String> {
+    records: &[(i64, String)],
+) -> Result<(Vec<i64>, UploadReport), String> {
     match service {
         Service::Lotw => {
             Err("LoTW upload needs TQSL and a certificate — not supported here.".into())
         }
-        Service::Eqsl => eqsl::upload(login, password, adif),
-        Service::Qrz => qrz::insert(password, adif),
+        Service::Eqsl => eqsl::upload(login, password, records),
+        Service::Qrz => qrz::insert(password, records),
     }
 }

--- a/rigflow-client/src/logging/services.rs
+++ b/rigflow-client/src/logging/services.rs
@@ -1,0 +1,129 @@
+//! The online QSL services and the sync operations over them.
+//!
+//! One place that knows, per service: its storage key, display name, how it
+//! authenticates (username+password vs an API key), and which directions it
+//! supports. The per-service HTTP lives in [`super::lotw`], [`super::eqsl`],
+//! [`super::qrz`]; this module dispatches to them so the worker and UI stay
+//! service-agnostic.
+//!
+//! **Verification note:** LoTW download is the only path exercised against a live
+//! service so far. The eQSL and QRZ request shapes follow their documented APIs
+//! but need a run with real accounts — the exact form fields and response
+//! wording are quirky and centralized here for easy adjustment.
+
+use super::{eqsl, lotw, qrz};
+
+/// An online QSL service.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Service {
+    Lotw,
+    Eqsl,
+    Qrz,
+}
+
+/// A sync direction.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Direction {
+    /// Pull confirmations (and QSOs) down, into the import pipeline.
+    Download,
+    /// Push not-yet-uploaded QSOs up.
+    Upload,
+}
+
+/// How a service authenticates.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CredKind {
+    /// A username and password (LoTW, eQSL).
+    UserPass,
+    /// A single API key (QRZ Logbook). Stored in the password slot; login empty.
+    ApiKey,
+}
+
+/// The result of an upload, parsed from the service's reply.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct UploadReport {
+    /// Records the service accepted (added, or already-present duplicates).
+    pub accepted: usize,
+    /// Records the service rejected outright.
+    pub rejected: usize,
+    /// A short human line from the service, for the status area.
+    pub message: String,
+}
+
+impl Service {
+    pub const ALL: [Service; 3] = [Service::Lotw, Service::Eqsl, Service::Qrz];
+
+    /// Storage key — the `qso_service.service` / `sync_state.service` value and
+    /// the credential-store key. Lower-case and stable.
+    pub fn key(self) -> &'static str {
+        match self {
+            Service::Lotw => "lotw",
+            Service::Eqsl => "eqsl",
+            Service::Qrz => "qrz",
+        }
+    }
+
+    pub fn name(self) -> &'static str {
+        match self {
+            Service::Lotw => "LoTW",
+            Service::Eqsl => "eQSL",
+            Service::Qrz => "QRZ Logbook",
+        }
+    }
+
+    pub fn cred_kind(self) -> CredKind {
+        match self {
+            Service::Qrz => CredKind::ApiKey,
+            _ => CredKind::UserPass,
+        }
+    }
+
+    /// LoTW upload needs a TQSL-signed file + certificate, out of scope here.
+    pub fn can_upload(self) -> bool {
+        !matches!(self, Service::Lotw)
+    }
+
+    pub fn can_download(self) -> bool {
+        true
+    }
+}
+
+/// Download a service's ADIF (confirmations / QSOs) and the next incremental
+/// marker, if the service provides one. `since` is the stored marker.
+///
+/// For QRZ, `password` carries the API key and `login` is unused.
+pub fn download(
+    service: Service,
+    login: &str,
+    password: &str,
+    since: Option<&str>,
+) -> Result<(String, Option<String>), String> {
+    match service {
+        Service::Lotw => {
+            let adif = lotw::fetch_report(login, password, since)?;
+            let marker = lotw::extract_lastqsl(&adif);
+            Ok((adif, marker))
+        }
+        // eQSL/QRZ have no clean "since confirmation" cursor, so they pull the
+        // full set and lean on the import being idempotent (already-confirmed
+        // records skip). No marker.
+        Service::Eqsl => Ok((eqsl::download(login, password)?, None)),
+        Service::Qrz => Ok((qrz::fetch(password)?, None)),
+    }
+}
+
+/// Upload an ADIF batch to a service. `password` carries the API key for QRZ.
+pub fn upload(
+    service: Service,
+    login: &str,
+    password: &str,
+    adif: &str,
+) -> Result<UploadReport, String> {
+    match service {
+        Service::Lotw => {
+            Err("LoTW upload needs TQSL and a certificate — not supported here.".into())
+        }
+        Service::Eqsl => eqsl::upload(login, password, adif),
+        Service::Qrz => qrz::insert(password, adif),
+    }
+}

--- a/rigflow-client/src/logging/wsjtx_listener.rs
+++ b/rigflow-client/src/logging/wsjtx_listener.rs
@@ -1,0 +1,77 @@
+//! WSJT-X UDP telemetry listener (port 2237).
+//!
+//! A dumb background thread: bind, receive datagrams, decode with
+//! `rigflow_log::wsjtx`, and forward the `LoggedADIF` payload over an `mpsc`
+//! channel. The UI thread drains it and inserts into whatever operator's store
+//! is currently open (so FT8 QSOs auto-route to the active operator). The bind
+//! is non-fatal — a taken port surfaces a status string, never a crash.
+
+use std::net::UdpSocket;
+use std::sync::mpsc::{Receiver, Sender};
+use std::sync::{Arc, Mutex};
+
+use rigflow_log::wsjtx::{self, WsjtxMessage};
+
+use crate::ui::state::UiState;
+
+/// The WSJT-X bind address. Localhost is the common WSJT-X-on-same-host setup;
+/// `0.0.0.0` also accepts a WSJT-X on another LAN host pointed here.
+const WSJTX_UDP_ADDR: &str = "0.0.0.0:2237";
+
+/// An event forwarded from the listener thread to the UI thread.
+#[derive(Debug, Clone)]
+pub enum LogEvent {
+    /// A `LoggedADIF` datagram's ADIF text (header + one record).
+    LoggedAdif(String),
+}
+
+/// Spawn the listener. Returns the receiver the UI thread drains each frame.
+/// On bind failure the thread writes `wsjtx_listen_status` into `UiState` and
+/// exits; the returned receiver simply never yields (its sender is dropped).
+pub fn spawn_wsjtx_listener(state: Arc<Mutex<UiState>>) -> Receiver<LogEvent> {
+    let (tx, rx) = std::sync::mpsc::channel();
+    let _ = std::thread::Builder::new()
+        .name("wsjtx-udp".to_string())
+        .spawn(move || run(state, tx));
+    rx
+}
+
+fn set_status(state: &Arc<Mutex<UiState>>, msg: String) {
+    if let Ok(mut s) = state.lock() {
+        s.wsjtx_listen_status = msg;
+    }
+}
+
+fn run(state: Arc<Mutex<UiState>>, tx: Sender<LogEvent>) {
+    let socket = match UdpSocket::bind(WSJTX_UDP_ADDR) {
+        Ok(s) => s,
+        Err(e) => {
+            set_status(
+                &state,
+                format!("WSJT-X UDP {WSJTX_UDP_ADDR} unavailable: {e}"),
+            );
+            return;
+        }
+    };
+    set_status(&state, format!("Listening for WSJT-X on {WSJTX_UDP_ADDR}"));
+
+    let mut buf = vec![0u8; 65536];
+    loop {
+        let n = match socket.recv_from(&mut buf) {
+            Ok((n, _from)) => n,
+            Err(e) => {
+                // A transient recv error shouldn't kill the listener; a fatal
+                // one (socket closed) will keep erroring — cap the churn by
+                // reporting and continuing.
+                set_status(&state, format!("WSJT-X recv error: {e}"));
+                continue;
+            }
+        };
+        if let Some(WsjtxMessage::LoggedAdif { adif, .. }) = wsjtx::decode(&buf[..n]) {
+            // Receiver gone → the app is shutting down; stop the thread.
+            if tx.send(LogEvent::LoggedAdif(adif)).is_err() {
+                return;
+            }
+        }
+    }
+}

--- a/rigflow-client/src/main.rs
+++ b/rigflow-client/src/main.rs
@@ -115,6 +115,7 @@ mod cw_text;
 mod digital_audio;
 mod digital_rx;
 mod digital_tx;
+mod logging;
 mod mic;
 mod net;
 mod persistence;

--- a/rigflow-client/src/persistence/bootstrap.rs
+++ b/rigflow-client/src/persistence/bootstrap.rs
@@ -55,6 +55,8 @@ pub fn load_initial_ui_state(
 /// It should not assume that a last operator exists.
 pub fn apply_app_state_to_ui_state(state: &mut UiState, app_state: &AppStateFile) {
     state.known_operator_ids = app_state.known_operator_ids.clone();
+    // Global station location (shared across operators).
+    state.station_profile = app_state.station.clone();
 }
 
 /// Apply persisted operator settings to runtime UI state.
@@ -67,6 +69,7 @@ pub fn apply_operator_settings_to_ui_state(
     app_state: &AppStateFile,
 ) {
     state.operator_id = operator.operator_id.clone();
+    state.operator_name = operator.name.clone();
     state.known_operator_ids = app_state.known_operator_ids.clone();
 
     state.selected_license = operator.selected_license;
@@ -160,6 +163,7 @@ pub fn apply_operator_settings_to_ui_state(
 
 pub fn apply_ui_state_to_operator_settings(state: &UiState, operator: &mut OperatorSettingsFile) {
     operator.operator_id = state.operator_id.clone();
+    operator.name = state.operator_name.clone();
     operator.selected_license = state.selected_license;
     operator.server_ip = state.rigflow_server_ip.clone();
 

--- a/rigflow-client/src/persistence/models.rs
+++ b/rigflow-client/src/persistence/models.rs
@@ -21,11 +21,54 @@ pub struct BandMemoryEntry {
 pub const APP_STATE_FILE_VERSION: u32 = 1;
 pub const OPERATOR_SETTINGS_FILE_VERSION: u32 = 3;
 
+/// The station's *physical location*, shared across all operators (one rig, one
+/// grid). The **callsign and operator name are per-operator** (they belong to a
+/// person, not the station), so this holds only location fields. Snapshotted
+/// onto each logged QSO's `MY_*` at log time.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct StationProfileFile {
+    #[serde(default)]
+    pub gridsquare: String,
+    #[serde(default)]
+    pub state: String,
+    #[serde(default)]
+    pub county: String,
+    #[serde(default)]
+    pub cq_zone: String,
+    #[serde(default)]
+    pub itu_zone: String,
+}
+
+impl StationProfileFile {
+    fn opt(s: &str) -> Option<String> {
+        let t = s.trim();
+        (!t.is_empty()).then(|| t.to_string())
+    }
+
+    /// Build the `rigflow_log::Station` for a QSO, pairing this global location
+    /// with the per-operator callsign and operator name (`MY_NAME`).
+    pub fn to_log_station(&self, station_call: &str, operator_name: &str) -> rigflow_log::Station {
+        rigflow_log::Station {
+            station_call: station_call.trim().to_ascii_uppercase(),
+            gridsquare: Self::opt(&self.gridsquare),
+            name: Self::opt(operator_name),
+            my_state: Self::opt(&self.state),
+            my_county: Self::opt(&self.county),
+            cq_zone: Self::opt(&self.cq_zone),
+            itu_zone: Self::opt(&self.itu_zone),
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AppStateFile {
     pub version: u32,
     pub last_operator_id: Option<String>,
     pub known_operator_ids: Vec<String>,
+    /// Global station location (grid, etc.). `serde(default)` so pre-existing
+    /// `app_state.json` files load unchanged.
+    #[serde(default)]
+    pub station: StationProfileFile,
 }
 
 impl Default for AppStateFile {
@@ -34,6 +77,7 @@ impl Default for AppStateFile {
             version: APP_STATE_FILE_VERSION,
             last_operator_id: None,
             known_operator_ids: Vec::new(),
+            station: StationProfileFile::default(),
         }
     }
 }
@@ -273,6 +317,12 @@ pub struct OperatorSettingsFile {
     pub version: u32,
     pub operator_id: String,
 
+    /// The operator's personal name (ADIF `MY_NAME`), per-operator because it
+    /// belongs to the person, not the shared station. Serde-default so older
+    /// settings files load with an empty name.
+    #[serde(default)]
+    pub name: String,
+
     pub selected_license: Option<LicenseClass>,
     pub server_ip: String,
 
@@ -393,6 +443,7 @@ impl OperatorSettingsFile {
         Self {
             version: OPERATOR_SETTINGS_FILE_VERSION,
             operator_id,
+            name: String::new(),
             selected_license: None,
             // Seed new operators with localhost so a single-box (client+server on
             // one machine) setup can Connect with no typing; the user edits it for

--- a/rigflow-client/src/persistence/paths.rs
+++ b/rigflow-client/src/persistence/paths.rs
@@ -59,6 +59,16 @@ pub fn voice_keyer_clips_dir(config_dir: &Path, operator_id: &str) -> PathBuf {
     operator_data_dir(config_dir, operator_id).join("voice_keyer_clips")
 }
 
+/// This operator's contact-log SQLite database (the source of truth).
+pub fn qso_log_db_path(config_dir: &Path, operator_id: &str) -> PathBuf {
+    operator_data_dir(config_dir, operator_id).join("rigflow_log.db")
+}
+
+/// This operator's append-only ADIF journal (recovery + interop).
+pub fn qso_log_journal_path(config_dir: &Path, operator_id: &str) -> PathBuf {
+    operator_data_dir(config_dir, operator_id).join("rigflow_log.adi")
+}
+
 /// Normalize operator IDs for persistence.
 ///
 /// Current behavior:

--- a/rigflow-client/src/persistence/store.rs
+++ b/rigflow-client/src/persistence/store.rs
@@ -6,13 +6,14 @@ use std::{
     time::{SystemTime, UNIX_EPOCH},
 };
 
+use crate::persistence::models::StationProfileFile;
 use crate::persistence::{
     error::PersistenceError,
     migrations::migrate_operator_settings_value,
     models::{AppStateFile, OperatorSettingsFile},
     paths::{
-        app_state_path, normalize_operator_id, operator_file_path, operators_dir,
-        rx_recordings_dir, voice_keyer_clips_dir,
+        app_state_path, normalize_operator_id, operator_file_path, operators_dir, qso_log_db_path,
+        qso_log_journal_path, rx_recordings_dir, voice_keyer_clips_dir,
     },
 };
 
@@ -76,6 +77,26 @@ impl PersistenceStore {
     /// Directory holding this operator's SSB voice-keyer clips.
     pub fn voice_keyer_clips_dir(&self, operator_id: &str) -> PathBuf {
         voice_keyer_clips_dir(&self.config_dir, operator_id)
+    }
+
+    /// This operator's contact-log database path.
+    pub fn qso_log_db_path(&self, operator_id: &str) -> PathBuf {
+        qso_log_db_path(&self.config_dir, operator_id)
+    }
+
+    /// This operator's contact-log ADIF journal path.
+    pub fn qso_log_journal_path(&self, operator_id: &str) -> PathBuf {
+        qso_log_journal_path(&self.config_dir, operator_id)
+    }
+
+    /// Persist the global station profile into `app_state.json`.
+    pub fn save_station_profile(
+        &self,
+        station: &StationProfileFile,
+    ) -> Result<(), PersistenceError> {
+        let mut app_state = self.load_app_state()?;
+        app_state.station = station.clone();
+        self.save_app_state(&app_state)
     }
 
     pub fn load_app_state(&self) -> Result<AppStateFile, PersistenceError> {

--- a/rigflow-client/src/ui/app.rs
+++ b/rigflow-client/src/ui/app.rs
@@ -146,6 +146,19 @@ pub struct RigflowApp {
     /// Job queue to the export worker thread, and its replies.
     pub(crate) export_tx: std::sync::mpsc::Sender<crate::logging::export::ExportJob>,
     pub(crate) export_rx: std::sync::mpsc::Receiver<crate::logging::export::ExportEvent>,
+
+    // ── ADIF import ──────────────────────────────────────────────────────
+    /// Import window open flag (opened from the contact view).
+    pub(crate) show_import: bool,
+    /// The file being imported, and the plan the worker made for it. The plan
+    /// carries the parsed contacts, so committing needs no second parse — the
+    /// operator confirms exactly what they were shown.
+    pub(crate) import_file: Option<std::path::PathBuf>,
+    pub(crate) import_plan: Option<rigflow_log::import::ImportPlan>,
+    /// A plan is being made on the worker (parsing a large file takes a moment).
+    pub(crate) import_planning: bool,
+    /// Result / error line for the import window.
+    pub(crate) import_status: String,
 }
 
 impl RigflowApp {
@@ -227,6 +240,11 @@ impl RigflowApp {
             export_status: String::new(),
             export_tx,
             export_rx,
+            show_import: false,
+            import_file: None,
+            import_plan: None,
+            import_planning: false,
+            import_status: String::new(),
         };
 
         // Enumerate input devices once for the dropdown (one-time; cheap enough
@@ -757,6 +775,7 @@ impl eframe::App for RigflowApp {
         self.draw_contact_view_window(ctx, &snapshot);
         self.draw_filter_window(ctx);
         self.draw_export_window(ctx, &snapshot);
+        self.draw_import_window(ctx, &snapshot);
 
         // Per-operator audio recording + voice keyer: ensure dirs / refresh the
         // clip list on an operator switch, run any UI-requested action, and

--- a/rigflow-client/src/ui/app.rs
+++ b/rigflow-client/src/ui/app.rs
@@ -101,6 +101,26 @@ pub struct RigflowApp {
     pub(crate) contacts_cache_dirty: bool,
     /// Receiver for decoded WSJT-X `LoggedADIF` events from the UDP-2237 thread.
     pub(crate) wsjtx_rx: std::sync::mpsc::Receiver<crate::logging::wsjtx_listener::LogEvent>,
+
+    // ── ADIF export ──────────────────────────────────────────────────────
+    // All of this lives here rather than in `UiState`: only the export window
+    // touches it, and `UiState` is cloned every frame by `snapshot_state()`.
+    /// Export window open flag (opened from the contact view).
+    pub(crate) show_export: bool,
+    pub(crate) export_draft: crate::logging::export::ExportDraft,
+    /// Previous draft, to notice an edit and re-arm the count debounce.
+    pub(crate) export_draft_last: Option<crate::logging::export::ExportDraft>,
+    /// When the debounced dry-run count should fire.
+    pub(crate) export_count_due: Option<std::time::Instant>,
+    /// Latest dry-run match count (`None` = counting, or a filter error).
+    pub(crate) export_count: Option<usize>,
+    /// A write is in flight on the worker.
+    pub(crate) export_busy: bool,
+    /// Last export result / filter error, shown in the window.
+    pub(crate) export_status: String,
+    /// Job queue to the export worker thread, and its replies.
+    pub(crate) export_tx: std::sync::mpsc::Sender<crate::logging::export::ExportJob>,
+    pub(crate) export_rx: std::sync::mpsc::Receiver<crate::logging::export::ExportEvent>,
 }
 
 impl RigflowApp {
@@ -117,6 +137,10 @@ impl RigflowApp {
         // Spawn the WSJT-X UDP listener (non-fatal bind); it forwards decoded
         // LoggedADIF events we drain each frame.
         let wsjtx_rx = crate::logging::wsjtx_listener::spawn_wsjtx_listener(Arc::clone(&state));
+
+        // The export worker: read-only DB access on its own thread, so a large
+        // export streams to disk without stalling the frame loop.
+        let (export_tx, export_rx) = crate::logging::export::spawn_export_worker();
 
         // Create the virtual digital-audio endpoints once, at startup.
         let digital_audio = crate::digital_audio::DigitalAudio::start();
@@ -159,6 +183,15 @@ impl RigflowApp {
             contacts_cache: Vec::new(),
             contacts_cache_dirty: true,
             wsjtx_rx,
+            show_export: false,
+            export_draft: crate::logging::export::ExportDraft::default(),
+            export_draft_last: None,
+            export_count_due: None,
+            export_count: None,
+            export_busy: false,
+            export_status: String::new(),
+            export_tx,
+            export_rx,
         };
 
         // Enumerate input devices once for the dropdown (one-time; cheap enough
@@ -666,6 +699,9 @@ impl eframe::App for RigflowApp {
 
         // Ingest any WSJT-X FT8 contacts that arrived since the last frame.
         self.drain_wsjtx_events(ctx);
+        // Collect export counts/results from the worker (and advance the
+        // incremental bookmark when an incremental export has landed).
+        self.drain_export_events(ctx);
 
         self.ensure_mic();
         self.auto_relock_controls();
@@ -684,6 +720,7 @@ impl eframe::App for RigflowApp {
         self.draw_wsjtx_setup_window(ctx);
         self.draw_log_entry_window(ctx, &snapshot);
         self.draw_contact_view_window(ctx, &snapshot);
+        self.draw_export_window(ctx, &snapshot);
 
         // Per-operator audio recording + voice keyer: ensure dirs / refresh the
         // clip list on an operator switch, run any UI-requested action, and

--- a/rigflow-client/src/ui/app.rs
+++ b/rigflow-client/src/ui/app.rs
@@ -87,6 +87,20 @@ pub struct RigflowApp {
     /// Operator whose voice-keyer clip list is currently cached, so the list is
     /// refreshed (and the per-operator data dirs ensured) on an operator switch.
     pub(crate) clips_listed_for: Option<String>,
+
+    // ── Contact logging ──────────────────────────────────────────────────
+    /// The current operator's contact-log store (single-owner). `None` until an
+    /// operator is set. Reopened on operator switch by `sync_log_state`.
+    pub(crate) log: Option<rigflow_log::LogStore>,
+    /// Operator whose log store is currently open (drives reopen-on-switch).
+    pub(crate) log_open_for: Option<String>,
+    /// In-memory "worked before?" index for the open operator's log.
+    pub(crate) worked_before: rigflow_log::store::WorkedBefore,
+    /// Cached recent contacts for the contact-view window; refreshed when dirty.
+    pub(crate) contacts_cache: Vec<rigflow_log::store::LoggedQso>,
+    pub(crate) contacts_cache_dirty: bool,
+    /// Receiver for decoded WSJT-X `LoggedADIF` events from the UDP-2237 thread.
+    pub(crate) wsjtx_rx: std::sync::mpsc::Receiver<crate::logging::wsjtx_listener::LogEvent>,
 }
 
 impl RigflowApp {
@@ -100,6 +114,10 @@ impl RigflowApp {
         spectrum_db_b: Arc<Mutex<Vec<f32>>>,
         persistence_store: PersistenceStore,
     ) -> Self {
+        // Spawn the WSJT-X UDP listener (non-fatal bind); it forwards decoded
+        // LoggedADIF events we drain each frame.
+        let wsjtx_rx = crate::logging::wsjtx_listener::spawn_wsjtx_listener(Arc::clone(&state));
+
         // Create the virtual digital-audio endpoints once, at startup.
         let digital_audio = crate::digital_audio::DigitalAudio::start();
         let digital_output_available = digital_audio.output_available();
@@ -135,6 +153,12 @@ impl RigflowApp {
             rx_recorder: None,
             clip_recorder: None,
             clips_listed_for: None,
+            log: None,
+            log_open_for: None,
+            worked_before: rigflow_log::store::WorkedBefore::default(),
+            contacts_cache: Vec::new(),
+            contacts_cache_dirty: true,
+            wsjtx_rx,
         };
 
         // Enumerate input devices once for the dropdown (one-time; cheap enough
@@ -453,13 +477,27 @@ impl RigflowApp {
         // callsign/frequency never triggers them).  `X` = TX-focus swap,
         // `=` = copy VFO A onto VFO B.
         if !ctx.wants_keyboard_input() {
-            let (swap_tx, copy_ab, bookmark) = ctx.input(|i| {
+            let (swap_tx, copy_ab, bookmark, open_log, toggle_view) = ctx.input(|i| {
                 (
                     i.key_pressed(egui::Key::X),
                     i.key_pressed(egui::Key::Equals),
                     i.key_pressed(egui::Key::B),
+                    i.key_pressed(egui::Key::L),
+                    i.key_pressed(egui::Key::V),
                 )
             });
+            // Logging hotkeys don't require an acquired radio: `V` toggles the
+            // contact view; `L` opens the entry window (freezing whatever radio
+            // state is current).
+            if toggle_view {
+                if let Ok(mut s) = self.state.lock() {
+                    s.show_contact_view = !s.show_contact_view;
+                }
+            }
+            if open_log {
+                let snapshot = self.snapshot_state();
+                self.open_log_entry(&snapshot);
+            }
             if swap_tx || copy_ab || bookmark {
                 let snapshot = self.snapshot_state();
                 if snapshot.radio_acquired {
@@ -626,6 +664,9 @@ impl eframe::App for RigflowApp {
         let snapshot = self.snapshot_state();
         let config_mode = !snapshot.server_connected;
 
+        // Ingest any WSJT-X FT8 contacts that arrived since the last frame.
+        self.drain_wsjtx_events(ctx);
+
         self.ensure_mic();
         self.auto_relock_controls();
         self.handle_keyboard_shortcuts(ctx);
@@ -641,12 +682,31 @@ impl eframe::App for RigflowApp {
         self.draw_delete_operator_dialog(ctx);
         self.draw_swr_sweep_window(ctx);
         self.draw_wsjtx_setup_window(ctx);
+        self.draw_log_entry_window(ctx, &snapshot);
+        self.draw_contact_view_window(ctx, &snapshot);
 
         // Per-operator audio recording + voice keyer: ensure dirs / refresh the
         // clip list on an operator switch, run any UI-requested action, and
         // mirror live recorder status into UiState for the panels.
         self.sync_audio_recording_state(&snapshot);
         self.process_audio_requests(&snapshot);
+
+        // Contact logging: open/reopen the per-operator log store on an operator
+        // switch (mirrors the audio-recording sync above).
+        self.sync_log_state(&snapshot);
+
+        // Persist the global station profile when the Station panel flagged a
+        // committed edit (it only has `&self`, so it defers the save to here).
+        let save_station = {
+            let mut s = self.state.lock().unwrap();
+            std::mem::take(&mut s.pending_save_station_profile)
+        };
+        if save_station {
+            let profile = self.state.lock().unwrap().station_profile.clone();
+            if let Err(e) = self.persistence_store.save_station_profile(&profile) {
+                self.set_log_status(format!("station save failed: {e}"));
+            }
+        }
 
         // Persist per-radio settings: diff the live per-radio state against the
         // saved bucket and save ~600 ms after it stops changing.  Debounced so a

--- a/rigflow-client/src/ui/app.rs
+++ b/rigflow-client/src/ui/app.rs
@@ -159,6 +159,15 @@ pub struct RigflowApp {
     pub(crate) import_planning: bool,
     /// Result / error line for the import window.
     pub(crate) import_status: String,
+
+    // ── contact edit / delete ────────────────────────────────────────────
+    /// The contact open in the edit window: its row id, the original QSO (so
+    /// `extra` and untouched fields survive the round-trip), and editable copies
+    /// of the fields the operator can change. `None` = edit window closed.
+    pub(crate) edit_contact: Option<crate::ui::app_logging::ContactEdit>,
+    /// A contact awaiting delete confirmation: (row id, human label). `None` =
+    /// no pending delete.
+    pub(crate) delete_contact: Option<(i64, String)>,
 }
 
 impl RigflowApp {
@@ -245,6 +254,8 @@ impl RigflowApp {
             import_plan: None,
             import_planning: false,
             import_status: String::new(),
+            edit_contact: None,
+            delete_contact: None,
         };
 
         // Enumerate input devices once for the dropdown (one-time; cheap enough
@@ -776,6 +787,8 @@ impl eframe::App for RigflowApp {
         self.draw_filter_window(ctx);
         self.draw_export_window(ctx, &snapshot);
         self.draw_import_window(ctx, &snapshot);
+        self.draw_edit_contact_window(ctx);
+        self.draw_delete_contact_confirm(ctx);
 
         // Per-operator audio recording + voice keyer: ensure dirs / refresh the
         // clip list on an operator switch, run any UI-requested action, and

--- a/rigflow-client/src/ui/app.rs
+++ b/rigflow-client/src/ui/app.rs
@@ -99,24 +99,49 @@ pub struct RigflowApp {
     /// Cached recent contacts for the contact-view window; refreshed when dirty.
     pub(crate) contacts_cache: Vec<rigflow_log::store::LoggedQso>,
     pub(crate) contacts_cache_dirty: bool,
+    /// Total contacts matching the active filter, ignoring the row cap — so the
+    /// view can say "showing 500 of 1,483" instead of silently truncating.
+    pub(crate) contacts_total: usize,
     /// Receiver for decoded WSJT-X `LoggedADIF` events from the UDP-2237 thread.
     pub(crate) wsjtx_rx: std::sync::mpsc::Receiver<crate::logging::wsjtx_listener::LogEvent>,
 
-    // ── ADIF export ──────────────────────────────────────────────────────
-    // All of this lives here rather than in `UiState`: only the export window
-    // touches it, and `UiState` is cloned every frame by `snapshot_state()`.
+    // ── Contact filter / export ──────────────────────────────────────────
+    // All of this lives here rather than in `UiState`: only the logging windows
+    // touch it, and `UiState` is cloned every frame by `snapshot_state()`.
+    //
+    // `qso_filter` is the SHARED filter: it drives both the contact-view list and
+    // the export, so what the operator sees is what they get written.
+    pub(crate) qso_filter: crate::logging::export::QsoFilterDraft,
+    /// Previous filter, to notice an edit and re-arm the query debounce.
+    pub(crate) qso_filter_last: Option<crate::logging::export::QsoFilterDraft>,
+    /// Filter window open flag.
+    pub(crate) show_filter: bool,
+    /// When the debounced contact-view re-query should fire.
+    pub(crate) contacts_query_due: Option<std::time::Instant>,
+    /// Monotonic query id; a reply carrying an older one is stale and dropped.
+    pub(crate) contacts_query_seq: u64,
+    /// Filter error, shown in place of the match count.
+    pub(crate) filter_error: String,
+
+    /// Quick "have I worked this station?" lookup (contact-view toolbar).
+    pub(crate) call_lookup: String,
+    /// Rows + total for the lookup popup (`None` = no popup / still querying).
+    pub(crate) call_lookup_hits: Option<rigflow_log::export::ContactPage>,
+    pub(crate) call_lookup_seq: u64,
+    pub(crate) call_lookup_due: Option<std::time::Instant>,
+
     /// Export window open flag (opened from the contact view).
     pub(crate) show_export: bool,
     pub(crate) export_draft: crate::logging::export::ExportDraft,
-    /// Previous draft, to notice an edit and re-arm the count debounce.
+    /// Previous export draft, to re-arm the incremental count when it changes.
     pub(crate) export_draft_last: Option<crate::logging::export::ExportDraft>,
-    /// When the debounced dry-run count should fire.
-    pub(crate) export_count_due: Option<std::time::Instant>,
-    /// Latest dry-run match count (`None` = counting, or a filter error).
+    /// How many contacts the *export* would write. Differs from
+    /// `contacts_total` only when the export is incremental, and the window shows
+    /// both numbers so the difference is never a surprise.
     pub(crate) export_count: Option<usize>,
     /// A write is in flight on the worker.
     pub(crate) export_busy: bool,
-    /// Last export result / filter error, shown in the window.
+    /// Last export result / error, shown in the window.
     pub(crate) export_status: String,
     /// Job queue to the export worker thread, and its replies.
     pub(crate) export_tx: std::sync::mpsc::Sender<crate::logging::export::ExportJob>,
@@ -182,11 +207,21 @@ impl RigflowApp {
             worked_before: rigflow_log::store::WorkedBefore::default(),
             contacts_cache: Vec::new(),
             contacts_cache_dirty: true,
+            contacts_total: 0,
             wsjtx_rx,
+            qso_filter: crate::logging::export::QsoFilterDraft::default(),
+            qso_filter_last: None,
+            show_filter: false,
+            contacts_query_due: None,
+            contacts_query_seq: 0,
+            filter_error: String::new(),
+            call_lookup: String::new(),
+            call_lookup_hits: None,
+            call_lookup_seq: 0,
+            call_lookup_due: None,
             show_export: false,
             export_draft: crate::logging::export::ExportDraft::default(),
             export_draft_last: None,
-            export_count_due: None,
             export_count: None,
             export_busy: false,
             export_status: String::new(),
@@ -720,6 +755,7 @@ impl eframe::App for RigflowApp {
         self.draw_wsjtx_setup_window(ctx);
         self.draw_log_entry_window(ctx, &snapshot);
         self.draw_contact_view_window(ctx, &snapshot);
+        self.draw_filter_window(ctx);
         self.draw_export_window(ctx, &snapshot);
 
         // Per-operator audio recording + voice keyer: ensure dirs / refresh the

--- a/rigflow-client/src/ui/app.rs
+++ b/rigflow-client/src/ui/app.rs
@@ -168,6 +168,23 @@ pub struct RigflowApp {
     /// A contact awaiting delete confirmation: (row id, human label). `None` =
     /// no pending delete.
     pub(crate) delete_contact: Option<(i64, String)>,
+
+    // ── online sync (LoTW confirmation download) ─────────────────────────
+    /// Sync window open flag (opened from the contact view).
+    pub(crate) show_sync: bool,
+    /// LoTW login + password fields. Loaded from the credential store when the
+    /// window opens; the password is only re-saved when the operator edits it.
+    pub(crate) sync_login: String,
+    pub(crate) sync_password: String,
+    /// Where the loaded credential came from (keyring vs file), for a UI note.
+    pub(crate) sync_backend: Option<crate::logging::credentials::Backend>,
+    /// A download is in flight on the worker.
+    pub(crate) sync_busy: bool,
+    /// Result / error line for the sync window.
+    pub(crate) sync_status: String,
+    /// Operator whose credentials are currently loaded into the fields, so the
+    /// window loads once per operator rather than every frame.
+    pub(crate) sync_loaded_for: Option<String>,
 }
 
 impl RigflowApp {
@@ -256,6 +273,13 @@ impl RigflowApp {
             import_status: String::new(),
             edit_contact: None,
             delete_contact: None,
+            show_sync: false,
+            sync_login: String::new(),
+            sync_password: String::new(),
+            sync_backend: None,
+            sync_busy: false,
+            sync_status: String::new(),
+            sync_loaded_for: None,
         };
 
         // Enumerate input devices once for the dropdown (one-time; cheap enough
@@ -789,6 +813,7 @@ impl eframe::App for RigflowApp {
         self.draw_import_window(ctx, &snapshot);
         self.draw_edit_contact_window(ctx);
         self.draw_delete_contact_confirm(ctx);
+        self.draw_sync_window(ctx, &snapshot.operator_id);
 
         // Per-operator audio recording + voice keyer: ensure dirs / refresh the
         // clip list on an operator switch, run any UI-requested action, and

--- a/rigflow-client/src/ui/app.rs
+++ b/rigflow-client/src/ui/app.rs
@@ -185,6 +185,8 @@ pub struct RigflowApp {
     pub(crate) sync_password: String,
     /// Where the loaded credential came from (keyring vs file), for a UI note.
     pub(crate) sync_backend: Option<crate::logging::credentials::Backend>,
+    /// Re-upload QSOs already marked uploaded (ignore the not-uploaded filter).
+    pub(crate) sync_force_upload: bool,
     /// A sync is in flight on the worker.
     pub(crate) sync_busy: bool,
     /// Result / error line for the sync window.
@@ -287,6 +289,7 @@ impl RigflowApp {
             sync_login: String::new(),
             sync_password: String::new(),
             sync_backend: None,
+            sync_force_upload: false,
             sync_busy: false,
             sync_status: String::new(),
             sync_loaded_for: None,

--- a/rigflow-client/src/ui/app.rs
+++ b/rigflow-client/src/ui/app.rs
@@ -168,6 +168,11 @@ pub struct RigflowApp {
     /// A contact awaiting delete confirmation: (row id, human label). `None` =
     /// no pending delete.
     pub(crate) delete_contact: Option<(i64, String)>,
+    /// Multi-select in the contact view: the checked row ids. Drives the
+    /// selection action bar (export / bulk delete).
+    pub(crate) selected_contacts: std::collections::BTreeSet<i64>,
+    /// A bulk delete of `selected_contacts` is awaiting confirmation.
+    pub(crate) delete_selection_pending: bool,
 
     // ── online sync (LoTW confirmation download) ─────────────────────────
     /// Sync window open flag (opened from the contact view).
@@ -273,6 +278,8 @@ impl RigflowApp {
             import_status: String::new(),
             edit_contact: None,
             delete_contact: None,
+            selected_contacts: std::collections::BTreeSet::new(),
+            delete_selection_pending: false,
             show_sync: false,
             sync_login: String::new(),
             sync_password: String::new(),
@@ -813,6 +820,7 @@ impl eframe::App for RigflowApp {
         self.draw_import_window(ctx, &snapshot);
         self.draw_edit_contact_window(ctx);
         self.draw_delete_contact_confirm(ctx);
+        self.draw_delete_selection_confirm(ctx);
         self.draw_sync_window(ctx, &snapshot.operator_id);
 
         // Per-operator audio recording + voice keyer: ensure dirs / refresh the

--- a/rigflow-client/src/ui/app.rs
+++ b/rigflow-client/src/ui/app.rs
@@ -174,22 +174,24 @@ pub struct RigflowApp {
     /// A bulk delete of `selected_contacts` is awaiting confirmation.
     pub(crate) delete_selection_pending: bool,
 
-    // ── online sync (LoTW confirmation download) ─────────────────────────
+    // ── online sync (LoTW / eQSL / QRZ) ──────────────────────────────────
     /// Sync window open flag (opened from the contact view).
     pub(crate) show_sync: bool,
-    /// LoTW login + password fields. Loaded from the credential store when the
-    /// window opens; the password is only re-saved when the operator edits it.
+    /// The service the sync window is currently showing.
+    pub(crate) sync_service: crate::logging::services::Service,
+    /// Login + password (or API key, in `sync_password`) for the current service.
+    /// Loaded from the credential store; the password is re-saved when a sync runs.
     pub(crate) sync_login: String,
     pub(crate) sync_password: String,
     /// Where the loaded credential came from (keyring vs file), for a UI note.
     pub(crate) sync_backend: Option<crate::logging::credentials::Backend>,
-    /// A download is in flight on the worker.
+    /// A sync is in flight on the worker.
     pub(crate) sync_busy: bool,
     /// Result / error line for the sync window.
     pub(crate) sync_status: String,
-    /// Operator whose credentials are currently loaded into the fields, so the
-    /// window loads once per operator rather than every frame.
-    pub(crate) sync_loaded_for: Option<String>,
+    /// (operator, service) whose credentials are loaded into the fields, so the
+    /// window loads once per operator+service rather than every frame.
+    pub(crate) sync_loaded_for: Option<(String, crate::logging::services::Service)>,
 }
 
 impl RigflowApp {
@@ -281,6 +283,7 @@ impl RigflowApp {
             selected_contacts: std::collections::BTreeSet::new(),
             delete_selection_pending: false,
             show_sync: false,
+            sync_service: crate::logging::services::Service::Lotw,
             sync_login: String::new(),
             sync_password: String::new(),
             sync_backend: None,

--- a/rigflow-client/src/ui/app_actions.rs
+++ b/rigflow-client/src/ui/app_actions.rs
@@ -596,6 +596,41 @@ impl RigflowApp {
         self.save_bookmarks_to_current_operator();
     }
 
+    pub(crate) fn save_operator_name(&mut self) {
+        let (operator_id, name) = {
+            let state = self.state.lock().unwrap();
+            (state.operator_id.clone(), state.operator_name.clone())
+        };
+
+        if operator_id.trim().is_empty() {
+            return;
+        }
+
+        let mut operator_settings = match self
+            .persistence_store
+            .load_or_create_operator_settings(&operator_id)
+        {
+            Ok(settings) => settings,
+            Err(err) => {
+                if let Ok(mut state) = self.state.lock() {
+                    state.persistence_status = format!("failed to load operator: {err}");
+                }
+                return;
+            }
+        };
+
+        operator_settings.name = name;
+
+        if let Err(err) = self
+            .persistence_store
+            .save_operator_settings(&operator_settings)
+        {
+            if let Ok(mut state) = self.state.lock() {
+                state.persistence_status = format!("failed to save operator name: {err}");
+            }
+        }
+    }
+
     pub(crate) fn save_selected_operator_license(&mut self) {
         let (operator_id, selected_license) = {
             let state = self.state.lock().unwrap();

--- a/rigflow-client/src/ui/app_center.rs
+++ b/rigflow-client/src/ui/app_center.rs
@@ -385,7 +385,7 @@ impl RigflowApp {
         }
 
         if !snapshot.radio_acquired {
-            ui.label(egui::RichText::new("No radio acquired").weak());
+            ui.label("No radio acquired");
             return;
         }
 
@@ -544,7 +544,9 @@ impl RigflowApp {
                     .color(egui::Color32::from_rgb(235, 80, 80)),
             );
         } else {
-            ui.label(egui::RichText::new("RX").weak());
+            // Calm green against TX's alarm red: the quiet state is still legible
+            // at a glance, distinguished by colour rather than by being dimmed.
+            ui.label(egui::RichText::new("RX").color(egui::Color32::from_rgb(120, 200, 120)));
         }
 
         // SWR — shown only when the source reports it.

--- a/rigflow-client/src/ui/app_export.rs
+++ b/rigflow-client/src/ui/app_export.rs
@@ -14,6 +14,7 @@
 use eframe::egui;
 
 use crate::logging::export::{ExportDraft, ExportEvent, ExportJob, ProfileChoice, QUERY_DEBOUNCE};
+use crate::ui::panels::note_text;
 
 impl crate::ui::app::RigflowApp {
     /// Open the export window, seeding a dated default path in the operator's
@@ -325,15 +326,10 @@ impl crate::ui::app::RigflowApp {
                                 .desired_width(120.0),
                         );
                     });
-                    ui.label(
-                        egui::RichText::new(
-                            "Each named stream keeps its own position, and only an \
-                             incremental export moves it — an ordinary filtered export \
-                             never does.",
-                        )
-                        .small()
-                        .weak(),
-                    );
+                    ui.label(note_text(
+                        "Each named stream keeps its own position, and only an incremental \
+                         export moves it — an ordinary filtered export never does.",
+                    ));
                 }
 
                 ui.separator();
@@ -349,7 +345,7 @@ impl crate::ui::app::RigflowApp {
                             "{matching} match your filter · {n} new since the last export \
                              · exporting {n}"
                         )),
-                        None => ui.label(egui::RichText::new("counting…").weak()),
+                        None => ui.label("counting…"),
                     };
                 } else {
                     ui.label(format!(
@@ -365,7 +361,7 @@ impl crate::ui::app::RigflowApp {
                         do_export = true;
                     }
                     if self.export_busy {
-                        ui.label(egui::RichText::new("exporting…").weak());
+                        ui.label("exporting…");
                     }
                 });
                 if !self.export_status.is_empty() {

--- a/rigflow-client/src/ui/app_export.rs
+++ b/rigflow-client/src/ui/app_export.rs
@@ -1,0 +1,446 @@
+//! The ADIF export window, opened from the contact view (`V`).
+//!
+//! A floating `egui::Window` (non-blocking, like the log-entry window) with the
+//! filters grouped into collapsible sections, the output options, and a **live
+//! match count** so the operator sees "1,483 QSOs match" before committing to a
+//! file. That count is a real dry run through the same filter the export will
+//! use, debounced by [`COUNT_DEBOUNCE`].
+
+use eframe::egui;
+
+use crate::logging::export::{COUNT_DEBOUNCE, ExportDraft, ExportEvent, ExportJob, ProfileChoice};
+use rigflow_log::export::GridPrecision;
+use rigflow_log::normalize::ModeClass;
+
+impl crate::ui::app::RigflowApp {
+    /// Open the export window, seeding the draft with a dated default path in
+    /// the current operator's data directory.
+    pub(crate) fn open_export(&mut self, operator_id: &str) {
+        let (date, _) = rigflow_log::now_utc_adif();
+        let default_path = self
+            .persistence_store
+            .qso_log_db_path(operator_id)
+            .with_file_name(format!("export-{date}.adi"));
+        self.export_draft = ExportDraft::new(default_path);
+        self.export_count = None;
+        self.export_status.clear();
+        self.export_count_due = Some(std::time::Instant::now());
+        self.show_export = true;
+    }
+
+    /// Drain the export worker's replies. Called at the top of `update()`.
+    ///
+    /// This is where an incremental export's bookmark advances — on the UI
+    /// thread, on the read-write `LogStore`, and only after the worker reports a
+    /// **successful write** of an export that actually was incremental. The
+    /// worker itself runs on a read-only connection and cannot do it.
+    pub(crate) fn drain_export_events(&mut self, ctx: &egui::Context) {
+        let mut got = false;
+        while let Ok(evt) = self.export_rx.try_recv() {
+            got = true;
+            match evt {
+                ExportEvent::Count(Ok(n)) => {
+                    self.export_count = Some(n);
+                    self.export_status.clear();
+                }
+                ExportEvent::Count(Err(e)) => {
+                    self.export_count = None;
+                    self.export_status = e;
+                }
+                ExportEvent::Done(Ok(summary)) => {
+                    self.export_busy = false;
+
+                    // Advance the incremental bookmark — and ONLY for an
+                    // incremental export. An ad-hoc "export my 20m QSOs" must
+                    // never move an operator's incremental position, or the next
+                    // incremental run silently skips every unexported QSO that
+                    // fell outside that filter.
+                    //
+                    // A failed advance is reported, not swallowed: the file is on
+                    // disk but the position didn't move, so the next incremental
+                    // run would re-export these contacts. The operator has to know.
+                    let mut warning = String::new();
+                    if let (Some(profile), Some(max_id)) = (
+                        summary.filter.incremental_profile().map(str::to_string),
+                        summary.max_qso_id,
+                    ) && let Some(store) = self.log.as_mut()
+                        && let Err(e) = store.advance_export_bookmark(&profile, max_id)
+                    {
+                        warning = format!(" — but the bookmark did not advance: {e}");
+                    }
+
+                    self.export_status = format!(
+                        "exported {} contact{} to {}{}",
+                        summary.count,
+                        if summary.count == 1 { "" } else { "s" },
+                        summary.path.display(),
+                        warning,
+                    );
+                    self.set_log_status(self.export_status.clone());
+                }
+                ExportEvent::Done(Err(e)) => {
+                    self.export_busy = false;
+                    self.export_status = format!("export failed: {e}");
+                }
+            }
+        }
+        if got {
+            ctx.request_repaint();
+        }
+    }
+
+    /// Run the debounced dry-run count when the draft has settled.
+    fn maybe_request_count(&mut self, operator_id: &str, ctx: &egui::Context) {
+        // Any edit re-arms the timer.
+        if self.export_draft_last.as_ref() != Some(&self.export_draft) {
+            self.export_draft_last = Some(self.export_draft.clone());
+            self.export_count_due = Some(std::time::Instant::now() + COUNT_DEBOUNCE);
+            self.export_count = None;
+        }
+        let Some(due) = self.export_count_due else {
+            return;
+        };
+        if std::time::Instant::now() < due {
+            // Make sure we come back to fire it even if nothing else repaints.
+            ctx.request_repaint_after(COUNT_DEBOUNCE);
+            return;
+        }
+        self.export_count_due = None;
+
+        match self.export_draft.to_filter() {
+            Ok(filter) => {
+                let db_path = self.persistence_store.qso_log_db_path(operator_id);
+                let _ = self.export_tx.send(ExportJob::Count {
+                    db_path,
+                    filter: Box::new(filter),
+                });
+            }
+            // A malformed filter is shown, not run.
+            Err(e) => self.export_status = e.to_string(),
+        }
+    }
+
+    pub(crate) fn draw_export_window(
+        &mut self,
+        ctx: &egui::Context,
+        snapshot: &crate::ui::state::UiState,
+    ) {
+        if !self.show_export {
+            return;
+        }
+        let operator_id = snapshot.operator_id.clone();
+        if operator_id.trim().is_empty() || self.log.is_none() {
+            self.show_export = false;
+            return;
+        }
+
+        self.maybe_request_count(&operator_id, ctx);
+
+        let mut open = true;
+        let mut do_export = false;
+        let mut pick_path = false;
+
+        egui::Window::new("Export ADIF")
+            .open(&mut open)
+            .default_width(460.0)
+            .show(ctx, |ui| {
+                let d = &mut self.export_draft;
+
+                egui::CollapsingHeader::new("Date")
+                    .default_open(true)
+                    .show(ui, |ui| {
+                        ui.horizontal(|ui| {
+                            ui.label("From");
+                            ui.add(
+                                egui::TextEdit::singleline(&mut d.date_from)
+                                    .hint_text("YYYYMMDD")
+                                    .desired_width(90.0),
+                            );
+                            ui.label("To");
+                            ui.add(
+                                egui::TextEdit::singleline(&mut d.date_to)
+                                    .hint_text("YYYYMMDD")
+                                    .desired_width(90.0),
+                            );
+                        });
+                    });
+
+                egui::CollapsingHeader::new("Band & mode")
+                    .default_open(true)
+                    .show(ui, |ui| {
+                        ui.label("Bands (none = all)");
+                        egui::Grid::new("export_bands")
+                            .num_columns(6)
+                            .show(ui, |ui| {
+                                for (i, band) in ExportDraft::all_bands().into_iter().enumerate() {
+                                    let mut on = d.bands.contains(band);
+                                    if ui.checkbox(&mut on, band).changed() {
+                                        if on {
+                                            d.bands.insert(band.to_string());
+                                        } else {
+                                            d.bands.remove(band);
+                                        }
+                                    }
+                                    if i % 6 == 5 {
+                                        ui.end_row();
+                                    }
+                                }
+                            });
+                        ui.add_enabled(
+                            !d.bands.is_empty(),
+                            egui::Checkbox::new(
+                                &mut d.match_either_band,
+                                "also match the RX band (split across bands)",
+                            ),
+                        );
+
+                        ui.separator();
+                        ui.horizontal(|ui| {
+                            ui.label("Mode class");
+                            for c in ModeClass::ALL {
+                                let mut on = d.mode_classes.contains(c);
+                                if ui.checkbox(&mut on, c.as_str()).changed() {
+                                    if on {
+                                        d.mode_classes.insert(*c);
+                                    } else {
+                                        d.mode_classes.remove(c);
+                                    }
+                                }
+                            }
+                        });
+                        ui.horizontal(|ui| {
+                            ui.label("Modes");
+                            ui.add(
+                                egui::TextEdit::singleline(&mut d.modes)
+                                    .hint_text("SSB, CW, FT8")
+                                    .desired_width(150.0),
+                            );
+                            ui.label("Submodes");
+                            ui.add(
+                                egui::TextEdit::singleline(&mut d.submodes)
+                                    .hint_text("FT4")
+                                    .desired_width(100.0),
+                            );
+                        });
+                    });
+
+                egui::CollapsingHeader::new("Station").show(ui, |ui| {
+                    ui.horizontal(|ui| {
+                        ui.label("Call");
+                        ui.add(
+                            egui::TextEdit::singleline(&mut d.call_pattern)
+                                .hint_text("W1* or K?ZD")
+                                .desired_width(120.0),
+                        );
+                        ui.label("DXCC");
+                        ui.add(
+                            egui::TextEdit::singleline(&mut d.dxcc)
+                                .hint_text("291, 339")
+                                .desired_width(90.0),
+                        );
+                    });
+                    ui.horizontal(|ui| {
+                        ui.label("Their grid");
+                        ui.add(
+                            egui::TextEdit::singleline(&mut d.gridsquare)
+                                .hint_text("EM12")
+                                .desired_width(80.0),
+                        );
+                        egui::ComboBox::from_id_salt("grid_precision")
+                            .selected_text(match d.grid_precision {
+                                GridPrecision::Field => "field (2)",
+                                GridPrecision::Square => "square (4)",
+                                GridPrecision::Full => "exact",
+                            })
+                            .show_ui(ui, |ui| {
+                                ui.selectable_value(
+                                    &mut d.grid_precision,
+                                    GridPrecision::Field,
+                                    "field (2)",
+                                );
+                                ui.selectable_value(
+                                    &mut d.grid_precision,
+                                    GridPrecision::Square,
+                                    "square (4)",
+                                );
+                                ui.selectable_value(
+                                    &mut d.grid_precision,
+                                    GridPrecision::Full,
+                                    "exact",
+                                );
+                            });
+                    });
+                    ui.horizontal(|ui| {
+                        ui.label("My grid");
+                        ui.add(
+                            egui::TextEdit::singleline(&mut d.my_gridsquare)
+                                .hint_text("the grid you worked FROM")
+                                .desired_width(160.0),
+                        );
+                    })
+                    .response
+                    .on_hover_text(
+                        "Matches the grid recorded on each contact, so QSOs made \
+                             from a previous QTH are still found after you move.",
+                    );
+                    ui.horizontal(|ui| {
+                        ui.label("Contest");
+                        ui.add(
+                            egui::TextEdit::singleline(&mut d.contest_id)
+                                .hint_text("CQ-WW-SSB")
+                                .desired_width(140.0),
+                        );
+                    });
+                });
+
+                egui::CollapsingHeader::new("Confirmation").show(ui, |ui| {
+                    ui.label(
+                        egui::RichText::new(
+                            "Online-service state isn't tracked yet, so these match \
+                                 nothing (or everything) until service sync lands.",
+                        )
+                        .small()
+                        .weak(),
+                    );
+                    ui.horizontal(|ui| {
+                        ui.label("Not uploaded to");
+                        ui.add(
+                            egui::TextEdit::singleline(&mut d.not_uploaded_to)
+                                .hint_text("lotw")
+                                .desired_width(80.0),
+                        );
+                        ui.label("Confirmed by");
+                        ui.add(
+                            egui::TextEdit::singleline(&mut d.confirmed_by)
+                                .hint_text("lotw")
+                                .desired_width(80.0),
+                        );
+                    });
+                    ui.checkbox(&mut d.qsl_rcvd_yes, "QSL received (QSL_RCVD = Y)");
+                });
+
+                egui::CollapsingHeader::new("Incremental").show(ui, |ui| {
+                    ui.checkbox(&mut d.incremental, "Only contacts new since the last run");
+                    ui.add_enabled_ui(d.incremental, |ui| {
+                        ui.horizontal(|ui| {
+                            ui.label("Stream");
+                            ui.add(
+                                egui::TextEdit::singleline(&mut d.profile)
+                                    .hint_text("default")
+                                    .desired_width(120.0),
+                            );
+                        });
+                    });
+                    ui.label(
+                        egui::RichText::new(
+                            "Each named stream keeps its own position. Only an \
+                                 incremental export moves it — an ordinary filtered \
+                                 export never does.",
+                        )
+                        .small()
+                        .weak(),
+                    );
+                });
+
+                ui.separator();
+
+                // ── output ──
+                ui.horizontal(|ui| {
+                    ui.label("File");
+                    ui.add(egui::TextEdit::singleline(&mut d.output_path).desired_width(260.0));
+                    if ui.button("Browse…").clicked() {
+                        pick_path = true;
+                    }
+                });
+                ui.horizontal(|ui| {
+                    ui.label("Fields");
+                    ui.selectable_value(&mut d.profile_choice, ProfileChoice::Full, "Full");
+                    ui.selectable_value(&mut d.profile_choice, ProfileChoice::Core, "Core");
+                    ui.selectable_value(&mut d.profile_choice, ProfileChoice::Custom, "Custom");
+                    if d.profile_choice == ProfileChoice::Full {
+                        ui.checkbox(&mut d.include_extra, "include extra fields");
+                    }
+                });
+                if d.profile_choice == ProfileChoice::Custom {
+                    ui.horizontal(|ui| {
+                        ui.label("Custom fields");
+                        ui.add(
+                            egui::TextEdit::singleline(&mut d.custom_fields)
+                                .hint_text("CALL, QSO_DATE, BAND, MODE")
+                                .desired_width(280.0),
+                        );
+                    });
+                }
+                ui.checkbox(&mut d.sort_reverse, "newest first");
+
+                ui.separator();
+
+                // ── the live count + commit ──
+                ui.horizontal(|ui| {
+                    let ready =
+                        !self.export_busy && !self.export_draft.output_path.trim().is_empty();
+                    if ui.add_enabled(ready, egui::Button::new("Export")).clicked() {
+                        do_export = true;
+                    }
+                    match self.export_count {
+                        Some(n) => ui.label(format!(
+                            "{n} contact{} match",
+                            if n == 1 { "" } else { "es" }
+                        )),
+                        None => ui.label(
+                            egui::RichText::new(if self.export_busy {
+                                "exporting…"
+                            } else {
+                                "counting…"
+                            })
+                            .weak(),
+                        ),
+                    };
+                });
+                if !self.export_status.is_empty() {
+                    ui.label(&self.export_status);
+                }
+            });
+
+        // The native picker is synchronous, so it blocks the UI thread while it's
+        // open. That's the usual native-dialog trade (and correct on macOS, where
+        // AppKit demands the main thread); audio and the media runtime live on
+        // other threads and keep running.
+        if pick_path {
+            let start = std::path::PathBuf::from(self.export_draft.output_path.trim());
+            let mut dlg = rfd::FileDialog::new().add_filter("ADIF", &["adi", "adif"]);
+            if let Some(dir) = start.parent().filter(|p| p.is_dir()) {
+                dlg = dlg.set_directory(dir);
+            }
+            if let Some(name) = start.file_name().and_then(|n| n.to_str()) {
+                dlg = dlg.set_file_name(name);
+            }
+            if let Some(path) = dlg.save_file() {
+                self.export_draft.output_path = path.to_string_lossy().into_owned();
+            }
+        }
+
+        if do_export {
+            match (
+                self.export_draft.to_filter(),
+                self.export_draft.to_options(),
+            ) {
+                (Ok(filter), Ok(options)) => {
+                    let db_path = self.persistence_store.qso_log_db_path(&operator_id);
+                    self.export_busy = true;
+                    self.export_status.clear();
+                    let _ = self.export_tx.send(ExportJob::Write {
+                        db_path,
+                        filter: Box::new(filter),
+                        options: Box::new(options),
+                    });
+                }
+                (Err(e), _) | (_, Err(e)) => self.export_status = e.to_string(),
+            }
+        }
+
+        if !open {
+            self.show_export = false;
+        }
+    }
+}

--- a/rigflow-client/src/ui/app_export.rs
+++ b/rigflow-client/src/ui/app_export.rs
@@ -1,20 +1,23 @@
-//! The ADIF export window, opened from the contact view (`V`).
+//! The contact-view's query driver, the worker drain, and the **export window**.
 //!
-//! A floating `egui::Window` (non-blocking, like the log-entry window) with the
-//! filters grouped into collapsible sections, the output options, and a **live
-//! match count** so the operator sees "1,483 QSOs match" before committing to a
-//! file. That count is a real dry run through the same filter the export will
-//! use, debounced by [`COUNT_DEBOUNCE`].
+//! The export window is *output only* — File, Fields, sort, incremental, and the
+//! Export button. **Which** contacts get written is decided by the shared filter
+//! in the `Filter…` window (`app_filter.rs`) — the same filter the contact view
+//! lists — so the operator sees what they are exporting.
+//!
+//! The one thing that can make the written set differ from the visible list is
+//! **incremental** ("only what's new since the last run"), which is a fact about
+//! export progress, not about a contact. So the window spells out the arithmetic
+//! — *"1,483 match your filter · 12 new since the last export · exporting 12"* —
+//! rather than quietly writing a different set than the one on screen.
 
 use eframe::egui;
 
-use crate::logging::export::{COUNT_DEBOUNCE, ExportDraft, ExportEvent, ExportJob, ProfileChoice};
-use rigflow_log::export::GridPrecision;
-use rigflow_log::normalize::ModeClass;
+use crate::logging::export::{ExportDraft, ExportEvent, ExportJob, ProfileChoice, QUERY_DEBOUNCE};
 
 impl crate::ui::app::RigflowApp {
-    /// Open the export window, seeding the draft with a dated default path in
-    /// the current operator's data directory.
+    /// Open the export window, seeding a dated default path in the operator's
+    /// data directory.
     pub(crate) fn open_export(&mut self, operator_id: &str) {
         let (date, _) = rigflow_log::now_utc_adif();
         let default_path = self
@@ -22,31 +25,167 @@ impl crate::ui::app::RigflowApp {
             .qso_log_db_path(operator_id)
             .with_file_name(format!("export-{date}.adi"));
         self.export_draft = ExportDraft::new(default_path);
+        self.export_draft_last = None;
         self.export_count = None;
         self.export_status.clear();
-        self.export_count_due = Some(std::time::Instant::now());
         self.show_export = true;
     }
 
-    /// Drain the export worker's replies. Called at the top of `update()`.
+    /// Re-run the contact-view query when the filter (or the log) changes.
     ///
-    /// This is where an incremental export's bookmark advances — on the UI
+    /// Debounced: the filters that read the `extra` JSON blob are unindexed full
+    /// scans, so re-querying on every keystroke would stutter a large log. The
+    /// query runs on the worker's read-only connection, never on the UI thread
+    /// that owns the `LogStore`.
+    pub(crate) fn maybe_requery_contacts(&mut self, operator_id: &str, ctx: &egui::Context) {
+        if self.log.is_none() {
+            return;
+        }
+
+        // An edit to the shared filter re-arms the debounce and stales the
+        // export's count (which is derived from the same filter).
+        if self.qso_filter_last.as_ref() != Some(&self.qso_filter) {
+            self.qso_filter_last = Some(self.qso_filter.clone());
+            self.contacts_query_due = Some(std::time::Instant::now() + QUERY_DEBOUNCE);
+            self.export_count = None;
+        }
+        // A newly logged contact (or Refresh) invalidates immediately — there is
+        // nothing to settle, so no debounce.
+        if self.contacts_cache_dirty {
+            self.contacts_cache_dirty = false;
+            self.contacts_query_due = Some(std::time::Instant::now());
+        }
+
+        let now = std::time::Instant::now();
+
+        if let Some(due) = self.contacts_query_due {
+            if now < due {
+                ctx.request_repaint_after(QUERY_DEBOUNCE);
+            } else {
+                self.contacts_query_due = None;
+                self.dispatch_contacts_query(operator_id);
+            }
+        }
+
+        // The call lookup has its own debounce and its own (filter-independent)
+        // query.
+        if let Some(due) = self.call_lookup_due {
+            if now < due {
+                ctx.request_repaint_after(QUERY_DEBOUNCE);
+            } else {
+                self.call_lookup_due = None;
+                self.dispatch_call_lookup(operator_id);
+            }
+        }
+    }
+
+    /// Send the contact-view page query — and, when an incremental export is
+    /// being set up, its separate count.
+    fn dispatch_contacts_query(&mut self, operator_id: &str) {
+        let db_path = self.persistence_store.qso_log_db_path(operator_id);
+
+        // The view always asks for the plain shared filter — never incremental.
+        match self.qso_filter.to_filter(None) {
+            Ok(filter) => {
+                self.filter_error.clear();
+                self.contacts_query_seq += 1;
+                let _ = self.export_tx.send(ExportJob::Query {
+                    db_path: db_path.clone(),
+                    filter: Box::new(filter),
+                    seq: self.contacts_query_seq,
+                });
+            }
+            // A malformed filter is shown, not run — and the existing list is
+            // left alone rather than silently emptied.
+            Err(e) => {
+                self.filter_error = e.to_string();
+                return;
+            }
+        }
+
+        // An incremental export writes a *subset* of the visible list, so it
+        // needs its own count for the window to show the arithmetic honestly.
+        if self.show_export
+            && let Some(profile) = self.export_draft.incremental_profile()
+            && let Ok(filter) = self.qso_filter.to_filter(Some(profile))
+        {
+            let _ = self.export_tx.send(ExportJob::Count {
+                db_path,
+                filter: Box::new(filter),
+                seq: self.contacts_query_seq,
+            });
+        }
+    }
+
+    fn dispatch_call_lookup(&mut self, operator_id: &str) {
+        let call = self.call_lookup.trim().to_string();
+        if call.is_empty() {
+            self.call_lookup_hits = None;
+            return;
+        }
+        let Ok(filter) = crate::logging::export::call_lookup_filter(&call) else {
+            return;
+        };
+        self.call_lookup_seq += 1;
+        let _ = self.export_tx.send(ExportJob::CallLookup {
+            db_path: self.persistence_store.qso_log_db_path(operator_id),
+            call,
+            filter: Box::new(filter),
+            seq: self.call_lookup_seq,
+        });
+    }
+
+    /// Drain the worker's replies.
+    ///
+    /// This is also where an incremental export's bookmark advances — on the UI
     /// thread, on the read-write `LogStore`, and only after the worker reports a
-    /// **successful write** of an export that actually was incremental. The
-    /// worker itself runs on a read-only connection and cannot do it.
+    /// successful write of an export that actually *was* incremental. The worker
+    /// runs on a read-only connection and cannot do it itself.
     pub(crate) fn drain_export_events(&mut self, ctx: &egui::Context) {
         let mut got = false;
         while let Ok(evt) = self.export_rx.try_recv() {
             got = true;
             match evt {
-                ExportEvent::Count(Ok(n)) => {
-                    self.export_count = Some(n);
-                    self.export_status.clear();
+                // Replies for a filter the operator has already typed past are
+                // dropped — otherwise the list flashes stale rows.
+                ExportEvent::Contacts { seq, result } => {
+                    if seq != self.contacts_query_seq {
+                        continue;
+                    }
+                    match result {
+                        Ok(page) => {
+                            self.contacts_cache = page.rows;
+                            self.contacts_total = page.total;
+                            self.filter_error.clear();
+                        }
+                        Err(e) => self.filter_error = e,
+                    }
                 }
-                ExportEvent::Count(Err(e)) => {
-                    self.export_count = None;
-                    self.export_status = e;
+
+                ExportEvent::Count { seq, result } => {
+                    if seq != self.contacts_query_seq {
+                        continue;
+                    }
+                    self.export_count = result.ok();
                 }
+
+                ExportEvent::CallMatches { seq, call, result } => {
+                    // Two guards, because showing one station's contacts under
+                    // another station's name would be worse than showing none:
+                    // the sequence catches a reply the operator has typed past,
+                    // and the echoed callsign catches any way the two could still
+                    // disagree.
+                    if seq != self.call_lookup_seq
+                        || !call.eq_ignore_ascii_case(self.call_lookup.trim())
+                    {
+                        continue;
+                    }
+                    match result {
+                        Ok(page) => self.call_lookup_hits = Some(*page),
+                        Err(e) => self.set_log_status(format!("call lookup: {e}")),
+                    }
+                }
+
                 ExportEvent::Done(Ok(summary)) => {
                     self.export_busy = false;
 
@@ -58,7 +197,7 @@ impl crate::ui::app::RigflowApp {
                     //
                     // A failed advance is reported, not swallowed: the file is on
                     // disk but the position didn't move, so the next incremental
-                    // run would re-export these contacts. The operator has to know.
+                    // run would re-export these contacts. The operator must know.
                     let mut warning = String::new();
                     if let (Some(profile), Some(max_id)) = (
                         summary.filter.incremental_profile().map(str::to_string),
@@ -77,6 +216,11 @@ impl crate::ui::app::RigflowApp {
                         warning,
                     );
                     self.set_log_status(self.export_status.clone());
+
+                    // The bookmark just moved, so "what's still unexported" has
+                    // changed: re-count.
+                    self.export_count = None;
+                    self.contacts_query_due = Some(std::time::Instant::now());
                 }
                 ExportEvent::Done(Err(e)) => {
                     self.export_busy = false;
@@ -89,37 +233,7 @@ impl crate::ui::app::RigflowApp {
         }
     }
 
-    /// Run the debounced dry-run count when the draft has settled.
-    fn maybe_request_count(&mut self, operator_id: &str, ctx: &egui::Context) {
-        // Any edit re-arms the timer.
-        if self.export_draft_last.as_ref() != Some(&self.export_draft) {
-            self.export_draft_last = Some(self.export_draft.clone());
-            self.export_count_due = Some(std::time::Instant::now() + COUNT_DEBOUNCE);
-            self.export_count = None;
-        }
-        let Some(due) = self.export_count_due else {
-            return;
-        };
-        if std::time::Instant::now() < due {
-            // Make sure we come back to fire it even if nothing else repaints.
-            ctx.request_repaint_after(COUNT_DEBOUNCE);
-            return;
-        }
-        self.export_count_due = None;
-
-        match self.export_draft.to_filter() {
-            Ok(filter) => {
-                let db_path = self.persistence_store.qso_log_db_path(operator_id);
-                let _ = self.export_tx.send(ExportJob::Count {
-                    db_path,
-                    filter: Box::new(filter),
-                });
-            }
-            // A malformed filter is shown, not run.
-            Err(e) => self.export_status = e.to_string(),
-        }
-    }
-
+    /// The export window: **output options only**.
     pub(crate) fn draw_export_window(
         &mut self,
         ctx: &egui::Context,
@@ -134,215 +248,40 @@ impl crate::ui::app::RigflowApp {
             return;
         }
 
-        self.maybe_request_count(&operator_id, ctx);
+        // Toggling incremental changes what gets written — re-run the counts.
+        if self.export_draft_last.as_ref() != Some(&self.export_draft) {
+            self.export_draft_last = Some(self.export_draft.clone());
+            self.export_count = None;
+            self.contacts_query_due = Some(std::time::Instant::now());
+        }
 
         let mut open = true;
         let mut do_export = false;
         let mut pick_path = false;
+        let mut open_filter = false;
 
         egui::Window::new("Export ADIF")
             .open(&mut open)
-            .default_width(460.0)
+            .default_width(470.0)
             .show(ctx, |ui| {
-                let d = &mut self.export_draft;
-
-                egui::CollapsingHeader::new("Date")
-                    .default_open(true)
-                    .show(ui, |ui| {
-                        ui.horizontal(|ui| {
-                            ui.label("From");
-                            ui.add(
-                                egui::TextEdit::singleline(&mut d.date_from)
-                                    .hint_text("YYYYMMDD")
-                                    .desired_width(90.0),
-                            );
-                            ui.label("To");
-                            ui.add(
-                                egui::TextEdit::singleline(&mut d.date_to)
-                                    .hint_text("YYYYMMDD")
-                                    .desired_width(90.0),
-                            );
-                        });
-                    });
-
-                egui::CollapsingHeader::new("Band & mode")
-                    .default_open(true)
-                    .show(ui, |ui| {
-                        ui.label("Bands (none = all)");
-                        egui::Grid::new("export_bands")
-                            .num_columns(6)
-                            .show(ui, |ui| {
-                                for (i, band) in ExportDraft::all_bands().into_iter().enumerate() {
-                                    let mut on = d.bands.contains(band);
-                                    if ui.checkbox(&mut on, band).changed() {
-                                        if on {
-                                            d.bands.insert(band.to_string());
-                                        } else {
-                                            d.bands.remove(band);
-                                        }
-                                    }
-                                    if i % 6 == 5 {
-                                        ui.end_row();
-                                    }
-                                }
-                            });
-                        ui.add_enabled(
-                            !d.bands.is_empty(),
-                            egui::Checkbox::new(
-                                &mut d.match_either_band,
-                                "also match the RX band (split across bands)",
-                            ),
-                        );
-
-                        ui.separator();
-                        ui.horizontal(|ui| {
-                            ui.label("Mode class");
-                            for c in ModeClass::ALL {
-                                let mut on = d.mode_classes.contains(c);
-                                if ui.checkbox(&mut on, c.as_str()).changed() {
-                                    if on {
-                                        d.mode_classes.insert(*c);
-                                    } else {
-                                        d.mode_classes.remove(c);
-                                    }
-                                }
-                            }
-                        });
-                        ui.horizontal(|ui| {
-                            ui.label("Modes");
-                            ui.add(
-                                egui::TextEdit::singleline(&mut d.modes)
-                                    .hint_text("SSB, CW, FT8")
-                                    .desired_width(150.0),
-                            );
-                            ui.label("Submodes");
-                            ui.add(
-                                egui::TextEdit::singleline(&mut d.submodes)
-                                    .hint_text("FT4")
-                                    .desired_width(100.0),
-                            );
-                        });
-                    });
-
-                egui::CollapsingHeader::new("Station").show(ui, |ui| {
-                    ui.horizontal(|ui| {
-                        ui.label("Call");
-                        ui.add(
-                            egui::TextEdit::singleline(&mut d.call_pattern)
-                                .hint_text("W1* or K?ZD")
-                                .desired_width(120.0),
-                        );
-                        ui.label("DXCC");
-                        ui.add(
-                            egui::TextEdit::singleline(&mut d.dxcc)
-                                .hint_text("291, 339")
-                                .desired_width(90.0),
-                        );
-                    });
-                    ui.horizontal(|ui| {
-                        ui.label("Their grid");
-                        ui.add(
-                            egui::TextEdit::singleline(&mut d.gridsquare)
-                                .hint_text("EM12")
-                                .desired_width(80.0),
-                        );
-                        egui::ComboBox::from_id_salt("grid_precision")
-                            .selected_text(match d.grid_precision {
-                                GridPrecision::Field => "field (2)",
-                                GridPrecision::Square => "square (4)",
-                                GridPrecision::Full => "exact",
-                            })
-                            .show_ui(ui, |ui| {
-                                ui.selectable_value(
-                                    &mut d.grid_precision,
-                                    GridPrecision::Field,
-                                    "field (2)",
-                                );
-                                ui.selectable_value(
-                                    &mut d.grid_precision,
-                                    GridPrecision::Square,
-                                    "square (4)",
-                                );
-                                ui.selectable_value(
-                                    &mut d.grid_precision,
-                                    GridPrecision::Full,
-                                    "exact",
-                                );
-                            });
-                    });
-                    ui.horizontal(|ui| {
-                        ui.label("My grid");
-                        ui.add(
-                            egui::TextEdit::singleline(&mut d.my_gridsquare)
-                                .hint_text("the grid you worked FROM")
-                                .desired_width(160.0),
-                        );
-                    })
-                    .response
-                    .on_hover_text(
-                        "Matches the grid recorded on each contact, so QSOs made \
-                             from a previous QTH are still found after you move.",
-                    );
-                    ui.horizontal(|ui| {
-                        ui.label("Contest");
-                        ui.add(
-                            egui::TextEdit::singleline(&mut d.contest_id)
-                                .hint_text("CQ-WW-SSB")
-                                .desired_width(140.0),
-                        );
-                    });
-                });
-
-                egui::CollapsingHeader::new("Confirmation").show(ui, |ui| {
-                    ui.label(
-                        egui::RichText::new(
-                            "Online-service state isn't tracked yet, so these match \
-                                 nothing (or everything) until service sync lands.",
-                        )
-                        .small()
-                        .weak(),
-                    );
-                    ui.horizontal(|ui| {
-                        ui.label("Not uploaded to");
-                        ui.add(
-                            egui::TextEdit::singleline(&mut d.not_uploaded_to)
-                                .hint_text("lotw")
-                                .desired_width(80.0),
-                        );
-                        ui.label("Confirmed by");
-                        ui.add(
-                            egui::TextEdit::singleline(&mut d.confirmed_by)
-                                .hint_text("lotw")
-                                .desired_width(80.0),
-                        );
-                    });
-                    ui.checkbox(&mut d.qsl_rcvd_yes, "QSL received (QSL_RCVD = Y)");
-                });
-
-                egui::CollapsingHeader::new("Incremental").show(ui, |ui| {
-                    ui.checkbox(&mut d.incremental, "Only contacts new since the last run");
-                    ui.add_enabled_ui(d.incremental, |ui| {
-                        ui.horizontal(|ui| {
-                            ui.label("Stream");
-                            ui.add(
-                                egui::TextEdit::singleline(&mut d.profile)
-                                    .hint_text("default")
-                                    .desired_width(120.0),
-                            );
-                        });
-                    });
-                    ui.label(
-                        egui::RichText::new(
-                            "Each named stream keeps its own position. Only an \
-                                 incremental export moves it — an ordinary filtered \
-                                 export never does.",
-                        )
-                        .small()
-                        .weak(),
-                    );
+                // ── what will be written: an echo of the shared filter ──
+                // Without this, opening Export from a filtered view and getting a
+                // filtered file would be a surprise.
+                ui.horizontal_wrapped(|ui| {
+                    ui.label(egui::RichText::new("Contacts:").strong());
+                    if self.qso_filter.is_active() {
+                        ui.label(self.qso_filter.summary());
+                    } else {
+                        ui.label("the whole log (no filter)");
+                    }
+                    if ui.small_button("Filter…").clicked() {
+                        open_filter = true;
+                    }
                 });
 
                 ui.separator();
+
+                let d = &mut self.export_draft;
 
                 // ── output ──
                 ui.horizontal(|ui| {
@@ -375,30 +314,65 @@ impl crate::ui::app::RigflowApp {
 
                 ui.separator();
 
-                // ── the live count + commit ──
+                // ── incremental ──
+                ui.checkbox(&mut d.incremental, "Only contacts new since the last run");
+                if d.incremental {
+                    ui.horizontal(|ui| {
+                        ui.label("Stream");
+                        ui.add(
+                            egui::TextEdit::singleline(&mut d.profile)
+                                .hint_text("default")
+                                .desired_width(120.0),
+                        );
+                    });
+                    ui.label(
+                        egui::RichText::new(
+                            "Each named stream keeps its own position, and only an \
+                             incremental export moves it — an ordinary filtered export \
+                             never does.",
+                        )
+                        .small()
+                        .weak(),
+                    );
+                }
+
+                ui.separator();
+
+                // ── the arithmetic, then the button ──
+                // With incremental on, the written set is a SUBSET of the visible
+                // list. Say so in numbers, rather than letting the operator find
+                // out by opening the file.
+                let matching = self.contacts_total;
+                if self.export_draft.incremental {
+                    match self.export_count {
+                        Some(n) => ui.label(format!(
+                            "{matching} match your filter · {n} new since the last export \
+                             · exporting {n}"
+                        )),
+                        None => ui.label(egui::RichText::new("counting…").weak()),
+                    };
+                } else {
+                    ui.label(format!(
+                        "exporting {matching} contact{}",
+                        if matching == 1 { "" } else { "s" }
+                    ));
+                }
+
                 ui.horizontal(|ui| {
                     let ready =
                         !self.export_busy && !self.export_draft.output_path.trim().is_empty();
                     if ui.add_enabled(ready, egui::Button::new("Export")).clicked() {
                         do_export = true;
                     }
-                    match self.export_count {
-                        Some(n) => ui.label(format!(
-                            "{n} contact{} match",
-                            if n == 1 { "" } else { "es" }
-                        )),
-                        None => ui.label(
-                            egui::RichText::new(if self.export_busy {
-                                "exporting…"
-                            } else {
-                                "counting…"
-                            })
-                            .weak(),
-                        ),
-                    };
+                    if self.export_busy {
+                        ui.label(egui::RichText::new("exporting…").weak());
+                    }
                 });
                 if !self.export_status.is_empty() {
                     ui.label(&self.export_status);
+                }
+                if !self.filter_error.is_empty() {
+                    ui.colored_label(egui::Color32::LIGHT_RED, &self.filter_error);
                 }
             });
 
@@ -420,9 +394,14 @@ impl crate::ui::app::RigflowApp {
             }
         }
 
+        if open_filter {
+            self.show_filter = true;
+        }
+
         if do_export {
+            let incremental = self.export_draft.incremental_profile();
             match (
-                self.export_draft.to_filter(),
+                self.qso_filter.to_filter(incremental),
                 self.export_draft.to_options(),
             ) {
                 (Ok(filter), Ok(options)) => {

--- a/rigflow-client/src/ui/app_export.rs
+++ b/rigflow-client/src/ui/app_export.rs
@@ -16,6 +16,69 @@ use eframe::egui;
 use crate::logging::export::{ExportDraft, ExportEvent, ExportJob, ProfileChoice, QUERY_DEBOUNCE};
 use crate::ui::panels::note_text;
 
+/// Shown when there is no native file picker. The path field is always editable,
+/// so a missing picker is an inconvenience, never a blocker.
+const NO_PICKER_HINT: &str = "No file picker available — type the path above. \
+     (Linux: this needs an xdg-desktop-portal backend that implements FileChooser, \
+     e.g. xdg-desktop-portal-gtk or -kde. The wlr backend does not.)";
+
+/// Whether a native save dialog can actually open.
+///
+/// We build `rfd` with the **xdg-portal** backend (deliberately: rfd's GTK
+/// backend would link GTK into the client). It talks to `xdg-desktop-portal` over
+/// D-Bus, and when the dialog can't open, `save_file()` simply returns `None` —
+/// indistinguishable from a cancel. So probe first, and disable the button rather
+/// than offer one that does nothing.
+///
+/// **Having the portal is not enough**: the frontend delegates each interface to a
+/// *backend*, and a backend only implements some of them.
+/// `xdg-desktop-portal-wlr` (Sway/wlroots) implements ScreenCast and Screenshot
+/// but **not FileChooser** — so on such a box the portal is running, the call is
+/// accepted, no backend can serve it, and the picker silently yields nothing.
+/// That is a real configuration, so the probe looks for a backend that actually
+/// declares `FileChooser`, not merely for the portal's presence.
+///
+/// This reads the backends' `.portal` manifests rather than making a live D-Bus
+/// call — cheap, and cached for the process. If it still guesses wrong, the
+/// timing check at the call site catches the failure.
+#[cfg(target_os = "linux")]
+fn file_picker_available() -> bool {
+    use std::sync::OnceLock;
+    static AVAILABLE: OnceLock<bool> = OnceLock::new();
+    *AVAILABLE.get_or_init(|| {
+        // A session bus to talk to at all.
+        let has_bus = std::env::var_os("DBUS_SESSION_BUS_ADDRESS").is_some()
+            || std::env::var_os("XDG_RUNTIME_DIR")
+                .map(|d| std::path::Path::new(&d).join("bus").exists())
+                .unwrap_or(false);
+        if !has_bus {
+            return false;
+        }
+
+        // A backend that implements FileChooser. Each backend ships a manifest at
+        // <data-dir>/xdg-desktop-portal/portals/<name>.portal listing the
+        // `org.freedesktop.impl.portal.*` interfaces it serves.
+        let data_dirs = std::env::var("XDG_DATA_DIRS")
+            .unwrap_or_else(|_| "/usr/local/share:/usr/share".to_string());
+        data_dirs.split(':').any(|dir| {
+            let portals = std::path::Path::new(dir).join("xdg-desktop-portal/portals");
+            let Ok(entries) = std::fs::read_dir(&portals) else {
+                return false;
+            };
+            entries.filter_map(Result::ok).any(|e| {
+                e.path().extension().is_some_and(|x| x == "portal")
+                    && std::fs::read_to_string(e.path()).is_ok_and(|s| s.contains("FileChooser"))
+            })
+        })
+    })
+}
+
+/// macOS and Windows have a native picker in the OS; nothing to probe.
+#[cfg(not(target_os = "linux"))]
+fn file_picker_available() -> bool {
+    true
+}
+
 impl crate::ui::app::RigflowApp {
     /// Open the export window, seeding a dated default path in the operator's
     /// data directory.
@@ -288,10 +351,22 @@ impl crate::ui::app::RigflowApp {
                 ui.horizontal(|ui| {
                     ui.label("File");
                     ui.add(egui::TextEdit::singleline(&mut d.output_path).desired_width(260.0));
-                    if ui.button("Browse…").clicked() {
+
+                    // No native picker → say so, instead of offering a button that
+                    // silently does nothing. The path field above is always usable,
+                    // so export is never blocked by a missing portal.
+                    let picker = file_picker_available();
+                    if ui
+                        .add_enabled(picker, egui::Button::new("Browse…"))
+                        .on_disabled_hover_text(NO_PICKER_HINT)
+                        .clicked()
+                    {
                         pick_path = true;
                     }
                 });
+                if !file_picker_available() {
+                    ui.label(note_text(NO_PICKER_HINT));
+                }
                 ui.horizontal(|ui| {
                     ui.label("Fields");
                     ui.selectable_value(&mut d.profile_choice, ProfileChoice::Full, "Full");
@@ -379,14 +454,30 @@ impl crate::ui::app::RigflowApp {
         if pick_path {
             let start = std::path::PathBuf::from(self.export_draft.output_path.trim());
             let mut dlg = rfd::FileDialog::new().add_filter("ADIF", &["adi", "adif"]);
+            // Only seed the directory if it exists; a portal rejects a bad one.
             if let Some(dir) = start.parent().filter(|p| p.is_dir()) {
                 dlg = dlg.set_directory(dir);
             }
             if let Some(name) = start.file_name().and_then(|n| n.to_str()) {
                 dlg = dlg.set_file_name(name);
             }
-            if let Some(path) = dlg.save_file() {
-                self.export_draft.output_path = path.to_string_lossy().into_owned();
+            // `save_file()` returns None for BOTH "operator cancelled" and "the
+            // dialog never opened", and rfd gives us no way to tell them apart.
+            // Time it: a cancel needs a human to see the dialog and click, which
+            // cannot happen in a few milliseconds, whereas a failing portal call
+            // returns immediately. An instant None is therefore a broken picker,
+            // and we say so instead of leaving the button a silent no-op.
+            let t0 = std::time::Instant::now();
+            let picked = dlg.save_file();
+            let instant = t0.elapsed() < std::time::Duration::from_millis(150);
+
+            match picked {
+                Some(path) => {
+                    self.export_draft.output_path = path.to_string_lossy().into_owned();
+                    self.export_status.clear();
+                }
+                None if instant => self.export_status = NO_PICKER_HINT.to_string(),
+                None => {} // a real cancel — nothing to say
             }
         }
 

--- a/rigflow-client/src/ui/app_export.rs
+++ b/rigflow-client/src/ui/app_export.rs
@@ -18,7 +18,7 @@ use crate::ui::panels::note_text;
 
 /// Shown when there is no native file picker. The path field is always editable,
 /// so a missing picker is an inconvenience, never a blocker.
-const NO_PICKER_HINT: &str = "No file picker available — type the path above. \
+pub(crate) const NO_PICKER_HINT: &str = "No file picker available. \
      (Linux: this needs an xdg-desktop-portal backend that implements FileChooser, \
      e.g. xdg-desktop-portal-gtk or -kde. The wlr backend does not.)";
 
@@ -42,7 +42,7 @@ const NO_PICKER_HINT: &str = "No file picker available — type the path above. 
 /// call — cheap, and cached for the process. If it still guesses wrong, the
 /// timing check at the call site catches the failure.
 #[cfg(target_os = "linux")]
-fn file_picker_available() -> bool {
+pub(crate) fn file_picker_available() -> bool {
     use std::sync::OnceLock;
     static AVAILABLE: OnceLock<bool> = OnceLock::new();
     *AVAILABLE.get_or_init(|| {
@@ -75,8 +75,14 @@ fn file_picker_available() -> bool {
 
 /// macOS and Windows have a native picker in the OS; nothing to probe.
 #[cfg(not(target_os = "linux"))]
-fn file_picker_available() -> bool {
+pub(crate) fn file_picker_available() -> bool {
     true
+}
+
+/// Export's variant of the hint: unlike import, it has a typed-path fallback, so
+/// a missing picker is an inconvenience rather than a blocker.
+fn no_picker_hint_export() -> String {
+    format!("{NO_PICKER_HINT} Type the path above instead.")
 }
 
 impl crate::ui::app::RigflowApp {
@@ -290,6 +296,24 @@ impl crate::ui::app::RigflowApp {
                     self.export_busy = false;
                     self.export_status = format!("export failed: {e}");
                 }
+
+                ExportEvent::ImportPlanned { file, result } => {
+                    self.import_planning = false;
+                    // Ignore a plan for a file the operator has already replaced.
+                    if self.import_file.as_ref() != Some(&file) {
+                        continue;
+                    }
+                    match result {
+                        Ok(plan) => {
+                            self.import_plan = Some(*plan);
+                            self.import_status.clear();
+                        }
+                        Err(e) => {
+                            self.import_plan = None;
+                            self.import_status = format!("could not read that file: {e}");
+                        }
+                    }
+                }
             }
         }
         if got {
@@ -358,14 +382,14 @@ impl crate::ui::app::RigflowApp {
                     let picker = file_picker_available();
                     if ui
                         .add_enabled(picker, egui::Button::new("Browse…"))
-                        .on_disabled_hover_text(NO_PICKER_HINT)
+                        .on_disabled_hover_text(no_picker_hint_export())
                         .clicked()
                     {
                         pick_path = true;
                     }
                 });
                 if !file_picker_available() {
-                    ui.label(note_text(NO_PICKER_HINT));
+                    ui.label(note_text(no_picker_hint_export()));
                 }
                 ui.horizontal(|ui| {
                     ui.label("Fields");
@@ -476,7 +500,7 @@ impl crate::ui::app::RigflowApp {
                     self.export_draft.output_path = path.to_string_lossy().into_owned();
                     self.export_status.clear();
                 }
-                None if instant => self.export_status = NO_PICKER_HINT.to_string(),
+                None if instant => self.export_status = no_picker_hint_export(),
                 None => {} // a real cancel — nothing to say
             }
         }

--- a/rigflow-client/src/ui/app_export.rs
+++ b/rigflow-client/src/ui/app_export.rs
@@ -314,6 +314,16 @@ impl crate::ui::app::RigflowApp {
                         }
                     }
                 }
+
+                ExportEvent::LotwSynced { result, marker } => match result {
+                    // Auto-commit: a sync applies its confirmations without a
+                    // per-run confirmation step (they only touch qso_service).
+                    Ok(plan) => self.apply_lotw_sync(*plan, marker),
+                    Err(e) => {
+                        self.sync_busy = false;
+                        self.sync_status = format!("LoTW sync failed: {e}");
+                    }
+                },
             }
         }
         if got {

--- a/rigflow-client/src/ui/app_export.rs
+++ b/rigflow-client/src/ui/app_export.rs
@@ -315,15 +315,9 @@ impl crate::ui::app::RigflowApp {
                     }
                 }
 
-                ExportEvent::LotwSynced { result, marker } => match result {
-                    // Auto-commit: a sync applies its confirmations without a
-                    // per-run confirmation step (they only touch qso_service).
-                    Ok(plan) => self.apply_lotw_sync(*plan, marker),
-                    Err(e) => {
-                        self.sync_busy = false;
-                        self.sync_status = format!("LoTW sync failed: {e}");
-                    }
-                },
+                ExportEvent::ServiceSynced { service, result } => {
+                    self.apply_service_sync(service, result)
+                }
             }
         }
         if got {

--- a/rigflow-client/src/ui/app_filter.rs
+++ b/rigflow-client/src/ui/app_filter.rs
@@ -1,0 +1,236 @@
+//! The contact **filter** window, opened from the contact view's `Filter…`
+//! button.
+//!
+//! This edits the *shared* [`QsoFilterDraft`] — the one filter that decides both
+//! which contacts the view lists and which an export writes. Editing it here
+//! re-queries the list (debounced) so the operator watches the match count move
+//! as they narrow it down, and then exports exactly that.
+//!
+//! Incremental ("only what's new since the last run") is deliberately **not**
+//! here: it isn't a property of a contact, it's a property of export progress,
+//! so it lives in the export window. See `logging::export`.
+
+use eframe::egui;
+
+use crate::logging::export::QsoFilterDraft;
+use rigflow_log::export::GridPrecision;
+use rigflow_log::normalize::ModeClass;
+
+impl crate::ui::app::RigflowApp {
+    pub(crate) fn draw_filter_window(&mut self, ctx: &egui::Context) {
+        if !self.show_filter {
+            return;
+        }
+
+        let mut open = true;
+        let mut clear = false;
+
+        egui::Window::new("Filter contacts")
+            .open(&mut open)
+            .default_width(470.0)
+            .show(ctx, |ui| {
+                let d = &mut self.qso_filter;
+
+                egui::CollapsingHeader::new("Date")
+                    .default_open(true)
+                    .show(ui, |ui| {
+                        ui.horizontal(|ui| {
+                            ui.label("From");
+                            ui.add(
+                                egui::TextEdit::singleline(&mut d.date_from)
+                                    .hint_text("YYYYMMDD")
+                                    .desired_width(90.0),
+                            );
+                            ui.label("To");
+                            ui.add(
+                                egui::TextEdit::singleline(&mut d.date_to)
+                                    .hint_text("YYYYMMDD")
+                                    .desired_width(90.0),
+                            );
+                        });
+                    });
+
+                egui::CollapsingHeader::new("Band & mode")
+                    .default_open(true)
+                    .show(ui, |ui| {
+                        ui.label("Bands (none = all)");
+                        egui::Grid::new("filter_bands")
+                            .num_columns(6)
+                            .show(ui, |ui| {
+                                for (i, band) in QsoFilterDraft::all_bands().into_iter().enumerate()
+                                {
+                                    let mut on = d.bands.contains(band);
+                                    if ui.checkbox(&mut on, band).changed() {
+                                        if on {
+                                            d.bands.insert(band.to_string());
+                                        } else {
+                                            d.bands.remove(band);
+                                        }
+                                    }
+                                    if i % 6 == 5 {
+                                        ui.end_row();
+                                    }
+                                }
+                            });
+                        ui.add_enabled(
+                            !d.bands.is_empty(),
+                            egui::Checkbox::new(
+                                &mut d.match_either_band,
+                                "also match the RX band (split across bands)",
+                            ),
+                        );
+
+                        ui.separator();
+                        ui.horizontal(|ui| {
+                            ui.label("Mode class");
+                            for c in ModeClass::ALL {
+                                let mut on = d.mode_classes.contains(c);
+                                if ui.checkbox(&mut on, c.as_str()).changed() {
+                                    if on {
+                                        d.mode_classes.insert(*c);
+                                    } else {
+                                        d.mode_classes.remove(c);
+                                    }
+                                }
+                            }
+                        });
+                        ui.horizontal(|ui| {
+                            ui.label("Modes");
+                            ui.add(
+                                egui::TextEdit::singleline(&mut d.modes)
+                                    .hint_text("SSB, CW, FT8")
+                                    .desired_width(150.0),
+                            );
+                            ui.label("Submodes");
+                            ui.add(
+                                egui::TextEdit::singleline(&mut d.submodes)
+                                    .hint_text("FT4")
+                                    .desired_width(100.0),
+                            );
+                        });
+                    });
+
+                egui::CollapsingHeader::new("Station").show(ui, |ui| {
+                    ui.horizontal(|ui| {
+                        ui.label("Call");
+                        ui.add(
+                            egui::TextEdit::singleline(&mut d.call_pattern)
+                                .hint_text("W1* or K?ZD")
+                                .desired_width(120.0),
+                        );
+                        ui.label("DXCC");
+                        ui.add(
+                            egui::TextEdit::singleline(&mut d.dxcc)
+                                .hint_text("291, 339")
+                                .desired_width(90.0),
+                        );
+                    });
+                    ui.horizontal(|ui| {
+                        ui.label("Their grid");
+                        ui.add(
+                            egui::TextEdit::singleline(&mut d.gridsquare)
+                                .hint_text("EM12")
+                                .desired_width(80.0),
+                        );
+                        egui::ComboBox::from_id_salt("grid_precision")
+                            .selected_text(match d.grid_precision {
+                                GridPrecision::Field => "field (2)",
+                                GridPrecision::Square => "square (4)",
+                                GridPrecision::Full => "exact",
+                            })
+                            .show_ui(ui, |ui| {
+                                ui.selectable_value(
+                                    &mut d.grid_precision,
+                                    GridPrecision::Field,
+                                    "field (2)",
+                                );
+                                ui.selectable_value(
+                                    &mut d.grid_precision,
+                                    GridPrecision::Square,
+                                    "square (4)",
+                                );
+                                ui.selectable_value(
+                                    &mut d.grid_precision,
+                                    GridPrecision::Full,
+                                    "exact",
+                                );
+                            });
+                    });
+                    ui.horizontal(|ui| {
+                        ui.label("My grid");
+                        ui.add(
+                            egui::TextEdit::singleline(&mut d.my_gridsquare)
+                                .hint_text("the grid you worked FROM")
+                                .desired_width(160.0),
+                        );
+                    })
+                    .response
+                    .on_hover_text(
+                        "Matches the grid recorded on each contact, so QSOs made from a \
+                         previous QTH are still found after you move.",
+                    );
+                    ui.horizontal(|ui| {
+                        ui.label("Contest");
+                        ui.add(
+                            egui::TextEdit::singleline(&mut d.contest_id)
+                                .hint_text("CQ-WW-SSB")
+                                .desired_width(140.0),
+                        );
+                    });
+                });
+
+                egui::CollapsingHeader::new("Confirmation").show(ui, |ui| {
+                    ui.label(
+                        egui::RichText::new(
+                            "Online-service state isn't tracked yet, so these match nothing \
+                             (or everything) until service sync lands.",
+                        )
+                        .small()
+                        .weak(),
+                    );
+                    ui.horizontal(|ui| {
+                        ui.label("Not uploaded to");
+                        ui.add(
+                            egui::TextEdit::singleline(&mut d.not_uploaded_to)
+                                .hint_text("lotw")
+                                .desired_width(80.0),
+                        );
+                        ui.label("Confirmed by");
+                        ui.add(
+                            egui::TextEdit::singleline(&mut d.confirmed_by)
+                                .hint_text("lotw")
+                                .desired_width(80.0),
+                        );
+                    });
+                    ui.checkbox(&mut d.qsl_rcvd_yes, "QSL received (QSL_RCVD = Y)");
+                });
+
+                ui.separator();
+
+                // The live result of the filter, in the window where it's being
+                // edited — so narrowing it down is a tight loop, not a hunt back
+                // to the contact list.
+                ui.horizontal(|ui| {
+                    if ui.button("Clear all").clicked() {
+                        clear = true;
+                    }
+                    if !self.filter_error.is_empty() {
+                        ui.colored_label(egui::Color32::LIGHT_RED, &self.filter_error);
+                    } else {
+                        ui.label(format!(
+                            "{} contact{} match",
+                            self.contacts_total,
+                            if self.contacts_total == 1 { "" } else { "es" }
+                        ));
+                    }
+                });
+            });
+
+        if clear {
+            self.qso_filter = QsoFilterDraft::default();
+        }
+        if !open {
+            self.show_filter = false;
+        }
+    }
+}

--- a/rigflow-client/src/ui/app_filter.rs
+++ b/rigflow-client/src/ui/app_filter.rs
@@ -38,13 +38,13 @@ impl crate::ui::app::RigflowApp {
                             ui.label("From");
                             ui.add(
                                 egui::TextEdit::singleline(&mut d.date_from)
-                                    .hint_text("YYYYMMDD")
+                                    .hint_text("YYYY-MM-DD")
                                     .desired_width(90.0),
                             );
                             ui.label("To");
                             ui.add(
                                 egui::TextEdit::singleline(&mut d.date_to)
-                                    .hint_text("YYYYMMDD")
+                                    .hint_text("YYYY-MM-DD")
                                     .desired_width(90.0),
                             );
                         });

--- a/rigflow-client/src/ui/app_filter.rs
+++ b/rigflow-client/src/ui/app_filter.rs
@@ -13,6 +13,7 @@
 use eframe::egui;
 
 use crate::logging::export::QsoFilterDraft;
+use crate::ui::panels::note_text;
 use rigflow_log::export::GridPrecision;
 use rigflow_log::normalize::ModeClass;
 
@@ -180,14 +181,10 @@ impl crate::ui::app::RigflowApp {
                 });
 
                 egui::CollapsingHeader::new("Confirmation").show(ui, |ui| {
-                    ui.label(
-                        egui::RichText::new(
-                            "Online-service state isn't tracked yet, so these match nothing \
-                             (or everything) until service sync lands.",
-                        )
-                        .small()
-                        .weak(),
-                    );
+                    ui.label(note_text(
+                        "Online-service state isn't tracked yet, so these match nothing \
+                         (or everything) until service sync lands.",
+                    ));
                     ui.horizontal(|ui| {
                         ui.label("Not uploaded to");
                         ui.add(

--- a/rigflow-client/src/ui/app_import.rs
+++ b/rigflow-client/src/ui/app_import.rs
@@ -70,7 +70,7 @@ impl RigflowApp {
             return;
         };
 
-        match store.commit_import(&plan.importable, &station) {
+        match store.commit_import(&plan.importable, &plan.confirmations, &station) {
             Ok(outcome) => {
                 // The worked-before index and the contact list both describe a log
                 // that just changed underneath them.
@@ -82,8 +82,21 @@ impl RigflowApp {
                     outcome.imported,
                     if outcome.imported == 1 { "" } else { "s" }
                 );
+                if outcome.confirmed > 0 {
+                    msg.push_str(&format!(
+                        " · {} confirmation{} recorded",
+                        outcome.confirmed,
+                        if outcome.confirmed == 1 { "" } else { "s" }
+                    ));
+                }
                 if plan.duplicates > 0 {
                     msg.push_str(&format!(" · {} duplicate(s) skipped", plan.duplicates));
+                }
+                if plan.unmatched_confirmations > 0 {
+                    msg.push_str(&format!(
+                        " · {} confirmation(s) matched nothing",
+                        plan.unmatched_confirmations
+                    ));
                 }
                 if !plan.unusable.is_empty() {
                     msg.push_str(&format!(" · {} unusable", plan.unusable.len()));
@@ -155,6 +168,14 @@ impl RigflowApp {
                     // ── the preview: what this file would do to the log ──
                     ui.label(egui::RichText::new(plan.summary()).strong());
 
+                    if !plan.confirmations.is_empty() || plan.unmatched_confirmations > 0 {
+                        ui.label(note_text(
+                            "Confirmations are QSL reports (e.g. from LoTW). They mark \
+                             contacts your log already has as confirmed — no new contacts \
+                             are added. Ones that match nothing in your log are skipped.",
+                        ));
+                    }
+
                     if plan.duplicates > 0 {
                         ui.label(note_text(
                             "Duplicates are contacts your log already has (same call, band \
@@ -182,14 +203,7 @@ impl RigflowApp {
                     ui.horizontal(|ui| {
                         let can = !plan.is_empty();
                         if ui
-                            .add_enabled(
-                                can,
-                                egui::Button::new(format!(
-                                    "Import {} contact{}",
-                                    plan.importable.len(),
-                                    if plan.importable.len() == 1 { "" } else { "s" }
-                                )),
-                            )
+                            .add_enabled(can, egui::Button::new(import_button_label(plan)))
                             .on_disabled_hover_text("Nothing in this file is new to your log.")
                             .clicked()
                         {
@@ -238,5 +252,20 @@ impl RigflowApp {
         if !open {
             self.show_import = false;
         }
+    }
+}
+
+/// The commit button's label, tuned to what the plan actually does: adding
+/// contacts, recording confirmations, or both. A LoTW report is all
+/// confirmations and no contacts, so "Import 0 contacts" would read as a bug.
+fn import_button_label(plan: &rigflow_log::import::ImportPlan) -> String {
+    let n = plan.importable.len();
+    let m = plan.confirmations.len();
+    let contacts = |n: usize| format!("{n} contact{}", if n == 1 { "" } else { "s" });
+    let confs = |m: usize| format!("{m} confirmation{}", if m == 1 { "" } else { "s" });
+    match (n, m) {
+        (0, m) => format!("Record {}", confs(m)),
+        (n, 0) => format!("Import {}", contacts(n)),
+        (n, m) => format!("Import {} & record {}", contacts(n), confs(m)),
     }
 }

--- a/rigflow-client/src/ui/app_import.rs
+++ b/rigflow-client/src/ui/app_import.rs
@@ -1,0 +1,242 @@
+//! The ADIF **import** window, opened from the contact view.
+//!
+//! Two phases, mirroring the library ([`rigflow_log::import`]):
+//!
+//! 1. **Plan** — pick a file; the worker parses, normalizes, validates and
+//!    dedupes it against the log on its **read-only** connection, and reports
+//!    *"1,483 records · 1,471 to import · 12 duplicates (skipped) · 3 unusable"*.
+//!    Nothing has been written. The operator sees what the file would do to their
+//!    log before agreeing to it — the same promise the export window makes.
+//! 2. **Commit** — one transaction, one journal write, one fsync, all-or-nothing,
+//!    on the UI thread's read-write `LogStore`.
+//!
+//! Duplicates are skipped on the same ±30-minute rule the WSJT-X path uses, which
+//! makes import **idempotent**: importing the same file twice adds nothing the
+//! second time. Bad records are skipped and named, never fatal — a twenty-year log
+//! from another program will have cruft, and refusing 20,000 contacts over three
+//! junk rows would be hostile.
+
+use eframe::egui;
+
+use crate::logging::export::ExportJob;
+use crate::ui::app::RigflowApp;
+use crate::ui::app_export::{NO_PICKER_HINT, file_picker_available};
+use crate::ui::panels::note_text;
+
+impl RigflowApp {
+    /// Open the import window (empty — the operator picks a file next).
+    pub(crate) fn open_import(&mut self) {
+        self.import_file = None;
+        self.import_plan = None;
+        self.import_planning = false;
+        self.import_status.clear();
+        self.show_import = true;
+    }
+
+    /// Hand a chosen file to the worker to plan.
+    fn plan_import(&mut self, operator_id: &str, file: std::path::PathBuf) {
+        self.import_plan = None;
+        self.import_planning = true;
+        self.import_status.clear();
+        self.import_file = Some(file.clone());
+        let _ = self.export_tx.send(ExportJob::PlanImport {
+            db_path: self.persistence_store.qso_log_db_path(operator_id),
+            file,
+        });
+    }
+
+    /// Commit the planned contacts.
+    ///
+    /// Runs on the UI thread, on the store this thread owns. It is a single
+    /// transaction with one fsync — fast enough that even a large log lands in
+    /// well under a second — so it does not need the worker, and putting it there
+    /// would mean a second writer on the same database for no gain.
+    fn commit_import(&mut self) {
+        let Some(plan) = self.import_plan.take() else {
+            return;
+        };
+        let (op, name, profile) = {
+            let s = self.state.lock().unwrap();
+            (
+                s.operator_id.clone(),
+                s.operator_name.clone(),
+                s.station_profile.clone(),
+            )
+        };
+        let station = profile.to_log_station(&op, &name);
+
+        let Some(store) = self.log.as_mut() else {
+            self.import_status = "no operator selected — nothing imported".to_string();
+            return;
+        };
+
+        match store.commit_import(&plan.importable, &station) {
+            Ok(outcome) => {
+                // The worked-before index and the contact list both describe a log
+                // that just changed underneath them.
+                self.worked_before = store.load_worked_before().unwrap_or_default();
+                self.contacts_cache_dirty = true;
+
+                let mut msg = format!(
+                    "imported {} contact{}",
+                    outcome.imported,
+                    if outcome.imported == 1 { "" } else { "s" }
+                );
+                if plan.duplicates > 0 {
+                    msg.push_str(&format!(" · {} duplicate(s) skipped", plan.duplicates));
+                }
+                if !plan.unusable.is_empty() {
+                    msg.push_str(&format!(" · {} unusable", plan.unusable.len()));
+                }
+                if !outcome.journal_appended {
+                    msg.push_str(" (journal not written)");
+                }
+                self.import_status = msg.clone();
+                self.set_log_status(msg);
+                self.import_file = None;
+            }
+            // Atomic: nothing was written, so the log is exactly as it was.
+            Err(e) => self.import_status = format!("import failed, nothing written: {e}"),
+        }
+    }
+
+    pub(crate) fn draw_import_window(
+        &mut self,
+        ctx: &egui::Context,
+        snapshot: &crate::ui::state::UiState,
+    ) {
+        if !self.show_import {
+            return;
+        }
+        let operator_id = snapshot.operator_id.clone();
+        if operator_id.trim().is_empty() || self.log.is_none() {
+            self.show_import = false;
+            return;
+        }
+
+        let mut open = true;
+        let mut pick = false;
+        let mut do_import = false;
+
+        egui::Window::new("Import ADIF")
+            .open(&mut open)
+            .default_width(520.0)
+            .show(ctx, |ui| {
+                ui.horizontal(|ui| {
+                    ui.label("File");
+                    let name = self
+                        .import_file
+                        .as_ref()
+                        .map(|p| p.display().to_string())
+                        .unwrap_or_else(|| "— none chosen —".to_string());
+                    ui.label(name);
+                });
+                ui.horizontal(|ui| {
+                    let picker = file_picker_available();
+                    if ui
+                        .add_enabled(picker, egui::Button::new("Choose file…"))
+                        .on_disabled_hover_text(NO_PICKER_HINT)
+                        .clicked()
+                    {
+                        pick = true;
+                    }
+                });
+                if !file_picker_available() {
+                    // Import has no typed-path fallback the way export does — a
+                    // file has to exist to be read — so say what to install.
+                    ui.label(note_text(NO_PICKER_HINT));
+                }
+
+                ui.separator();
+
+                if self.import_planning {
+                    ui.label("reading the file…");
+                } else if let Some(plan) = &self.import_plan {
+                    // ── the preview: what this file would do to the log ──
+                    ui.label(egui::RichText::new(plan.summary()).strong());
+
+                    if plan.duplicates > 0 {
+                        ui.label(note_text(
+                            "Duplicates are contacts your log already has (same call, band \
+                             and mode, within 30 minutes). They are skipped, so importing \
+                             the same file twice is safe.",
+                        ));
+                    }
+
+                    if !plan.unusable.is_empty() {
+                        ui.separator();
+                        ui.label(note_text(
+                            "These records could not be imported. Everything else still will be:",
+                        ));
+                        egui::ScrollArea::vertical()
+                            .max_height(120.0)
+                            .id_salt("import_problems")
+                            .show(ui, |ui| {
+                                for p in &plan.unusable {
+                                    ui.label(p.to_string());
+                                }
+                            });
+                    }
+
+                    ui.separator();
+                    ui.horizontal(|ui| {
+                        let can = !plan.is_empty();
+                        if ui
+                            .add_enabled(
+                                can,
+                                egui::Button::new(format!(
+                                    "Import {} contact{}",
+                                    plan.importable.len(),
+                                    if plan.importable.len() == 1 { "" } else { "s" }
+                                )),
+                            )
+                            .on_disabled_hover_text("Nothing in this file is new to your log.")
+                            .clicked()
+                        {
+                            do_import = true;
+                        }
+                        if !can {
+                            ui.label("nothing to import");
+                        }
+                    });
+                } else if self.import_file.is_some() && self.import_status.is_empty() {
+                    ui.label("reading the file…");
+                } else if self.import_file.is_none() {
+                    ui.label(note_text(
+                        "Choose an ADIF file (.adi) to see what importing it would do. \
+                         Nothing is written until you confirm.",
+                    ));
+                }
+
+                if !self.import_status.is_empty() {
+                    ui.separator();
+                    ui.label(&self.import_status);
+                }
+            });
+
+        // Native picker: synchronous, so it blocks the UI thread while open. The
+        // media runtime and audio live on other threads and keep running.
+        if pick {
+            let mut dlg = rfd::FileDialog::new().add_filter("ADIF", &["adi", "adif"]);
+            if let Some(dir) = self
+                .persistence_store
+                .qso_log_db_path(&operator_id)
+                .parent()
+                .filter(|p| p.is_dir())
+            {
+                dlg = dlg.set_directory(dir);
+            }
+            if let Some(path) = dlg.pick_file() {
+                self.plan_import(&operator_id, path);
+            }
+        }
+
+        if do_import {
+            self.commit_import();
+        }
+
+        if !open {
+            self.show_import = false;
+        }
+    }
+}

--- a/rigflow-client/src/ui/app_logging.rs
+++ b/rigflow-client/src/ui/app_logging.rs
@@ -247,36 +247,94 @@ impl RigflowApp {
         }
     }
 
-    /// Draw the contact-view window: a table of logged contacts, most recent
-    /// first. Built to grow a filter bar in a later phase.
+    /// Draw the contact-view window: the toolbar (call lookup, filter, export,
+    /// refresh), the active-filter summary, and the table of matching contacts.
+    ///
+    /// The list is produced by the **same filter the export writes**, so the
+    /// operator can see what they are about to export. The row count is capped
+    /// (`VIEW_ROW_LIMIT`) but the *total* is always shown alongside — a capped
+    /// list that didn't say so would quietly break that promise.
     pub(crate) fn draw_contact_view_window(&mut self, ctx: &egui::Context, snapshot: &UiState) {
         if !snapshot.show_contact_view {
             return;
         }
-        if self.contacts_cache_dirty {
-            self.refresh_contacts_cache();
-        }
+        let operator_id = snapshot.operator_id.clone();
+        self.maybe_requery_contacts(&operator_id, ctx);
 
         let mut open = true;
         let mut open_export = false;
+        let mut open_filter = false;
+        let mut clear_filter = false;
+
         egui::Window::new("Contacts")
             .open(&mut open)
-            .default_width(560.0)
-            .default_height(400.0)
+            .default_width(620.0)
+            .default_height(440.0)
             .show(ctx, |ui| {
                 if self.log.is_none() {
                     ui.label("Set an operator to view its contact log.");
                     return;
                 }
+
+                // ── toolbar ──
                 ui.horizontal(|ui| {
-                    ui.label(format!("{} contacts", self.contacts_cache.len()));
-                    if ui.button("Refresh").clicked() {
-                        self.contacts_cache_dirty = true;
+                    ui.label("Call:");
+                    let r = ui.add(
+                        egui::TextEdit::singleline(&mut self.call_lookup)
+                            .hint_text("worked before?")
+                            .desired_width(110.0),
+                    );
+                    if r.changed() {
+                        // Live as you type: mid-QSO the operator needs a yes/no
+                        // now, not after finding and pressing a button.
+                        self.call_lookup_due = Some(
+                            std::time::Instant::now() + crate::logging::export::QUERY_DEBOUNCE,
+                        );
+                        if self.call_lookup.trim().is_empty() {
+                            self.call_lookup_hits = None;
+                        }
+                    }
+                    if ui.button("Filter…").clicked() {
+                        open_filter = true;
                     }
                     if ui.button("Export…").clicked() {
                         open_export = true;
                     }
+                    if ui.button("Refresh").clicked() {
+                        self.contacts_cache_dirty = true;
+                    }
                 });
+
+                // ── active-filter summary ──
+                // Always visible when filtering. A short list with no visible
+                // reason is the single most confusing thing this window could do.
+                if self.qso_filter.is_active() {
+                    ui.horizontal_wrapped(|ui| {
+                        ui.label(egui::RichText::new("Filtered:").strong());
+                        ui.label(self.qso_filter.summary());
+                        if ui
+                            .small_button("✕ clear")
+                            .on_hover_text("Remove all filters")
+                            .clicked()
+                        {
+                            clear_filter = true;
+                        }
+                    });
+                }
+
+                if !self.filter_error.is_empty() {
+                    ui.colored_label(egui::Color32::LIGHT_RED, &self.filter_error);
+                } else {
+                    let shown = self.contacts_cache.len();
+                    let total = self.contacts_total;
+                    ui.label(if shown < total {
+                        // The cap is load-bearing information, not a detail.
+                        format!("showing {shown} of {total} matching")
+                    } else {
+                        format!("{total} contact{}", if total == 1 { "" } else { "s" })
+                    });
+                }
+
                 ui.separator();
 
                 egui::ScrollArea::vertical().show(ui, |ui| {
@@ -304,13 +362,120 @@ impl RigflowApp {
                         });
                 });
             });
-        if open_export {
-            self.open_export(&snapshot.operator_id);
+
+        self.draw_call_lookup_popup(ctx);
+
+        if clear_filter {
+            self.qso_filter = Default::default();
         }
-        if !open {
-            if let Ok(mut s) = self.state.lock() {
-                s.show_contact_view = false;
-            }
+        if open_filter {
+            self.show_filter = true;
+        }
+        if open_export {
+            self.open_export(&operator_id);
+        }
+        if !open && let Ok(mut s) = self.state.lock() {
+            s.show_contact_view = false;
+        }
+    }
+
+    /// The quick "have I worked this station?" popup.
+    ///
+    /// Leads with the **verdict**, not the data: mid-QSO the operator needs
+    /// "new call" or "worked 3×" in under a second, and only then the rows. The
+    /// headline comes from the in-memory worked-before index (no query at all);
+    /// the rows come from the worker.
+    ///
+    /// It searches the **whole log** and never touches the view filter — "have I
+    /// ever worked this station" is a question about the log, not about whatever
+    /// the operator happens to be looking at.
+    fn draw_call_lookup_popup(&mut self, ctx: &egui::Context) {
+        let call = self.call_lookup.trim().to_ascii_uppercase();
+        if call.is_empty() {
+            return;
+        }
+        // Escape dismisses — a popup you can only close by aiming at a button is
+        // an annoyance when you're in the middle of a contact.
+        if ctx.input(|i| i.key_pressed(egui::Key::Escape)) {
+            self.call_lookup.clear();
+            self.call_lookup_hits = None;
+            return;
+        }
+
+        let is_new = self.worked_before.is_new_call(&call);
+        let mut dismiss = false;
+
+        egui::Window::new(format!("Worked {call}?"))
+            .collapsible(false)
+            .resizable(false)
+            .anchor(egui::Align2::RIGHT_TOP, [-16.0, 64.0])
+            .show(ctx, |ui| {
+                // Verdict first, from the in-memory index — instant, no DB hit.
+                if is_new {
+                    ui.label(
+                        egui::RichText::new("NEW CALL")
+                            .heading()
+                            .color(egui::Color32::LIGHT_GREEN),
+                    );
+                } else {
+                    match &self.call_lookup_hits {
+                        Some(page) if page.total > 0 => {
+                            let last = &page.rows[0].qso; // newest-first
+                            ui.label(
+                                egui::RichText::new(format!("Worked {}×", page.total))
+                                    .heading()
+                                    .color(egui::Color32::LIGHT_YELLOW),
+                            );
+                            ui.label(format!(
+                                "last {} · {} {}",
+                                last.qso_date, last.band, last.mode
+                            ));
+                        }
+                        // The index says worked, the rows haven't landed yet.
+                        _ => {
+                            ui.label(egui::RichText::new("Worked before").heading());
+                            ui.label(egui::RichText::new("looking up…").weak());
+                        }
+                    }
+                }
+
+                if let Some(page) = &self.call_lookup_hits
+                    && page.total > 0
+                {
+                    ui.separator();
+                    egui::ScrollArea::vertical()
+                        .max_height(160.0)
+                        .show(ui, |ui| {
+                            egui::Grid::new("call_lookup_table")
+                                .num_columns(4)
+                                .striped(true)
+                                .spacing([10.0, 2.0])
+                                .show(ui, |ui| {
+                                    for h in ["Date", "Time", "Band", "Mode"] {
+                                        ui.strong(h);
+                                    }
+                                    ui.end_row();
+                                    for row in &page.rows {
+                                        let q = &row.qso;
+                                        ui.label(&q.qso_date);
+                                        ui.label(q.time_on.get(..4).unwrap_or(&q.time_on));
+                                        ui.label(&q.band);
+                                        ui.label(&q.mode);
+                                        ui.end_row();
+                                    }
+                                });
+                        });
+                }
+
+                ui.separator();
+                if ui.button("Dismiss").clicked() {
+                    dismiss = true;
+                }
+            });
+
+        if dismiss {
+            self.call_lookup.clear();
+            self.call_lookup_hits = None;
         }
     }
 }

--- a/rigflow-client/src/ui/app_logging.rs
+++ b/rigflow-client/src/ui/app_logging.rs
@@ -1,0 +1,309 @@
+//! The logging UI surfaces: the manual entry window (`L`) and the contact-view
+//! window (`V`).
+//!
+//! Both are floating `egui::Window`s (non-blocking, so the operator can keep
+//! tuning while logging). The entry window freezes the radio snapshot the
+//! instant it opens — time, TX/RX frequency, and mode — so the logged values
+//! reflect when contact was made, not when the operator finally saves.
+
+use std::collections::BTreeMap;
+
+use eframe::egui;
+
+use crate::logging::LogEntryDraft;
+use crate::logging::capture;
+use crate::ui::app::RigflowApp;
+use crate::ui::state::UiState;
+
+impl RigflowApp {
+    /// Open the manual entry window, freezing the current radio state into the
+    /// draft. Called from the `L` hotkey.
+    pub(crate) fn open_log_entry(&mut self, snapshot: &UiState) {
+        let captured = capture::capture_radio_state(snapshot);
+        let (qso_date, time_on) = rigflow_log::now_utc_adif();
+        let derived_rx = captured.derive_freq_rx();
+        let mode = capture::effective_tx_mode(snapshot);
+
+        let draft = LogEntryDraft {
+            call: String::new(),
+            rst_sent: capture::default_rst(mode).to_string(),
+            rst_rcvd: capture::default_rst(mode).to_string(),
+            name: String::new(),
+            comment: String::new(),
+            gridsquare: String::new(),
+            mode: captured.tx_mode.clone(),
+            freq_rx_hz_str: derived_rx.map(|h| h.to_string()).unwrap_or_default(),
+            qso_date,
+            time_on,
+            tx_freq_hz: captured.tx_freq_hz,
+            split_active: captured.split_active,
+            derived_freq_rx_hz: derived_rx,
+        };
+
+        if let Ok(mut s) = self.state.lock() {
+            s.log_entry_draft = draft;
+            s.show_log_entry = true;
+            s.log_entry_focus_pending = true;
+            s.log_status.clear();
+        }
+    }
+
+    /// Draw the manual entry window. Enter saves, Esc closes.
+    pub(crate) fn draw_log_entry_window(&mut self, ctx: &egui::Context, snapshot: &UiState) {
+        if !snapshot.show_log_entry {
+            return;
+        }
+
+        let mut save = false;
+        let mut cancel = false;
+        // Live-edited copy of the draft; written back after the window closure.
+        let mut draft = snapshot.log_entry_draft.clone();
+        let focus_pending = snapshot.log_entry_focus_pending;
+        let mut focus_consumed = false;
+
+        egui::Window::new("Log Contact")
+            .collapsible(false)
+            .resizable(false)
+            .default_width(320.0)
+            .show(ctx, |ui| {
+                // Frozen capture — read-only.
+                let tx_mhz = draft.tx_freq_hz as f64 / 1_000_000.0;
+                if draft.split_active {
+                    let rx_txt = draft
+                        .derived_freq_rx_hz
+                        .map(|h| format!("{:.4}", h as f64 / 1_000_000.0))
+                        .unwrap_or_else(|| "—".to_string());
+                    ui.label(format!("{tx_mhz:.4} ↑ / {rx_txt} ↓ MHz  ({})", draft.mode));
+                } else {
+                    ui.label(format!("{tx_mhz:.4} MHz  ({})", draft.mode));
+                }
+                ui.label(format!("{} {}Z UTC", draft.qso_date, &draft.time_on[..4]));
+                ui.separator();
+
+                egui::Grid::new("log_entry_grid")
+                    .num_columns(2)
+                    .spacing([8.0, 4.0])
+                    .show(ui, |ui| {
+                        ui.label("Call");
+                        let call_resp = ui.text_edit_singleline(&mut draft.call);
+                        if focus_pending && !focus_consumed {
+                            call_resp.request_focus();
+                            focus_consumed = true;
+                        }
+                        ui.end_row();
+
+                        ui.label("RST sent");
+                        ui.text_edit_singleline(&mut draft.rst_sent);
+                        ui.end_row();
+                        ui.label("RST rcvd");
+                        ui.text_edit_singleline(&mut draft.rst_rcvd);
+                        ui.end_row();
+                        ui.label("Mode");
+                        ui.text_edit_singleline(&mut draft.mode);
+                        ui.end_row();
+                        if draft.split_active {
+                            ui.label("FREQ_RX (Hz)");
+                            ui.text_edit_singleline(&mut draft.freq_rx_hz_str);
+                            ui.end_row();
+                        }
+                        ui.label("Name");
+                        ui.text_edit_singleline(&mut draft.name);
+                        ui.end_row();
+                        ui.label("Grid");
+                        ui.text_edit_singleline(&mut draft.gridsquare);
+                        ui.end_row();
+                        ui.label("Comment");
+                        ui.text_edit_singleline(&mut draft.comment);
+                        ui.end_row();
+                    });
+
+                // Live "worked before?" hints from the in-memory index.
+                self.show_worked_before_hints(ui, &draft);
+
+                ui.separator();
+                ui.horizontal(|ui| {
+                    if ui.button("Cancel").clicked() {
+                        cancel = true;
+                    }
+                    let can_save = !draft.call.trim().is_empty();
+                    if ui
+                        .add_enabled(can_save, egui::Button::new("Log (Enter)"))
+                        .clicked()
+                    {
+                        save = true;
+                    }
+                });
+
+                if !snapshot.log_status.is_empty() {
+                    ui.colored_label(egui::Color32::LIGHT_GREEN, &snapshot.log_status);
+                }
+            });
+
+        // Keyboard: Enter saves (if a call is present), Esc closes.
+        let (enter, esc) = ctx.input(|i| {
+            (
+                i.key_pressed(egui::Key::Enter),
+                i.key_pressed(egui::Key::Escape),
+            )
+        });
+        if enter && !draft.call.trim().is_empty() {
+            save = true;
+        }
+        if esc {
+            cancel = true;
+        }
+
+        // Persist the live edits + focus consumption back into UiState.
+        if let Ok(mut s) = self.state.lock() {
+            s.log_entry_draft = draft;
+            if focus_consumed {
+                s.log_entry_focus_pending = false;
+            }
+        }
+
+        if cancel {
+            if let Ok(mut s) = self.state.lock() {
+                s.show_log_entry = false;
+                s.log_entry_draft = LogEntryDraft::default();
+            }
+        } else if save {
+            self.commit_log_entry();
+        }
+    }
+
+    fn show_worked_before_hints(&self, ui: &mut egui::Ui, draft: &LogEntryDraft) {
+        let call = draft.call.trim();
+        if call.is_empty() {
+            return;
+        }
+        let band = rigflow_log::normalize::band_for_freq_hz(draft.tx_freq_hz).unwrap_or("");
+        if self.worked_before.is_new_call(call) {
+            ui.colored_label(egui::Color32::LIGHT_GREEN, "New callsign");
+        } else if self.worked_before.is_new_band(call, band) {
+            ui.colored_label(
+                egui::Color32::YELLOW,
+                format!("Worked before — new on {band}"),
+            );
+        } else {
+            ui.colored_label(egui::Color32::GRAY, "Worked before on this band");
+        }
+    }
+
+    /// Build a `Qso` from the current draft and log it.
+    fn commit_log_entry(&mut self) {
+        let draft = {
+            let s = self.state.lock().unwrap();
+            s.log_entry_draft.clone()
+        };
+        if draft.call.trim().is_empty() {
+            self.set_log_status("callsign required".to_string());
+            return;
+        }
+
+        let mut extra = BTreeMap::new();
+        for (k, v) in [
+            ("NAME", draft.name.trim()),
+            ("COMMENT", draft.comment.trim()),
+        ] {
+            if !v.is_empty() {
+                extra.insert(k.to_string(), v.to_string());
+            }
+        }
+
+        // FREQ_RX only for a real split QSO; the user may have cleared/edited it.
+        let freq_rx_hz = if draft.split_active {
+            draft.freq_rx_hz_str.trim().parse::<u64>().ok()
+        } else {
+            None
+        };
+
+        let opt = |s: &str| {
+            let t = s.trim();
+            (!t.is_empty()).then(|| t.to_string())
+        };
+
+        let qso = rigflow_log::Qso {
+            call: draft.call.trim().to_ascii_uppercase(),
+            qso_date: draft.qso_date.clone(),
+            time_on: draft.time_on.clone(),
+            band: String::new(), // derived from freq_hz by normalize()
+            mode: draft.mode.clone(),
+            submode: None,
+            freq_hz: Some(draft.tx_freq_hz),
+            freq_rx_hz,
+            band_rx: None, // derived from freq_rx_hz by normalize()
+            rst_sent: opt(&draft.rst_sent),
+            rst_rcvd: opt(&draft.rst_rcvd),
+            gridsquare: opt(&draft.gridsquare),
+            dxcc: None,
+            extra,
+        };
+
+        self.log_contact(qso);
+
+        if let Ok(mut s) = self.state.lock() {
+            s.show_log_entry = false;
+            s.log_entry_draft = LogEntryDraft::default();
+        }
+    }
+
+    /// Draw the contact-view window: a table of logged contacts, most recent
+    /// first. Built to grow a filter bar in a later phase.
+    pub(crate) fn draw_contact_view_window(&mut self, ctx: &egui::Context, snapshot: &UiState) {
+        if !snapshot.show_contact_view {
+            return;
+        }
+        if self.contacts_cache_dirty {
+            self.refresh_contacts_cache();
+        }
+
+        let mut open = true;
+        egui::Window::new("Contacts")
+            .open(&mut open)
+            .default_width(560.0)
+            .default_height(400.0)
+            .show(ctx, |ui| {
+                if self.log.is_none() {
+                    ui.label("Set an operator to view its contact log.");
+                    return;
+                }
+                ui.horizontal(|ui| {
+                    ui.label(format!("{} contacts", self.contacts_cache.len()));
+                    if ui.button("Refresh").clicked() {
+                        self.contacts_cache_dirty = true;
+                    }
+                });
+                ui.separator();
+
+                egui::ScrollArea::vertical().show(ui, |ui| {
+                    egui::Grid::new("contacts_table")
+                        .num_columns(6)
+                        .striped(true)
+                        .spacing([12.0, 2.0])
+                        .show(ui, |ui| {
+                            for h in ["Date", "Time", "Call", "Band", "Mode", "Confirm"] {
+                                ui.strong(h);
+                            }
+                            ui.end_row();
+                            for row in &self.contacts_cache {
+                                let q = &row.qso;
+                                ui.label(&q.qso_date);
+                                ui.label(q.time_on.get(..4).unwrap_or(&q.time_on));
+                                ui.label(&q.call);
+                                ui.label(&q.band);
+                                ui.label(&q.mode);
+                                // Per-service confirmation badge slots — empty in
+                                // phase 1 (populated once service sync lands).
+                                ui.label("—");
+                                ui.end_row();
+                            }
+                        });
+                });
+            });
+        if !open {
+            if let Ok(mut s) = self.state.lock() {
+                s.show_contact_view = false;
+            }
+        }
+    }
+}

--- a/rigflow-client/src/ui/app_logging.rs
+++ b/rigflow-client/src/ui/app_logging.rs
@@ -14,6 +14,7 @@ use crate::logging::LogEntryDraft;
 use crate::logging::capture;
 use crate::ui::app::RigflowApp;
 use crate::ui::state::UiState;
+use rigflow_log::display;
 
 impl RigflowApp {
     /// Open the manual entry window, freezing the current radio state into the
@@ -77,7 +78,15 @@ impl RigflowApp {
                 } else {
                     ui.label(format!("{tx_mhz:.4} MHz  ({})", draft.mode));
                 }
-                ui.label(format!("{} {}Z UTC", draft.qso_date, &draft.time_on[..4]));
+                // Seconds shown here (unlike the list): this is the frozen instant
+                // the contact will be logged at, so the operator is checking it.
+                // Formatted via the helpers rather than sliced — `&time_on[..4]`
+                // would panic on any value shorter than 4 chars.
+                ui.label(format!(
+                    "{} {}Z UTC",
+                    display::date(&draft.qso_date),
+                    display::time_hhmmss(&draft.time_on)
+                ));
                 ui.separator();
 
                 egui::Grid::new("log_entry_grid")
@@ -343,14 +352,14 @@ impl RigflowApp {
                         .striped(true)
                         .spacing([12.0, 2.0])
                         .show(ui, |ui| {
-                            for h in ["Date", "Time", "Call", "Band", "Mode", "Confirm"] {
+                            for h in ["Date", "Time (UTC)", "Call", "Band", "Mode", "Confirm"] {
                                 ui.strong(h);
                             }
                             ui.end_row();
                             for row in &self.contacts_cache {
                                 let q = &row.qso;
-                                ui.label(&q.qso_date);
-                                ui.label(q.time_on.get(..4).unwrap_or(&q.time_on));
+                                ui.label(display::date(&q.qso_date));
+                                ui.label(display::time_hhmm(&q.time_on));
                                 ui.label(&q.call);
                                 ui.label(&q.band);
                                 ui.label(&q.mode);
@@ -428,7 +437,9 @@ impl RigflowApp {
                             );
                             ui.label(format!(
                                 "last {} · {} {}",
-                                last.qso_date, last.band, last.mode
+                                display::date(&last.qso_date),
+                                last.band,
+                                last.mode
                             ));
                         }
                         // The index says worked, the rows haven't landed yet.
@@ -451,14 +462,14 @@ impl RigflowApp {
                                 .striped(true)
                                 .spacing([10.0, 2.0])
                                 .show(ui, |ui| {
-                                    for h in ["Date", "Time", "Band", "Mode"] {
+                                    for h in ["Date", "Time (UTC)", "Band", "Mode"] {
                                         ui.strong(h);
                                     }
                                     ui.end_row();
                                     for row in &page.rows {
                                         let q = &row.qso;
-                                        ui.label(&q.qso_date);
-                                        ui.label(q.time_on.get(..4).unwrap_or(&q.time_on));
+                                        ui.label(display::date(&q.qso_date));
+                                        ui.label(display::time_hhmm(&q.time_on));
                                         ui.label(&q.band);
                                         ui.label(&q.mode);
                                         ui.end_row();

--- a/rigflow-client/src/ui/app_logging.rs
+++ b/rigflow-client/src/ui/app_logging.rs
@@ -13,8 +13,97 @@ use eframe::egui;
 use crate::logging::LogEntryDraft;
 use crate::logging::capture;
 use crate::ui::app::RigflowApp;
+use crate::ui::panels::note_text;
 use crate::ui::state::UiState;
 use rigflow_log::display;
+
+/// The editable state of one contact open in the edit window. Holds the original
+/// [`rigflow_log::Qso`] so `extra` (the MY_* snapshot, imported fields, QSL data)
+/// and any column the form doesn't expose survive the edit untouched.
+pub(crate) struct ContactEdit {
+    pub id: i64,
+    original: rigflow_log::Qso,
+    call: String,
+    qso_date: String,
+    time_on: String,
+    mode: String,
+    freq_mhz: String,
+    rst_sent: String,
+    rst_rcvd: String,
+    gridsquare: String,
+    /// Last validation / save error, shown under the form. Empty = none.
+    error: String,
+}
+
+impl ContactEdit {
+    fn from_logged(row: &rigflow_log::store::LoggedQso) -> Self {
+        let q = &row.qso;
+        ContactEdit {
+            id: row.id,
+            original: q.clone(),
+            call: q.call.clone(),
+            qso_date: q.qso_date.clone(),
+            time_on: q.time_on.clone(),
+            mode: q.mode.clone(),
+            freq_mhz: q
+                .freq_hz
+                .map(rigflow_log::adif::hz_to_mhz_string)
+                .unwrap_or_default(),
+            rst_sent: q.rst_sent.clone().unwrap_or_default(),
+            rst_rcvd: q.rst_rcvd.clone().unwrap_or_default(),
+            gridsquare: q.gridsquare.clone().unwrap_or_default(),
+            error: String::new(),
+        }
+    }
+
+    /// Build the edited QSO from the form, preserving the original's `extra` and
+    /// unedited columns. `Err` is a message to show; don't save. Frequency drives
+    /// band: a parseable MHz value updates the TX freq and lets `normalize`
+    /// re-derive the band; a blank value keeps whatever was there.
+    fn to_qso(&self) -> Result<rigflow_log::Qso, String> {
+        let opt = |s: &str| {
+            let t = s.trim();
+            (!t.is_empty()).then(|| t.to_string())
+        };
+        let call = self.call.trim().to_ascii_uppercase();
+        if call.is_empty() {
+            return Err("Call is required.".into());
+        }
+        let date = self.qso_date.trim().to_string();
+        if date.len() != 8 || !date.bytes().all(|b| b.is_ascii_digit()) {
+            return Err("Date must be 8 digits, YYYYMMDD.".into());
+        }
+        let time = self.time_on.trim().to_string();
+        if !matches!(time.len(), 4 | 6) || !time.bytes().all(|b| b.is_ascii_digit()) {
+            return Err("Time must be HHMM or HHMMSS.".into());
+        }
+        if self.mode.trim().is_empty() {
+            return Err("Mode is required.".into());
+        }
+
+        let mut q = self.original.clone();
+        q.call = call;
+        q.qso_date = date;
+        q.time_on = time;
+        q.mode = self.mode.trim().to_ascii_uppercase();
+        q.rst_sent = opt(&self.rst_sent);
+        q.rst_rcvd = opt(&self.rst_rcvd);
+        q.gridsquare = opt(&self.gridsquare);
+
+        let f = self.freq_mhz.trim();
+        if !f.is_empty() {
+            match rigflow_log::adif::mhz_string_to_hz(f) {
+                Some(hz) => {
+                    q.freq_hz = Some(hz);
+                    q.band = String::new(); // re-derived from freq by normalize()
+                }
+                None => return Err("Frequency must be in MHz, e.g. 14.074.".into()),
+            }
+        }
+        q.normalize();
+        Ok(q)
+    }
+}
 
 impl RigflowApp {
     /// Open the manual entry window, freezing the current radio state into the
@@ -275,6 +364,10 @@ impl RigflowApp {
         let mut open_import = false;
         let mut open_filter = false;
         let mut clear_filter = false;
+        // Row actions, applied after the window closure so the immutable borrow of
+        // `contacts_cache` inside the grid doesn't collide with the &mut self they need.
+        let mut open_edit: Option<ContactEdit> = None;
+        let mut req_delete: Option<(i64, String)> = None;
 
         egui::Window::new("Contacts")
             .open(&mut open)
@@ -352,11 +445,11 @@ impl RigflowApp {
 
                 egui::ScrollArea::vertical().show(ui, |ui| {
                     egui::Grid::new("contacts_table")
-                        .num_columns(6)
+                        .num_columns(7)
                         .striped(true)
                         .spacing([12.0, 2.0])
                         .show(ui, |ui| {
-                            for h in ["Date", "Time (UTC)", "Call", "Band", "Mode", "Confirm"] {
+                            for h in ["Date", "Time (UTC)", "Call", "Band", "Mode", "Confirm", ""] {
                                 ui.strong(h);
                             }
                             ui.end_row();
@@ -368,6 +461,17 @@ impl RigflowApp {
                                 ui.label(&q.band);
                                 ui.label(&q.mode);
                                 confirm_badge(ui, &row.confirmed);
+                                ui.horizontal(|ui| {
+                                    if ui.button("Edit").clicked() {
+                                        open_edit = Some(ContactEdit::from_logged(row));
+                                    }
+                                    if ui.button("Delete").clicked() {
+                                        req_delete = Some((
+                                            row.id,
+                                            format!("{} · {} · {}", q.call, q.band, q.mode),
+                                        ));
+                                    }
+                                });
                                 ui.end_row();
                             }
                         });
@@ -387,6 +491,12 @@ impl RigflowApp {
         }
         if open_import {
             self.open_import();
+        }
+        if let Some(edit) = open_edit {
+            self.edit_contact = Some(edit);
+        }
+        if let Some(del) = req_delete {
+            self.delete_contact = Some(del);
         }
         if !open && let Ok(mut s) = self.state.lock() {
             s.show_contact_view = false;
@@ -492,6 +602,137 @@ impl RigflowApp {
         if dismiss {
             self.call_lookup.clear();
             self.call_lookup_hits = None;
+        }
+    }
+
+    /// The edit-contact window, opened by "Edit" in the contact view. Edits the
+    /// modeled columns; `extra` and untouched fields ride along via the original
+    /// QSO held in [`ContactEdit`]. Save routes through `LogStore::update_qso`
+    /// (DB-only; the append-only journal is untouched), then refreshes the view.
+    pub(crate) fn draw_edit_contact_window(&mut self, ctx: &egui::Context) {
+        let Some(mut edit) = self.edit_contact.take() else {
+            return;
+        };
+        let mut open = true;
+        let mut save = false;
+        let mut cancel = false;
+
+        egui::Window::new("Edit Contact")
+            .open(&mut open)
+            .collapsible(false)
+            .resizable(false)
+            .default_width(320.0)
+            .show(ctx, |ui| {
+                egui::Grid::new("edit_contact_grid")
+                    .num_columns(2)
+                    .spacing([8.0, 4.0])
+                    .show(ui, |ui| {
+                        for (label, field) in [
+                            ("Call", &mut edit.call),
+                            ("Date (YYYYMMDD)", &mut edit.qso_date),
+                            ("Time (HHMMSS)", &mut edit.time_on),
+                            ("Mode", &mut edit.mode),
+                            ("Freq (MHz)", &mut edit.freq_mhz),
+                            ("RST sent", &mut edit.rst_sent),
+                            ("RST rcvd", &mut edit.rst_rcvd),
+                            ("Grid", &mut edit.gridsquare),
+                        ] {
+                            ui.label(label);
+                            ui.text_edit_singleline(field);
+                            ui.end_row();
+                        }
+                    });
+
+                if !edit.error.is_empty() {
+                    ui.colored_label(egui::Color32::from_rgb(0xff, 0x6b, 0x6b), &edit.error);
+                }
+
+                ui.separator();
+                ui.horizontal(|ui| {
+                    if ui.button("Cancel").clicked() {
+                        cancel = true;
+                    }
+                    if ui.button("Save").clicked() {
+                        save = true;
+                    }
+                });
+            });
+
+        // Closed via X or Cancel: drop the edit (already taken), window stays shut.
+        if cancel || !open {
+            return;
+        }
+        if save {
+            match edit.to_qso() {
+                Ok(q) => {
+                    if let Some(store) = self.log.as_mut() {
+                        match store.update_qso(edit.id, &q) {
+                            Ok(()) => {
+                                self.worked_before = store.load_worked_before().unwrap_or_default();
+                                self.contacts_cache_dirty = true;
+                                self.set_log_status(format!("updated {}", q.call));
+                                return; // success → window closes
+                            }
+                            Err(e) => edit.error = format!("update failed: {e}"),
+                        }
+                    } else {
+                        edit.error = "no operator selected".into();
+                    }
+                }
+                Err(msg) => edit.error = msg,
+            }
+        }
+        // Still editing (or a save error to show): keep the window open next frame.
+        self.edit_contact = Some(edit);
+    }
+
+    /// The delete-confirmation dialog. Deleting is irreversible and drops the
+    /// contact's confirmations too (ON DELETE CASCADE), so it always confirms
+    /// first. Routes through `LogStore::delete_qso` (DB-only; the append-only
+    /// journal keeps the original record as history).
+    pub(crate) fn draw_delete_contact_confirm(&mut self, ctx: &egui::Context) {
+        let Some((id, label)) = self.delete_contact.clone() else {
+            return;
+        };
+        let mut open = true;
+        let mut confirm = false;
+        let mut cancel = false;
+
+        egui::Window::new("Delete Contact")
+            .open(&mut open)
+            .collapsible(false)
+            .resizable(false)
+            .show(ctx, |ui| {
+                ui.label(format!("Delete this contact?\n\n{label}"));
+                ui.label(note_text(
+                    "This removes it from the log, along with any confirmations, and cannot \
+                     be undone. The append-only ADIF journal keeps the original record.",
+                ));
+                ui.separator();
+                ui.horizontal(|ui| {
+                    if ui.button("Cancel").clicked() {
+                        cancel = true;
+                    }
+                    if ui.button("Delete").clicked() {
+                        confirm = true;
+                    }
+                });
+            });
+
+        if confirm {
+            if let Some(store) = self.log.as_mut() {
+                match store.delete_qso(id) {
+                    Ok(_) => {
+                        self.worked_before = store.load_worked_before().unwrap_or_default();
+                        self.contacts_cache_dirty = true;
+                        self.set_log_status(format!("deleted {label}"));
+                    }
+                    Err(e) => self.set_log_status(format!("delete failed: {e}")),
+                }
+            }
+            self.delete_contact = None;
+        } else if cancel || !open {
+            self.delete_contact = None;
         }
     }
 }

--- a/rigflow-client/src/ui/app_logging.rs
+++ b/rigflow-client/src/ui/app_logging.rs
@@ -367,9 +367,7 @@ impl RigflowApp {
                                 ui.label(&q.call);
                                 ui.label(&q.band);
                                 ui.label(&q.mode);
-                                // Per-service confirmation badge slots — empty in
-                                // phase 1 (populated once service sync lands).
-                                ui.label("—");
+                                confirm_badge(ui, &row.confirmed);
                                 ui.end_row();
                             }
                         });
@@ -495,5 +493,32 @@ impl RigflowApp {
             self.call_lookup.clear();
             self.call_lookup_hits = None;
         }
+    }
+}
+
+/// The contact view's "Confirm" cell: the service names that have confirmed the
+/// QSO (LoTW, eQSL, …) in green, or a plain "—" when none have. Emphasis is by
+/// colour only — no leading glyph. A checkmark (U+2713) is not in egui's default
+/// font and renders as a tofu box, so the green text alone carries "confirmed".
+fn confirm_badge(ui: &mut egui::Ui, confirmed: &[String]) {
+    if confirmed.is_empty() {
+        ui.label("—");
+        return;
+    }
+    let text = confirmed
+        .iter()
+        .map(|s| service_label(s))
+        .collect::<Vec<_>>()
+        .join(" · ");
+    ui.colored_label(egui::Color32::from_rgb(0x4c, 0xaf, 0x50), text);
+}
+
+/// Display name for a `qso_service` code.
+fn service_label(s: &str) -> &str {
+    match s {
+        "lotw" => "LoTW",
+        "eqsl" => "eQSL",
+        "qsl" => "QSL",
+        other => other,
     }
 }

--- a/rigflow-client/src/ui/app_logging.rs
+++ b/rigflow-client/src/ui/app_logging.rs
@@ -272,6 +272,7 @@ impl RigflowApp {
 
         let mut open = true;
         let mut open_export = false;
+        let mut open_import = false;
         let mut open_filter = false;
         let mut clear_filter = false;
 
@@ -308,6 +309,9 @@ impl RigflowApp {
                     }
                     if ui.button("Export…").clicked() {
                         open_export = true;
+                    }
+                    if ui.button("Import…").clicked() {
+                        open_import = true;
                     }
                     if ui.button("Refresh").clicked() {
                         self.contacts_cache_dirty = true;
@@ -382,6 +386,9 @@ impl RigflowApp {
         }
         if open_export {
             self.open_export(&operator_id);
+        }
+        if open_import {
+            self.open_import();
         }
         if !open && let Ok(mut s) = self.state.lock() {
             s.show_contact_view = false;

--- a/rigflow-client/src/ui/app_logging.rs
+++ b/rigflow-client/src/ui/app_logging.rs
@@ -258,6 +258,7 @@ impl RigflowApp {
         }
 
         let mut open = true;
+        let mut open_export = false;
         egui::Window::new("Contacts")
             .open(&mut open)
             .default_width(560.0)
@@ -271,6 +272,9 @@ impl RigflowApp {
                     ui.label(format!("{} contacts", self.contacts_cache.len()));
                     if ui.button("Refresh").clicked() {
                         self.contacts_cache_dirty = true;
+                    }
+                    if ui.button("Export…").clicked() {
+                        open_export = true;
                     }
                 });
                 ui.separator();
@@ -300,6 +304,9 @@ impl RigflowApp {
                         });
                 });
             });
+        if open_export {
+            self.open_export(&snapshot.operator_id);
+        }
         if !open {
             if let Ok(mut s) = self.state.lock() {
                 s.show_contact_view = false;

--- a/rigflow-client/src/ui/app_logging.rs
+++ b/rigflow-client/src/ui/app_logging.rs
@@ -445,7 +445,7 @@ impl RigflowApp {
                         // The index says worked, the rows haven't landed yet.
                         _ => {
                             ui.label(egui::RichText::new("Worked before").heading());
-                            ui.label(egui::RichText::new("looking up…").weak());
+                            ui.label("looking up…");
                         }
                     }
                 }

--- a/rigflow-client/src/ui/app_logging.rs
+++ b/rigflow-client/src/ui/app_logging.rs
@@ -369,6 +369,12 @@ impl RigflowApp {
         // `contacts_cache` inside the grid doesn't collide with the &mut self they need.
         let mut open_edit: Option<ContactEdit> = None;
         let mut req_delete: Option<(i64, String)> = None;
+        let mut export_selection = false;
+        let mut delete_selection = false;
+        let mut clear_selection = false;
+        // The checkbox state, taken out so the grid can mutate it while holding an
+        // immutable borrow of `contacts_cache`; written back after the closure.
+        let mut selection = std::mem::take(&mut self.selected_contacts);
 
         egui::Window::new("Contacts")
             .open(&mut open)
@@ -445,20 +451,66 @@ impl RigflowApp {
                     });
                 }
 
+                // ── selection action bar ──
+                // Only present when something is checked, so the common case (no
+                // selection) is uncluttered.
+                if !selection.is_empty() {
+                    ui.horizontal_wrapped(|ui| {
+                        ui.label(
+                            egui::RichText::new(format!("{} selected", selection.len())).strong(),
+                        );
+                        if ui.button("Export selected…").clicked() {
+                            export_selection = true;
+                        }
+                        if ui.button("Delete selected").clicked() {
+                            delete_selection = true;
+                        }
+                        if ui.button("Clear").clicked() {
+                            clear_selection = true;
+                        }
+                    });
+                }
+
                 ui.separator();
 
                 egui::ScrollArea::vertical().show(ui, |ui| {
                     egui::Grid::new("contacts_table")
-                        .num_columns(7)
+                        .num_columns(8)
                         .striped(true)
                         .spacing([12.0, 2.0])
                         .show(ui, |ui| {
+                            // Header: a select-all-shown checkbox, then the columns.
+                            let all_shown: Vec<i64> =
+                                self.contacts_cache.iter().map(|r| r.id).collect();
+                            let mut all = !all_shown.is_empty()
+                                && all_shown.iter().all(|id| selection.contains(id));
+                            if ui
+                                .checkbox(&mut all, "")
+                                .on_hover_text("Select all shown")
+                                .changed()
+                            {
+                                if all {
+                                    selection.extend(all_shown.iter().copied());
+                                } else {
+                                    for id in &all_shown {
+                                        selection.remove(id);
+                                    }
+                                }
+                            }
                             for h in ["Date", "Time (UTC)", "Call", "Band", "Mode", "Confirm", ""] {
                                 ui.strong(h);
                             }
                             ui.end_row();
                             for row in &self.contacts_cache {
                                 let q = &row.qso;
+                                let mut checked = selection.contains(&row.id);
+                                if ui.checkbox(&mut checked, "").changed() {
+                                    if checked {
+                                        selection.insert(row.id);
+                                    } else {
+                                        selection.remove(&row.id);
+                                    }
+                                }
                                 ui.label(display::date(&q.qso_date));
                                 ui.label(display::time_hhmm(&q.time_on));
                                 ui.label(&q.call);
@@ -482,6 +534,9 @@ impl RigflowApp {
                 });
             });
 
+        // Selection is owned by `self` again.
+        self.selected_contacts = selection;
+
         self.draw_call_lookup_popup(ctx);
 
         if clear_filter {
@@ -504,6 +559,22 @@ impl RigflowApp {
         }
         if let Some(del) = req_delete {
             self.delete_contact = Some(del);
+        }
+        if clear_selection {
+            self.selected_contacts.clear();
+        }
+        if export_selection && !self.selected_contacts.is_empty() {
+            // A selection replaces the shared filter with an ids-only one, so the
+            // view (and the export it drives) show exactly the checked rows — the
+            // documented "clears the other filters when exporting a selection".
+            self.qso_filter = crate::logging::export::QsoFilterDraft {
+                qso_ids: Some(self.selected_contacts.iter().copied().collect()),
+                ..Default::default()
+            };
+            self.open_export(&operator_id);
+        }
+        if delete_selection && !self.selected_contacts.is_empty() {
+            self.delete_selection_pending = true;
         }
         if !open && let Ok(mut s) = self.state.lock() {
             s.show_contact_view = false;
@@ -740,6 +811,76 @@ impl RigflowApp {
             self.delete_contact = None;
         } else if cancel || !open {
             self.delete_contact = None;
+        }
+    }
+
+    /// The bulk-delete confirmation for a contact-view multi-selection. Deletes
+    /// each checked row through `LogStore::delete_qso` (DB-only). A per-row
+    /// failure is counted, not fatal — the rest still go.
+    pub(crate) fn draw_delete_selection_confirm(&mut self, ctx: &egui::Context) {
+        if !self.delete_selection_pending {
+            return;
+        }
+        let n = self.selected_contacts.len();
+        if n == 0 {
+            self.delete_selection_pending = false;
+            return;
+        }
+        let mut open = true;
+        let mut confirm = false;
+        let mut cancel = false;
+
+        egui::Window::new("Delete Contacts")
+            .open(&mut open)
+            .collapsible(false)
+            .resizable(false)
+            .show(ctx, |ui| {
+                ui.label(format!(
+                    "Delete {n} selected contact{}?",
+                    if n == 1 { "" } else { "s" }
+                ));
+                ui.label(note_text(
+                    "This removes them from the log, along with any confirmations, and cannot \
+                     be undone. The append-only ADIF journal keeps the original records.",
+                ));
+                ui.separator();
+                ui.horizontal(|ui| {
+                    if ui.button("Cancel").clicked() {
+                        cancel = true;
+                    }
+                    if ui.button(format!("Delete {n}")).clicked() {
+                        confirm = true;
+                    }
+                });
+            });
+
+        if confirm {
+            if let Some(store) = self.log.as_mut() {
+                let ids: Vec<i64> = self.selected_contacts.iter().copied().collect();
+                let mut deleted = 0usize;
+                let mut failed = 0usize;
+                for id in ids {
+                    match store.delete_qso(id) {
+                        Ok(true) => deleted += 1,
+                        Ok(false) => {}
+                        Err(_) => failed += 1,
+                    }
+                }
+                self.worked_before = store.load_worked_before().unwrap_or_default();
+                self.contacts_cache_dirty = true;
+                let mut msg = format!(
+                    "deleted {deleted} contact{}",
+                    if deleted == 1 { "" } else { "s" }
+                );
+                if failed > 0 {
+                    msg.push_str(&format!(" · {failed} failed"));
+                }
+                self.set_log_status(msg);
+            }
+            self.selected_contacts.clear();
+            self.delete_selection_pending = false;
+        } else if cancel || !open {
+            self.delete_selection_pending = false;
         }
     }
 }

--- a/rigflow-client/src/ui/app_logging.rs
+++ b/rigflow-client/src/ui/app_logging.rs
@@ -907,6 +907,7 @@ fn service_label(s: &str) -> &str {
     match s {
         "lotw" => "LoTW",
         "eqsl" => "eQSL",
+        "qrz" => "QRZ",
         "qsl" => "QSL",
         other => other,
     }

--- a/rigflow-client/src/ui/app_logging.rs
+++ b/rigflow-client/src/ui/app_logging.rs
@@ -413,7 +413,7 @@ impl RigflowApp {
                     if ui.button("Import…").clicked() {
                         open_import = true;
                     }
-                    if ui.button("LoTW…").clicked() {
+                    if ui.button("Sync…").clicked() {
                         open_sync = true;
                     }
                     if ui.button("Refresh").clicked() {

--- a/rigflow-client/src/ui/app_logging.rs
+++ b/rigflow-client/src/ui/app_logging.rs
@@ -362,6 +362,7 @@ impl RigflowApp {
         let mut open = true;
         let mut open_export = false;
         let mut open_import = false;
+        let mut open_sync = false;
         let mut open_filter = false;
         let mut clear_filter = false;
         // Row actions, applied after the window closure so the immutable borrow of
@@ -405,6 +406,9 @@ impl RigflowApp {
                     }
                     if ui.button("Import…").clicked() {
                         open_import = true;
+                    }
+                    if ui.button("LoTW…").clicked() {
+                        open_sync = true;
                     }
                     if ui.button("Refresh").clicked() {
                         self.contacts_cache_dirty = true;
@@ -491,6 +495,9 @@ impl RigflowApp {
         }
         if open_import {
             self.open_import();
+        }
+        if open_sync {
+            self.open_sync(&operator_id);
         }
         if let Some(edit) = open_edit {
             self.edit_contact = Some(edit);

--- a/rigflow-client/src/ui/app_swr_sweep.rs
+++ b/rigflow-client/src/ui/app_swr_sweep.rs
@@ -90,7 +90,7 @@ impl RigflowApp {
                             plot_ui.line(Line::new(PlotPoints::from(points.clone())).name("SWR"));
                             plot_ui.points(
                                 Points::new(PlotPoints::from(points.clone()))
-                                    .radius(3.0)
+                                    .radius(3.0_f32)
                                     .name("SWR"),
                             );
                         }

--- a/rigflow-client/src/ui/app_sync.rs
+++ b/rigflow-client/src/ui/app_sync.rs
@@ -84,6 +84,9 @@ impl RigflowApp {
             None
         };
 
+        // Force applies only to an upload; a download always uses its marker.
+        let force = direction == Direction::Upload && self.sync_force_upload;
+
         self.sync_busy = true;
         self.sync_status = format!(
             "{} {}…",
@@ -100,6 +103,7 @@ impl RigflowApp {
             login: cred.login,
             password: cred.password,
             since,
+            force,
         });
     }
 
@@ -309,6 +313,16 @@ impl RigflowApp {
                         ui.spinner();
                     }
                 });
+                if service.can_upload() {
+                    ui.checkbox(
+                        &mut self.sync_force_upload,
+                        "Re-upload QSOs already marked uploaded",
+                    )
+                    .on_hover_text(
+                        "Ignore the upload history and send everything; the service skips real \
+                         duplicates. Use this to recover if the log was wrongly marked uploaded.",
+                    );
+                }
                 if !service.can_upload() {
                     ui.label(note_text(
                         "Uploading to LoTW needs TQSL and your certificate, so it's done with \

--- a/rigflow-client/src/ui/app_sync.rs
+++ b/rigflow-client/src/ui/app_sync.rs
@@ -1,28 +1,26 @@
-//! The **LoTW sync** window: download QSL confirmations from Logbook of the World
-//! and apply them to the log.
+//! The **online-sync** window: download QSL confirmations and upload QSOs to
+//! LoTW, eQSL, and QRZ Logbook.
 //!
-//! Download-only (upload needs TQSL/a certificate — out of scope). The heavy
-//! lifting is elsewhere: the HTTPS GET + import plan run on the export worker
-//! (off the UI thread); applying the plan is the same `commit_import` the manual
-//! import uses. A sync **auto-commits** — confirmations only touch `qso_service`,
-//! never insert contacts — so there's no per-run confirmation step, just a result.
+//! The heavy lifting is elsewhere: the HTTP + read-only DB work run on the export
+//! worker (off the UI thread); a download applies through the same `commit_import`
+//! the manual import uses, an upload stamps `uploaded_at`. A **download
+//! auto-commits** — confirmations only touch `qso_service`, never insert contacts.
 //!
-//! Credentials live in the OS keyring where available, else a per-operator
-//! `0600` file (see [`crate::logging::credentials`]). The password field is only
-//! re-saved when the operator edits it.
+//! Per service: LoTW is download-only (upload needs TQSL); eQSL and QRZ do both.
+//! Credentials are a username+password (LoTW, eQSL) or an API key (QRZ), stored in
+//! the OS keyring where available, else a per-operator `0600` file. LoTW is the
+//! only path exercised live so far — see [`crate::logging::services`].
 
 use eframe::egui;
 
 use crate::logging::credentials::{self, Credential};
-use crate::logging::export::ExportJob;
+use crate::logging::export::{ExportJob, SyncOutcome};
+use crate::logging::services::{CredKind, Direction, Service};
 use crate::ui::app::RigflowApp;
 use crate::ui::panels::note_text;
 
-/// The ham service key for the credential store and `sync_state`.
-const SERVICE: &str = "lotw";
-
 impl RigflowApp {
-    /// Open the sync window and load this operator's saved credentials once.
+    /// Open the sync window and load the current service's saved credentials.
     pub(crate) fn open_sync(&mut self, operator_id: &str) {
         self.show_sync = true;
         self.sync_status.clear();
@@ -38,13 +36,15 @@ impl RigflowApp {
             .unwrap_or_default()
     }
 
-    /// Load saved LoTW credentials into the fields, once per operator.
+    /// Load the current `(operator, service)`'s saved credentials into the
+    /// fields, once — re-runs when the operator or the selected service changes.
     fn load_sync_credentials(&mut self, operator_id: &str) {
-        if self.sync_loaded_for.as_deref() == Some(operator_id) {
+        let want = (operator_id.to_string(), self.sync_service);
+        if self.sync_loaded_for.as_ref() == Some(&want) {
             return;
         }
         let dir = self.operator_dir(operator_id);
-        match credentials::load(SERVICE, operator_id, &dir) {
+        match credentials::load(self.sync_service.key(), operator_id, &dir) {
             Some((cred, backend)) => {
                 self.sync_login = cred.login;
                 self.sync_password = cred.password;
@@ -56,18 +56,19 @@ impl RigflowApp {
                 self.sync_backend = None;
             }
         }
-        self.sync_loaded_for = Some(operator_id.to_string());
+        self.sync_loaded_for = Some(want);
     }
 
-    /// Kick off a download on the worker: save the credentials, read the
-    /// incremental marker, and send the job.
-    fn start_lotw_sync(&mut self, operator_id: &str) {
+    /// Kick off a sync on the worker: save the credentials, read the marker (for a
+    /// download), and send the job.
+    fn start_sync(&mut self, operator_id: &str, direction: Direction) {
+        let service = self.sync_service;
         let dir = self.operator_dir(operator_id);
         let cred = Credential {
             login: self.sync_login.trim().to_string(),
             password: self.sync_password.clone(),
         };
-        match credentials::store(SERVICE, operator_id, &cred, &dir) {
+        match credentials::store(service.key(), operator_id, &cred, &dir) {
             Ok(backend) => self.sync_backend = Some(backend),
             Err(e) => {
                 self.sync_status = format!("could not save credentials: {e}");
@@ -75,14 +76,26 @@ impl RigflowApp {
             }
         }
 
-        let since = self
-            .log
-            .as_ref()
-            .and_then(|s| s.sync_marker(SERVICE).ok().flatten());
+        let since = if direction == Direction::Download {
+            self.log
+                .as_ref()
+                .and_then(|s| s.sync_marker(service.key()).ok().flatten())
+        } else {
+            None
+        };
 
         self.sync_busy = true;
-        self.sync_status = "contacting LoTW…".to_string();
-        let _ = self.export_tx.send(ExportJob::LotwSync {
+        self.sync_status = format!(
+            "{} {}…",
+            match direction {
+                Direction::Download => "downloading from",
+                Direction::Upload => "uploading to",
+            },
+            service.name()
+        );
+        let _ = self.export_tx.send(ExportJob::ServiceSync {
+            service,
+            direction,
             db_path: self.persistence_store.qso_log_db_path(operator_id),
             login: cred.login,
             password: cred.password,
@@ -90,15 +103,34 @@ impl RigflowApp {
         });
     }
 
-    /// Apply a completed LoTW download: auto-commit the confirmations and advance
-    /// the marker. Called from the export-event drain.
-    pub(crate) fn apply_lotw_sync(
+    /// Apply a completed sync from the worker. Called from the export-event drain.
+    /// The [`SyncOutcome`] itself distinguishes download from upload.
+    pub(crate) fn apply_service_sync(
         &mut self,
+        service: Service,
+        result: Result<SyncOutcome, String>,
+    ) {
+        self.sync_busy = false;
+        let outcome = match result {
+            Ok(o) => o,
+            Err(e) => {
+                self.sync_status = format!("{} sync failed: {e}", service.name());
+                return;
+            }
+        };
+        match outcome {
+            SyncOutcome::Downloaded { plan, marker } => self.apply_download(service, *plan, marker),
+            SyncOutcome::Uploaded { ids, report } => self.apply_upload(service, ids, report),
+        }
+    }
+
+    /// A download: auto-commit the confirmations and advance the marker.
+    fn apply_download(
+        &mut self,
+        service: Service,
         plan: rigflow_log::import::ImportPlan,
         marker: Option<String>,
     ) {
-        self.sync_busy = false;
-
         let (op, name, profile) = {
             let s = self.state.lock().unwrap();
             (
@@ -113,22 +145,25 @@ impl RigflowApp {
             self.sync_status = "no operator selected — nothing applied".to_string();
             return;
         };
-
         match store.commit_import(&plan.importable, &plan.confirmations, &station) {
-            Ok(outcome) => {
-                // Only advance the marker on a successful apply, so a failure
+            Ok(commit) => {
+                // Advance the marker only on a successful apply, so a failure
                 // re-fetches the same window next time rather than skipping it.
-                if let Err(e) = store.set_sync_marker(SERVICE, marker.as_deref()) {
-                    eprintln!("rigflow: LoTW sync marker not saved: {e}");
+                if let Err(e) = store.set_sync_marker(service.key(), marker.as_deref()) {
+                    eprintln!("rigflow: {} sync marker not saved: {e}", service.key());
                 }
                 self.worked_before = store.load_worked_before().unwrap_or_default();
                 self.contacts_cache_dirty = true;
 
                 let mut msg = format!(
-                    "LoTW: {} new confirmation{}",
-                    outcome.confirmed,
-                    if outcome.confirmed == 1 { "" } else { "s" }
+                    "{}: {} new confirmation{}",
+                    service.name(),
+                    commit.confirmed,
+                    if commit.confirmed == 1 { "" } else { "s" }
                 );
+                if commit.imported > 0 {
+                    msg.push_str(&format!(" · {} new contact(s)", commit.imported));
+                }
                 if plan.already_confirmed > 0 {
                     msg.push_str(&format!(" · {} already confirmed", plan.already_confirmed));
                 }
@@ -141,8 +176,39 @@ impl RigflowApp {
                 self.sync_status = msg.clone();
                 self.set_log_status(msg);
             }
-            Err(e) => self.sync_status = format!("LoTW sync: apply failed, nothing changed: {e}"),
+            Err(e) => self.sync_status = format!("{} sync: apply failed: {e}", service.name()),
         }
+    }
+
+    /// An upload: stamp the pushed QSOs uploaded and report the service's counts.
+    fn apply_upload(
+        &mut self,
+        service: Service,
+        ids: Vec<i64>,
+        report: crate::logging::services::UploadReport,
+    ) {
+        if let Some(store) = self.log.as_mut()
+            && !ids.is_empty()
+            && let Err(e) = store.mark_uploaded(&ids, service.key())
+        {
+            self.sync_status = format!(
+                "{} upload: sent, but marking uploaded failed: {e}",
+                service.name()
+            );
+            return;
+        }
+        self.contacts_cache_dirty = true; // "not uploaded" filters just changed
+        let msg = if ids.is_empty() {
+            format!("{}: {}", service.name(), report.message)
+        } else {
+            let mut m = format!("{}: uploaded {} QSO(s)", service.name(), ids.len());
+            if report.rejected > 0 {
+                m.push_str(&format!(" · {} rejected", report.rejected));
+            }
+            m
+        };
+        self.sync_status = msg.clone();
+        self.set_log_status(msg);
     }
 
     pub(crate) fn draw_sync_window(&mut self, ctx: &egui::Context, operator_id: &str) {
@@ -153,37 +219,58 @@ impl RigflowApp {
             self.show_sync = false;
             return;
         }
+        // Load creds if the service selection changed since last frame.
+        self.load_sync_credentials(operator_id);
 
-        // "Last synced" line, straight from the store.
+        let service = self.sync_service;
         let last_run = self
             .log
             .as_ref()
-            .and_then(|s| s.sync_last_run(SERVICE).ok().flatten());
+            .and_then(|s| s.sync_last_run(service.key()).ok().flatten());
 
         let mut open = true;
         let mut download = false;
+        let mut upload = false;
         let mut forget = false;
+        let mut switch_to: Option<Service> = None;
 
-        egui::Window::new("LoTW Sync")
+        egui::Window::new("Online Sync")
             .open(&mut open)
-            .default_width(360.0)
+            .default_width(380.0)
             .show(ctx, |ui| {
-                ui.label(note_text(
-                    "Download your QSL confirmations from Logbook of the World and apply \
-                     them to matching contacts. (Uploading to LoTW is not done here.)",
-                ));
+                // Service picker.
+                ui.horizontal(|ui| {
+                    ui.label("Service:");
+                    for s in Service::ALL {
+                        if ui.selectable_label(service == s, s.name()).clicked() && service != s {
+                            switch_to = Some(s);
+                        }
+                    }
+                });
                 ui.separator();
 
-                egui::Grid::new("lotw_creds")
+                // Credentials, shaped by the auth kind.
+                egui::Grid::new("sync_creds")
                     .num_columns(2)
                     .spacing([8.0, 4.0])
-                    .show(ui, |ui| {
-                        ui.label("LoTW username");
-                        ui.text_edit_singleline(&mut self.sync_login);
-                        ui.end_row();
-                        ui.label("Password");
-                        ui.add(egui::TextEdit::singleline(&mut self.sync_password).password(true));
-                        ui.end_row();
+                    .show(ui, |ui| match service.cred_kind() {
+                        CredKind::UserPass => {
+                            ui.label(format!("{} username", service.name()));
+                            ui.text_edit_singleline(&mut self.sync_login);
+                            ui.end_row();
+                            ui.label("Password");
+                            ui.add(
+                                egui::TextEdit::singleline(&mut self.sync_password).password(true),
+                            );
+                            ui.end_row();
+                        }
+                        CredKind::ApiKey => {
+                            ui.label("API key");
+                            ui.add(
+                                egui::TextEdit::singleline(&mut self.sync_password).password(true),
+                            );
+                            ui.end_row();
+                        }
                     });
 
                 if let Some(b) = self.sync_backend {
@@ -192,28 +279,45 @@ impl RigflowApp {
 
                 ui.separator();
                 if let Some(run) = &last_run {
-                    // Stored RFC3339 (…"2026-07-24T09:00:00+00:00"); show the
-                    // readable "YYYY-MM-DD HH:MM:SS" prefix, in UTC as stored.
                     let shown: String = run.replace('T', " ").chars().take(19).collect();
-                    ui.label(format!("Last synced: {shown} UTC"));
-                } else {
-                    ui.label("Never synced.");
+                    ui.label(format!("Last download: {shown} UTC"));
+                } else if service.can_download() {
+                    ui.label("Never downloaded.");
                 }
 
+                let ready = !self.sync_busy
+                    && !self.sync_password.is_empty()
+                    && (service.cred_kind() == CredKind::ApiKey
+                        || !self.sync_login.trim().is_empty());
+
                 ui.horizontal(|ui| {
-                    let ready = !self.sync_login.trim().is_empty()
-                        && !self.sync_password.is_empty()
-                        && !self.sync_busy;
-                    if ui
-                        .add_enabled(ready, egui::Button::new("Download confirmations"))
-                        .clicked()
+                    if service.can_download()
+                        && ui
+                            .add_enabled(ready, egui::Button::new("Download confirmations"))
+                            .clicked()
                     {
                         download = true;
+                    }
+                    if service.can_upload()
+                        && ui
+                            .add_enabled(ready, egui::Button::new("Upload new QSOs"))
+                            .clicked()
+                    {
+                        upload = true;
                     }
                     if self.sync_busy {
                         ui.spinner();
                     }
-                    if ui.button("Forget saved password").clicked() {
+                });
+                if !service.can_upload() {
+                    ui.label(note_text(
+                        "Uploading to LoTW needs TQSL and your certificate, so it's done with \
+                         the TQSL app, not here.",
+                    ));
+                }
+
+                ui.horizontal(|ui| {
+                    if ui.button("Forget saved credentials").clicked() {
                         forget = true;
                     }
                 });
@@ -224,14 +328,24 @@ impl RigflowApp {
                 }
             });
 
+        if let Some(s) = switch_to {
+            self.sync_service = s;
+            self.sync_status.clear();
+            // Force a reload for the new service next frame.
+            self.sync_loaded_for = None;
+        }
         if download {
-            self.start_lotw_sync(operator_id);
+            self.start_sync(operator_id, Direction::Download);
+        }
+        if upload {
+            self.start_sync(operator_id, Direction::Upload);
         }
         if forget {
-            credentials::clear(SERVICE, operator_id, &self.operator_dir(operator_id));
+            credentials::clear(service.key(), operator_id, &self.operator_dir(operator_id));
+            self.sync_login.clear();
             self.sync_password.clear();
             self.sync_backend = None;
-            self.sync_status = "saved password forgotten".to_string();
+            self.sync_status = "saved credentials forgotten".to_string();
         }
         if !open {
             self.show_sync = false;

--- a/rigflow-client/src/ui/app_sync.rs
+++ b/rigflow-client/src/ui/app_sync.rs
@@ -1,0 +1,240 @@
+//! The **LoTW sync** window: download QSL confirmations from Logbook of the World
+//! and apply them to the log.
+//!
+//! Download-only (upload needs TQSL/a certificate — out of scope). The heavy
+//! lifting is elsewhere: the HTTPS GET + import plan run on the export worker
+//! (off the UI thread); applying the plan is the same `commit_import` the manual
+//! import uses. A sync **auto-commits** — confirmations only touch `qso_service`,
+//! never insert contacts — so there's no per-run confirmation step, just a result.
+//!
+//! Credentials live in the OS keyring where available, else a per-operator
+//! `0600` file (see [`crate::logging::credentials`]). The password field is only
+//! re-saved when the operator edits it.
+
+use eframe::egui;
+
+use crate::logging::credentials::{self, Credential};
+use crate::logging::export::ExportJob;
+use crate::ui::app::RigflowApp;
+use crate::ui::panels::note_text;
+
+/// The ham service key for the credential store and `sync_state`.
+const SERVICE: &str = "lotw";
+
+impl RigflowApp {
+    /// Open the sync window and load this operator's saved credentials once.
+    pub(crate) fn open_sync(&mut self, operator_id: &str) {
+        self.show_sync = true;
+        self.sync_status.clear();
+        self.load_sync_credentials(operator_id);
+    }
+
+    /// The per-operator directory that backs the credential file fallback.
+    fn operator_dir(&self, operator_id: &str) -> std::path::PathBuf {
+        self.persistence_store
+            .qso_log_db_path(operator_id)
+            .parent()
+            .map(|p| p.to_path_buf())
+            .unwrap_or_default()
+    }
+
+    /// Load saved LoTW credentials into the fields, once per operator.
+    fn load_sync_credentials(&mut self, operator_id: &str) {
+        if self.sync_loaded_for.as_deref() == Some(operator_id) {
+            return;
+        }
+        let dir = self.operator_dir(operator_id);
+        match credentials::load(SERVICE, operator_id, &dir) {
+            Some((cred, backend)) => {
+                self.sync_login = cred.login;
+                self.sync_password = cred.password;
+                self.sync_backend = Some(backend);
+            }
+            None => {
+                self.sync_login.clear();
+                self.sync_password.clear();
+                self.sync_backend = None;
+            }
+        }
+        self.sync_loaded_for = Some(operator_id.to_string());
+    }
+
+    /// Kick off a download on the worker: save the credentials, read the
+    /// incremental marker, and send the job.
+    fn start_lotw_sync(&mut self, operator_id: &str) {
+        let dir = self.operator_dir(operator_id);
+        let cred = Credential {
+            login: self.sync_login.trim().to_string(),
+            password: self.sync_password.clone(),
+        };
+        match credentials::store(SERVICE, operator_id, &cred, &dir) {
+            Ok(backend) => self.sync_backend = Some(backend),
+            Err(e) => {
+                self.sync_status = format!("could not save credentials: {e}");
+                return;
+            }
+        }
+
+        let since = self
+            .log
+            .as_ref()
+            .and_then(|s| s.sync_marker(SERVICE).ok().flatten());
+
+        self.sync_busy = true;
+        self.sync_status = "contacting LoTW…".to_string();
+        let _ = self.export_tx.send(ExportJob::LotwSync {
+            db_path: self.persistence_store.qso_log_db_path(operator_id),
+            login: cred.login,
+            password: cred.password,
+            since,
+        });
+    }
+
+    /// Apply a completed LoTW download: auto-commit the confirmations and advance
+    /// the marker. Called from the export-event drain.
+    pub(crate) fn apply_lotw_sync(
+        &mut self,
+        plan: rigflow_log::import::ImportPlan,
+        marker: Option<String>,
+    ) {
+        self.sync_busy = false;
+
+        let (op, name, profile) = {
+            let s = self.state.lock().unwrap();
+            (
+                s.operator_id.clone(),
+                s.operator_name.clone(),
+                s.station_profile.clone(),
+            )
+        };
+        let station = profile.to_log_station(&op, &name);
+
+        let Some(store) = self.log.as_mut() else {
+            self.sync_status = "no operator selected — nothing applied".to_string();
+            return;
+        };
+
+        match store.commit_import(&plan.importable, &plan.confirmations, &station) {
+            Ok(outcome) => {
+                // Only advance the marker on a successful apply, so a failure
+                // re-fetches the same window next time rather than skipping it.
+                if let Err(e) = store.set_sync_marker(SERVICE, marker.as_deref()) {
+                    eprintln!("rigflow: LoTW sync marker not saved: {e}");
+                }
+                self.worked_before = store.load_worked_before().unwrap_or_default();
+                self.contacts_cache_dirty = true;
+
+                let mut msg = format!(
+                    "LoTW: {} new confirmation{}",
+                    outcome.confirmed,
+                    if outcome.confirmed == 1 { "" } else { "s" }
+                );
+                if plan.already_confirmed > 0 {
+                    msg.push_str(&format!(" · {} already confirmed", plan.already_confirmed));
+                }
+                if plan.unmatched_confirmations > 0 {
+                    msg.push_str(&format!(
+                        " · {} for QSOs not in your log",
+                        plan.unmatched_confirmations
+                    ));
+                }
+                self.sync_status = msg.clone();
+                self.set_log_status(msg);
+            }
+            Err(e) => self.sync_status = format!("LoTW sync: apply failed, nothing changed: {e}"),
+        }
+    }
+
+    pub(crate) fn draw_sync_window(&mut self, ctx: &egui::Context, operator_id: &str) {
+        if !self.show_sync {
+            return;
+        }
+        if operator_id.trim().is_empty() || self.log.is_none() {
+            self.show_sync = false;
+            return;
+        }
+
+        // "Last synced" line, straight from the store.
+        let last_run = self
+            .log
+            .as_ref()
+            .and_then(|s| s.sync_last_run(SERVICE).ok().flatten());
+
+        let mut open = true;
+        let mut download = false;
+        let mut forget = false;
+
+        egui::Window::new("LoTW Sync")
+            .open(&mut open)
+            .default_width(360.0)
+            .show(ctx, |ui| {
+                ui.label(note_text(
+                    "Download your QSL confirmations from Logbook of the World and apply \
+                     them to matching contacts. (Uploading to LoTW is not done here.)",
+                ));
+                ui.separator();
+
+                egui::Grid::new("lotw_creds")
+                    .num_columns(2)
+                    .spacing([8.0, 4.0])
+                    .show(ui, |ui| {
+                        ui.label("LoTW username");
+                        ui.text_edit_singleline(&mut self.sync_login);
+                        ui.end_row();
+                        ui.label("Password");
+                        ui.add(egui::TextEdit::singleline(&mut self.sync_password).password(true));
+                        ui.end_row();
+                    });
+
+                if let Some(b) = self.sync_backend {
+                    ui.label(note_text(b.note()));
+                }
+
+                ui.separator();
+                if let Some(run) = &last_run {
+                    // Stored RFC3339 (…"2026-07-24T09:00:00+00:00"); show the
+                    // readable "YYYY-MM-DD HH:MM:SS" prefix, in UTC as stored.
+                    let shown: String = run.replace('T', " ").chars().take(19).collect();
+                    ui.label(format!("Last synced: {shown} UTC"));
+                } else {
+                    ui.label("Never synced.");
+                }
+
+                ui.horizontal(|ui| {
+                    let ready = !self.sync_login.trim().is_empty()
+                        && !self.sync_password.is_empty()
+                        && !self.sync_busy;
+                    if ui
+                        .add_enabled(ready, egui::Button::new("Download confirmations"))
+                        .clicked()
+                    {
+                        download = true;
+                    }
+                    if self.sync_busy {
+                        ui.spinner();
+                    }
+                    if ui.button("Forget saved password").clicked() {
+                        forget = true;
+                    }
+                });
+
+                if !self.sync_status.is_empty() {
+                    ui.separator();
+                    ui.label(&self.sync_status);
+                }
+            });
+
+        if download {
+            self.start_lotw_sync(operator_id);
+        }
+        if forget {
+            credentials::clear(SERVICE, operator_id, &self.operator_dir(operator_id));
+            self.sync_password.clear();
+            self.sync_backend = None;
+            self.sync_status = "saved password forgotten".to_string();
+        }
+        if !open {
+            self.show_sync = false;
+        }
+    }
+}

--- a/rigflow-client/src/ui/mod.rs
+++ b/rigflow-client/src/ui/mod.rs
@@ -18,6 +18,7 @@ mod app_audio;
 mod app_center;
 mod app_dialogs;
 mod app_export;
+mod app_filter;
 mod app_logging;
 mod app_swr_sweep;
 mod app_wsjtx_setup;

--- a/rigflow-client/src/ui/mod.rs
+++ b/rigflow-client/src/ui/mod.rs
@@ -17,6 +17,7 @@ mod app_actions;
 mod app_audio;
 mod app_center;
 mod app_dialogs;
+mod app_logging;
 mod app_swr_sweep;
 mod app_wsjtx_setup;
 mod panels;

--- a/rigflow-client/src/ui/mod.rs
+++ b/rigflow-client/src/ui/mod.rs
@@ -19,6 +19,7 @@ mod app_center;
 mod app_dialogs;
 mod app_export;
 mod app_filter;
+mod app_import;
 mod app_logging;
 mod app_swr_sweep;
 mod app_wsjtx_setup;

--- a/rigflow-client/src/ui/mod.rs
+++ b/rigflow-client/src/ui/mod.rs
@@ -17,6 +17,7 @@ mod app_actions;
 mod app_audio;
 mod app_center;
 mod app_dialogs;
+mod app_export;
 mod app_logging;
 mod app_swr_sweep;
 mod app_wsjtx_setup;

--- a/rigflow-client/src/ui/mod.rs
+++ b/rigflow-client/src/ui/mod.rs
@@ -22,5 +22,6 @@ mod app_filter;
 mod app_import;
 mod app_logging;
 mod app_swr_sweep;
+mod app_sync;
 mod app_wsjtx_setup;
 mod panels;

--- a/rigflow-client/src/ui/panels/latency.rs
+++ b/rigflow-client/src/ui/panels/latency.rs
@@ -121,14 +121,12 @@ impl RigflowApp {
                     });
 
                 if (diag.underruns | diag.overruns) != 0 {
-                    ui.label(
-                        egui::RichText::new(format!(
-                            "underruns {}  ·  overruns {}",
-                            diag.underruns, diag.overruns
-                        ))
-                        .small()
-                        .weak(),
-                    );
+                    // Non-zero means audio actually broke up — the last thing that
+                    // should be rendered in unreadably small, dim text.
+                    ui.label(super::note_text(format!(
+                        "underruns {}  ·  overruns {}",
+                        diag.underruns, diag.overruns
+                    )));
                 }
 
                 ui.add_space(4.0);

--- a/rigflow-client/src/ui/panels/mod.rs
+++ b/rigflow-client/src/ui/panels/mod.rs
@@ -169,6 +169,7 @@ pub(crate) use radio_control::s_meter_label;
 mod server;
 mod source_control;
 mod source_status;
+mod station;
 mod tx_tune_test;
 mod vfo;
 mod waterfall_control;
@@ -234,6 +235,8 @@ impl RigflowApp {
                         }
 
                         self.draw_operator_panel(ui, snapshot, config_mode);
+                        ui.separator();
+                        self.draw_station_panel(ui, snapshot);
                         ui.separator();
                         self.draw_server_panel(ui, snapshot, config_mode);
                         ui.separator();

--- a/rigflow-client/src/ui/panels/operator.rs
+++ b/rigflow-client/src/ui/panels/operator.rs
@@ -103,6 +103,19 @@ impl RigflowApp {
                     }
 
                     ui.add_space(8.0);
+                    ui.label("Operator name (logged as MY_NAME):");
+                    let mut operator_name = snapshot.operator_name.clone();
+                    let name_resp = ui.text_edit_singleline(&mut operator_name);
+                    if name_resp.changed() {
+                        if let Ok(mut state) = self.state.lock() {
+                            state.operator_name = operator_name;
+                        }
+                    }
+                    if name_resp.lost_focus() {
+                        self.save_operator_name();
+                    }
+
+                    ui.add_space(8.0);
 
                     ui.horizontal(|ui| {
                         if ui.button("Add Operator").clicked() {

--- a/rigflow-client/src/ui/panels/radio_control.rs
+++ b/rigflow-client/src/ui/panels/radio_control.rs
@@ -439,7 +439,7 @@ impl RigflowApp {
             } else {
                 ("muted", egui::Color32::from_rgb(210, 130, 130))
             };
-            ui.label(RichText::new(text).color(color).small());
+            ui.label(RichText::new(text).color(color));
         });
 
         let enabled = *t.squelch_enabled(state);
@@ -763,11 +763,9 @@ impl RigflowApp {
                 "● Transmitting clip…",
             );
         } else if !ssb {
-            ui.label(
-                RichText::new("Switch to USB / LSB / Data to transmit a clip.")
-                    .small()
-                    .weak(),
-            );
+            ui.label(super::note_text(
+                "Switch to USB / LSB / Data to transmit a clip.",
+            ));
         }
         if let Some(err) = &state.voice_keyer_error {
             ui.colored_label(egui::Color32::from_rgb(230, 140, 60), err.clone());
@@ -876,7 +874,7 @@ impl RigflowApp {
                 self.cw_text_abort.store(true, Ordering::Relaxed);
             }
             if sending {
-                ui.label(RichText::new("● sending…").small());
+                ui.label("● sending…");
             }
         });
 
@@ -974,11 +972,7 @@ impl RigflowApp {
             if ui.checkbox(&mut enabled, "Enable Decode").changed() {
                 state.cw_decode.set_enabled(enabled);
             }
-            ui.label(
-                RichText::new(format!("Auto WPM (~{})", state.cw_decode.est_wpm()))
-                    .small()
-                    .weak(),
-            );
+            ui.label(format!("Auto WPM (~{})", state.cw_decode.est_wpm()));
         });
 
         // Scrolling, read-only decoded text (auto-scrolls to the newest).
@@ -1079,7 +1073,7 @@ impl RigflowApp {
         if !state.mic_status.is_empty() {
             ui.colored_label(
                 egui::Color32::from_rgb(255, 200, 50),
-                RichText::new(&state.mic_status).small(),
+                RichText::new(&state.mic_status),
             );
         }
 

--- a/rigflow-client/src/ui/panels/source_control.rs
+++ b/rigflow-client/src/ui/panels/source_control.rs
@@ -480,7 +480,7 @@ impl RigflowApp {
         }
 
         if let Some(name) = &rec.filename {
-            ui.label(egui::RichText::new(name).small().monospace());
+            ui.label(egui::RichText::new(name).monospace());
             ui.label(format!(
                 "{}   {}",
                 format_elapsed(rec.elapsed_secs),
@@ -523,7 +523,7 @@ impl RigflowApp {
         if rec.recording {
             ui.colored_label(egui::Color32::from_rgb(230, 90, 90), "● Recording");
             if let Some(name) = &rec.filename {
-                ui.label(egui::RichText::new(name).small().monospace());
+                ui.label(egui::RichText::new(name).monospace());
                 ui.label(format!(
                     "{}   {}",
                     format_elapsed(rec.elapsed_secs),
@@ -539,11 +539,7 @@ impl RigflowApp {
         } else {
             ui.colored_label(egui::Color32::GRAY, "○ Idle");
         }
-        ui.label(
-            egui::RichText::new("Saved per-operator — the audio you hear.")
-                .small()
-                .weak(),
-        );
+        ui.label(super::note_text("Saved per-operator — the audio you hear."));
     }
 
     /// HL2 Band Control: band radio buttons (tune to default freq + mode via the
@@ -724,7 +720,6 @@ impl RigflowApp {
                         state.tx_tone_freq_hz,
                         off_center_pct,
                     ))
-                    .small()
                     .color(egui::Color32::from_rgb(255, 200, 50)),
                 );
             } else {
@@ -760,7 +755,6 @@ impl RigflowApp {
         if state.tx_tone_running {
             ui.label(
                 egui::RichText::new("● Transmitting tone…")
-                    .small()
                     .color(egui::Color32::from_rgb(100, 220, 100)),
             );
         }

--- a/rigflow-client/src/ui/panels/station.rs
+++ b/rigflow-client/src/ui/panels/station.rs
@@ -1,0 +1,65 @@
+use crate::UiState;
+use crate::ui::app::RigflowApp;
+use eframe::egui;
+
+impl RigflowApp {
+    /// The **Station** panel: the physical station's location, shared across all
+    /// operators (one rig, one grid). The callsign is the operator id, not here.
+    /// These values feed the `MY_*` fields snapshotted onto each logged QSO.
+    ///
+    /// Not gated by the connected/config lock: it's global config (in
+    /// `app_state.json`), sends nothing to the server, and the operator may need
+    /// to set their grid at any time.
+    pub(crate) fn draw_station_panel(&mut self, ui: &mut egui::Ui, snapshot: &UiState) {
+        egui::CollapsingHeader::new(super::panel_header("Station"))
+            .default_open(false)
+            .show(ui, |ui| {
+                ui.label("Shared station location — applies to all operators.");
+                ui.add_space(4.0);
+
+                let mut p = snapshot.station_profile.clone();
+                let mut changed = false;
+                let mut committed = false;
+                let mut field = |ui: &mut egui::Ui, label: &str, val: &mut String| {
+                    ui.label(label);
+                    let r = ui.text_edit_singleline(val);
+                    changed |= r.changed();
+                    committed |= r.lost_focus();
+                    ui.end_row();
+                };
+
+                egui::Grid::new("station_profile_grid")
+                    .num_columns(2)
+                    .spacing([8.0, 4.0])
+                    .show(ui, |ui| {
+                        field(ui, "Grid square", &mut p.gridsquare);
+                        field(ui, "State", &mut p.state);
+                        field(ui, "County", &mut p.county);
+                        field(ui, "CQ zone", &mut p.cq_zone);
+                        field(ui, "ITU zone", &mut p.itu_zone);
+                    });
+
+                // Mirror edits into UiState live; only persist to disk when a
+                // field loses focus (so we don't rewrite app_state.json per key).
+                if changed || committed {
+                    if let Ok(mut s) = self.state.lock() {
+                        s.station_profile = p;
+                        if committed {
+                            s.pending_save_station_profile = true;
+                        }
+                    }
+                }
+
+                ui.add_space(6.0);
+                let call = snapshot.operator_id.trim();
+                if call.is_empty() {
+                    ui.colored_label(
+                        egui::Color32::from_rgb(255, 190, 70),
+                        "Set an operator — its ID is your logging callsign.",
+                    );
+                } else {
+                    ui.label(format!("Logging callsign: {}", call.to_uppercase()));
+                }
+            });
+    }
+}

--- a/rigflow-client/src/ui/panels/tx_tune_test.rs
+++ b/rigflow-client/src/ui/panels/tx_tune_test.rs
@@ -40,8 +40,7 @@ impl RigflowApp {
                     "⚠ Short low-power carrier pulse.\n\
                          Verify antenna/load and band before use.",
                 )
-                .color(egui::Color32::from_rgb(255, 160, 40))
-                .small(),
+                .color(egui::Color32::from_rgb(255, 160, 40)),
             );
             ui.add_space(2.0);
 
@@ -52,7 +51,7 @@ impl RigflowApp {
                 let s = snapshot.last_tx_tune_result.status;
                 (format_status(s), status_color(s))
             };
-            ui.label(egui::RichText::new(state_text).color(state_color).small());
+            ui.label(egui::RichText::new(state_text).color(state_color));
             ui.add_space(4.0);
 
             // ── Current TX Drive (read-only) ─────────────────────────────

--- a/rigflow-client/src/ui/panels/vfo.rs
+++ b/rigflow-client/src/ui/panels/vfo.rs
@@ -277,11 +277,9 @@ impl RigflowApp {
                 self.send_radio_msg(ClientRadioMessage::SetDualWatch { enabled: dw });
             }
             if !dual_watch_supported {
-                ui.label(
-                    egui::RichText::new("Dual-watch needs an HL2 (second receiver).")
-                        .small()
-                        .weak(),
-                );
+                ui.label(super::note_text(
+                    "Dual-watch needs an HL2 (second receiver).",
+                ));
             }
         });
     }

--- a/rigflow-client/src/ui/spectrum_view.rs
+++ b/rigflow-client/src/ui/spectrum_view.rs
@@ -68,7 +68,7 @@ pub fn draw_spectrum_plot(
     painter.rect_stroke(
         plot_rect,
         0.0,
-        Stroke::new(1.0, Color32::from_gray(110)),
+        Stroke::new(1.0_f32, Color32::from_gray(110)),
         egui::StrokeKind::Inside,
     );
 
@@ -146,7 +146,7 @@ fn draw_grid_and_y_axis(
                 Pos2::new(plot_rect.left(), y),
                 Pos2::new(plot_rect.right(), y),
             ],
-            Stroke::new(1.0, grid_color),
+            Stroke::new(1.0_f32, grid_color),
         );
 
         let db = egui::lerp(db_min..=db_max, t);
@@ -198,7 +198,7 @@ fn draw_x_axis(
                 Pos2::new(x, plot_rect.top()),
                 Pos2::new(x, plot_rect.bottom()),
             ],
-            Stroke::new(1.0, grid_color),
+            Stroke::new(1.0_f32, grid_color),
         );
 
         let freq_hz = egui::lerp(left_hz..=right_hz, t);
@@ -265,7 +265,7 @@ fn draw_trace(
 
     painter.add(egui::Shape::line(
         points,
-        Stroke::new(1.5, Color32::LIGHT_GREEN),
+        Stroke::new(1.5_f32, Color32::LIGHT_GREEN),
     ));
 }
 
@@ -344,7 +344,7 @@ fn draw_frequency_markers(
                 Pos2::new(target_x, plot_rect.top()),
                 Pos2::new(target_x, plot_rect.bottom()),
             ],
-            Stroke::new(1.5, Color32::from_rgb(255, 220, 80)),
+            Stroke::new(1.5_f32, Color32::from_rgb(255, 220, 80)),
         );
 
         let label = format!("T: {} MHz", format_mhz(state.target_freq_hz));
@@ -440,7 +440,7 @@ fn draw_passband_overlay(
             Pos2::new(x0, plot_rect.top()),
             Pos2::new(x0, plot_rect.bottom()),
         ],
-        Stroke::new(1.0, Color32::from_rgb(120, 160, 255)),
+        Stroke::new(1.0_f32, Color32::from_rgb(120, 160, 255)),
     );
 
     painter.line_segment(
@@ -448,7 +448,7 @@ fn draw_passband_overlay(
             Pos2::new(x1, plot_rect.top()),
             Pos2::new(x1, plot_rect.bottom()),
         ],
-        Stroke::new(1.0, Color32::from_rgb(120, 160, 255)),
+        Stroke::new(1.0_f32, Color32::from_rgb(120, 160, 255)),
     );
 }
 
@@ -774,7 +774,7 @@ fn draw_bookmark_overlays<'a>(
         painter.rect_stroke(
             rect,
             4.0,
-            Stroke::new(1.0, border_color),
+            Stroke::new(1.0_f32, border_color),
             egui::StrokeKind::Inside,
         );
 
@@ -896,7 +896,7 @@ fn draw_tooltip_bubble(
     painter.rect_stroke(
         bubble_rect,
         6.0,
-        Stroke::new(1.0, border_color),
+        Stroke::new(1.0_f32, border_color),
         egui::StrokeKind::Inside,
     );
 

--- a/rigflow-client/src/ui/state.rs
+++ b/rigflow-client/src/ui/state.rs
@@ -310,6 +310,9 @@ pub struct UiState {
     // OPERATOR / PERSISTENCE (logical state, even if not yet persisted)
     // =====================================================================
     pub operator_id: String,
+    /// The current operator's personal name (ADIF `MY_NAME`), persisted per
+    /// operator; edited in the Operator panel.
+    pub operator_name: String,
     pub known_operator_ids: Vec<String>,
 
     pub show_add_operator_dialog: bool,
@@ -320,6 +323,27 @@ pub struct UiState {
     pub pending_delete_operator_id: Option<String>,
 
     pub persistence_status: String,
+
+    // =====================================================================
+    // CONTACT LOGGING
+    // =====================================================================
+    /// Global station location (grid, etc.), shared across operators; mirrored
+    /// from `app_state.json`. Callsign is per-operator (`operator_id`).
+    pub station_profile: crate::persistence::models::StationProfileFile,
+    /// Set by the Station panel (which has only `&self`) to request a save.
+    pub pending_save_station_profile: bool,
+    /// Manual log-entry window (`L`) open flag + its draft.
+    pub show_log_entry: bool,
+    pub log_entry_draft: crate::logging::LogEntryDraft,
+    /// True on the frame the entry window opens, so the callsign field grabs
+    /// focus once (egui drops the first keystrokes without an explicit focus).
+    pub log_entry_focus_pending: bool,
+    /// Contact-view window (`V`) open flag.
+    pub show_contact_view: bool,
+    /// Status/last-action line for the logging UI.
+    pub log_status: String,
+    /// WSJT-X UDP listener status (bind result / errors), surfaced for the user.
+    pub wsjtx_listen_status: String,
 
     // =====================================================================
     // PER-DEMOD OPERATOR PREFERENCES
@@ -734,6 +758,7 @@ impl Default for UiState {
             // OPERATOR / PERSISTENCE
             // =================================================================
             operator_id: String::new(),
+            operator_name: String::new(),
             known_operator_ids: Vec::new(),
 
             show_add_operator_dialog: false,
@@ -744,6 +769,18 @@ impl Default for UiState {
             pending_delete_operator_id: None,
 
             persistence_status: String::new(),
+
+            // =================================================================
+            // CONTACT LOGGING
+            // =================================================================
+            station_profile: crate::persistence::models::StationProfileFile::default(),
+            pending_save_station_profile: false,
+            show_log_entry: false,
+            log_entry_draft: crate::logging::LogEntryDraft::default(),
+            log_entry_focus_pending: false,
+            show_contact_view: false,
+            log_status: String::new(),
+            wsjtx_listen_status: String::new(),
 
             // =================================================================
             // BOOKMARKS

--- a/rigflow-log/Cargo.toml
+++ b/rigflow-log/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "rigflow-log"
+version.workspace = true
+edition = "2024"
+description = "Rigflow contact (QSO) logging: SQLite store, ADIF, WSJT-X ingest, split-frequency capture"
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+
+[dependencies]
+rusqlite = { version = "0.32", features = ["bundled"] }
+chrono = { version = "0.4", default-features = false, features = ["clock", "std"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"

--- a/rigflow-log/src/adif.rs
+++ b/rigflow-log/src/adif.rs
@@ -108,6 +108,10 @@ pub fn parse_adif(text: &str) -> Result<Vec<AdifRecord>, AdifError> {
                     records.push(std::mem::take(&mut current));
                 }
             }
+            // LoTW report files terminate with a lengthless `<APP_LoTW_EOF>`
+            // marker. It's a documented end-of-file control tag, not a data
+            // field, so stop parsing here rather than treating it as corruption.
+            ("APP_LOTW_EOF", _) => break,
             (_, None) => return Err(AdifError::MissingLength(name)),
             (_, Some(len_str)) => {
                 let len: usize = len_str
@@ -343,6 +347,28 @@ mod tests {
             parse_adif("<CALL>W1AW<EOR>").unwrap_err(),
             AdifError::MissingLength(_)
         ));
+    }
+
+    #[test]
+    fn parse_lotw_report_with_eof_marker() {
+        // LoTW report: preamble text, lowercase <eoh>, values whose declared
+        // length stops before a trailing `// …` comment, and a lengthless
+        // <APP_LoTW_EOF> terminator that must not error.
+        let text = "ARRL Logbook of the World Status Report\n\
+                    Generated at 2026-07-23 20:48:28\n\
+                    <PROGRAMID:4>LoTW\n<APP_LoTW_NUMREC:1>1\n<eoh>\n\n\
+                    <STATION_CALLSIGN:6>KK7TCY\n<CALL:5>W7WRO\n<BAND:3>40M\n\
+                    <FREQ:7>7.07600\n<MODE:3>FT8\n<QSO_DATE:8>20260712\n\
+                    <APP_LoTW_RXQSO:19>2026-07-23 20:45:06 // QSO record inserted/modified at LoTW\n\
+                    <TIME_ON:6>235600\n<QSL_RCVD:1>Y\n<eor>\n\n<APP_LoTW_EOF>\n";
+        let recs = parse_adif(text).unwrap();
+        assert_eq!(recs.len(), 1);
+        assert_eq!(recs[0]["CALL"], "W7WRO");
+        assert_eq!(recs[0]["QSL_RCVD"], "Y");
+        // Declared length (19) clips the trailing `// …` comment off the value.
+        assert_eq!(recs[0]["APP_LOTW_RXQSO"], "2026-07-23 20:45:06");
+        // The lengthless EOF marker is not captured as a field.
+        assert!(!recs[0].contains_key("APP_LOTW_EOF"));
     }
 
     #[test]

--- a/rigflow-log/src/adif.rs
+++ b/rigflow-log/src/adif.rs
@@ -54,7 +54,7 @@ impl std::fmt::Display for AdifError {
 impl std::error::Error for AdifError {}
 
 /// The ADIF fields modeled as `Qso` columns; every other field goes to `extra`.
-const COLUMN_FIELDS: &[&str] = &[
+pub(crate) const COLUMN_FIELDS: &[&str] = &[
     "CALL",
     "QSO_DATE",
     "TIME_ON",
@@ -157,12 +157,43 @@ pub fn adif_header() -> String {
     "<ADIF_VER:5>3.1.6 <PROGRAMID:7>rigflow <EOH>\n".to_string()
 }
 
+/// This program's ADIF `PROGRAMID`.
+pub const PROGRAM_ID: &str = "rigflow";
+
+/// Serialize one ADIF field as `<NAME:LEN>value`. `LEN` is the **byte** length,
+/// which is what makes `*_INTL` (UTF-8) values round-trip: a multi-byte value
+/// declares its byte count, not its character count.
+fn write_field(name: &str, value: &str) -> String {
+    format!("<{}:{}>{}", name, value.len(), value)
+}
+
+/// A fresh header for an exported file: `ADIF_VER`, `PROGRAMID`,
+/// `PROGRAMVERSION`, `CREATED_TIMESTAMP`, then `<EOH>`.
+///
+/// Distinct from [`adif_header`], which stamps the append-only journal. An
+/// export is a new document with its own creation time; the journal's header was
+/// written once, whenever the journal happened to be started.
+///
+/// `created_timestamp` is ADIF-native `YYYYMMDD HHMMSS` (UTC).
+pub fn export_header(adif_version: &str, program_version: &str, created_timestamp: &str) -> String {
+    let mut out = String::new();
+    out.push_str(&write_field("ADIF_VER", adif_version));
+    out.push(' ');
+    out.push_str(&write_field("PROGRAMID", PROGRAM_ID));
+    out.push(' ');
+    out.push_str(&write_field("PROGRAMVERSION", program_version));
+    out.push(' ');
+    out.push_str(&write_field("CREATED_TIMESTAMP", created_timestamp));
+    out.push_str(" <EOH>\n");
+    out
+}
+
 /// Serialize one record as `<NAME:LEN>value…<EOR>`. Fields are emitted in
 /// sorted (deterministic) order so the writer is stable across round-trips.
 pub fn write_record(record: &AdifRecord) -> String {
     let mut out = String::new();
     for (name, value) in record {
-        out.push_str(&format!("<{}:{}>{}", name, value.len(), value));
+        out.push_str(&write_field(name, value));
         out.push(' ');
     }
     out.push_str("<EOR>\n");

--- a/rigflow-log/src/adif.rs
+++ b/rigflow-log/src/adif.rs
@@ -1,0 +1,395 @@
+//! Hand-rolled ADIF parser and writer.
+//!
+//! ADIF fields are length-prefixed: `<NAME:LEN>value` or `<NAME:LEN:TYPE>value`,
+//! where `LEN` is the **byte** count of `value` (so `*_INTL` UTF-8 fields work
+//! unchanged). Control tags `<EOH>` (end of header) and `<EOR>` (end of record)
+//! carry no length. Text outside tags is a comment and ignored.
+//!
+//! We parse to [`AdifRecord`] (upper-cased field name → value) and map to/from
+//! [`Qso`]: modeled fields become columns, everything else (including `APP_*`
+//! extensions and `*_INTL` fields) round-trips through [`Qso::extra`].
+
+use std::collections::BTreeMap;
+
+use crate::model::Qso;
+
+/// A raw ADIF record: upper-cased field name → value.
+pub type AdifRecord = BTreeMap<String, String>;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AdifError {
+    /// A `<` tag was opened but never closed with `>`.
+    UnterminatedTag,
+    /// A field tag was missing its `:LEN` (only `EOH`/`EOR` may be lengthless).
+    MissingLength(String),
+    /// `LEN` was not a valid number.
+    BadLength(String),
+    /// The declared length ran past the end of the input.
+    TruncatedValue {
+        field: String,
+        want: usize,
+        have: usize,
+    },
+    /// A field value was not valid UTF-8.
+    NonUtf8(String),
+}
+
+impl std::fmt::Display for AdifError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            AdifError::UnterminatedTag => write!(f, "unterminated ADIF tag (missing '>')"),
+            AdifError::MissingLength(t) => write!(f, "ADIF field <{t}> missing length"),
+            AdifError::BadLength(t) => write!(f, "ADIF field <{t}> has an invalid length"),
+            AdifError::TruncatedValue { field, want, have } => {
+                write!(
+                    f,
+                    "ADIF field {field} declares {want} bytes, only {have} left"
+                )
+            }
+            AdifError::NonUtf8(field) => write!(f, "ADIF field {field} value is not valid UTF-8"),
+        }
+    }
+}
+
+impl std::error::Error for AdifError {}
+
+/// The ADIF fields modeled as `Qso` columns; every other field goes to `extra`.
+const COLUMN_FIELDS: &[&str] = &[
+    "CALL",
+    "QSO_DATE",
+    "TIME_ON",
+    "BAND",
+    "MODE",
+    "SUBMODE",
+    "FREQ",
+    "FREQ_RX",
+    "BAND_RX",
+    "RST_SENT",
+    "RST_RCVD",
+    "GRIDSQUARE",
+    "DXCC",
+];
+
+/// Parse an ADIF document into its records. A leading header terminated by
+/// `<EOH>` is discarded; if there is no `<EOH>`, the whole document is records.
+pub fn parse_adif(text: &str) -> Result<Vec<AdifRecord>, AdifError> {
+    let bytes = text.as_bytes();
+    let mut i = 0usize;
+    let mut records: Vec<AdifRecord> = Vec::new();
+    let mut current: AdifRecord = BTreeMap::new();
+
+    while i < bytes.len() {
+        // Advance to the next tag; everything before '<' is comment text.
+        if bytes[i] != b'<' {
+            i += 1;
+            continue;
+        }
+        // Find the closing '>'.
+        let close = bytes[i + 1..]
+            .iter()
+            .position(|&b| b == b'>')
+            .map(|p| i + 1 + p)
+            .ok_or(AdifError::UnterminatedTag)?;
+        let inner = &text[i + 1..close];
+        i = close + 1;
+
+        let mut parts = inner.splitn(3, ':');
+        let name = parts.next().unwrap_or("").trim().to_ascii_uppercase();
+        let len_part = parts.next();
+        // parts.next() would be the optional TYPE indicator; we don't need it.
+
+        match (name.as_str(), len_part) {
+            ("EOH", _) => {
+                // End of header — discard anything accumulated as header fields.
+                current.clear();
+            }
+            ("EOR", _) => {
+                if !current.is_empty() {
+                    records.push(std::mem::take(&mut current));
+                }
+            }
+            (_, None) => return Err(AdifError::MissingLength(name)),
+            (_, Some(len_str)) => {
+                let len: usize = len_str
+                    .trim()
+                    .parse()
+                    .map_err(|_| AdifError::BadLength(name.clone()))?;
+                let end = i + len;
+                if end > bytes.len() {
+                    return Err(AdifError::TruncatedValue {
+                        field: name,
+                        want: len,
+                        have: bytes.len() - i,
+                    });
+                }
+                let value = std::str::from_utf8(&bytes[i..end])
+                    .map_err(|_| AdifError::NonUtf8(name.clone()))?
+                    .to_string();
+                i = end;
+                current.insert(name, value);
+            }
+        }
+    }
+    // Tolerate a final record with no trailing <EOR> only if we already saw
+    // records (otherwise a bare header without <EOH> would masquerade as one).
+    if !current.is_empty() && !records.is_empty() {
+        records.push(current);
+    }
+    Ok(records)
+}
+
+/// The single ingest pipeline: ADIF text → normalized [`Qso`]s. File import and
+/// WSJT-X `LoggedADIF` both go through here, so mode/band normalization and
+/// band-from-freq derivation are applied uniformly.
+pub fn parse_adif_to_qsos(text: &str) -> Result<Vec<Qso>, AdifError> {
+    Ok(parse_adif(text)?
+        .iter()
+        .map(|r| {
+            let mut q = record_to_qso(r);
+            q.normalize();
+            q
+        })
+        .collect())
+}
+
+/// The ADIF header written once at journal creation.
+pub fn adif_header() -> String {
+    "<ADIF_VER:5>3.1.6 <PROGRAMID:7>rigflow <EOH>\n".to_string()
+}
+
+/// Serialize one record as `<NAME:LEN>value…<EOR>`. Fields are emitted in
+/// sorted (deterministic) order so the writer is stable across round-trips.
+pub fn write_record(record: &AdifRecord) -> String {
+    let mut out = String::new();
+    for (name, value) in record {
+        out.push_str(&format!("<{}:{}>{}", name, value.len(), value));
+        out.push(' ');
+    }
+    out.push_str("<EOR>\n");
+    out
+}
+
+/// Convert a [`Qso`] to an [`AdifRecord`]. Modeled columns become their ADIF
+/// fields; `extra` entries are copied verbatim. `FREQ`/`FREQ_RX` are emitted in
+/// MHz per ADIF; `BAND_RX`/`FREQ_RX` are omitted on a simplex QSO.
+pub fn qso_to_record(q: &Qso) -> AdifRecord {
+    let mut r: AdifRecord = BTreeMap::new();
+    r.insert("CALL".into(), q.call.clone());
+    r.insert("QSO_DATE".into(), q.qso_date.clone());
+    r.insert("TIME_ON".into(), q.time_on.clone());
+    if !q.band.is_empty() {
+        r.insert("BAND".into(), q.band.clone());
+    }
+    r.insert("MODE".into(), q.mode.clone());
+    if let Some(sm) = &q.submode {
+        r.insert("SUBMODE".into(), sm.clone());
+    }
+    if let Some(hz) = q.freq_hz {
+        r.insert("FREQ".into(), hz_to_mhz_string(hz));
+    }
+    // Split-only fields: present iff a real split RX frequency exists.
+    if let Some(hz) = q.freq_rx_hz {
+        r.insert("FREQ_RX".into(), hz_to_mhz_string(hz));
+        if let Some(b) = &q.band_rx {
+            r.insert("BAND_RX".into(), b.clone());
+        }
+    }
+    for (k, v) in [
+        ("RST_SENT", &q.rst_sent),
+        ("RST_RCVD", &q.rst_rcvd),
+        ("GRIDSQUARE", &q.gridsquare),
+    ] {
+        if let Some(v) = v {
+            r.insert(k.into(), v.clone());
+        }
+    }
+    if let Some(dxcc) = q.dxcc {
+        r.insert("DXCC".into(), dxcc.to_string());
+    }
+    for (k, v) in &q.extra {
+        r.entry(k.clone()).or_insert_with(|| v.clone());
+    }
+    r
+}
+
+/// Convert an [`AdifRecord`] to a [`Qso`]. Modeled fields fill columns; all
+/// other fields (incl. `APP_*`, `*_INTL`, `MY_*`) go to `extra`. Does **not**
+/// normalize — callers that want canonical mode/band call [`Qso::normalize`].
+pub fn record_to_qso(r: &AdifRecord) -> Qso {
+    let get = |k: &str| r.get(k).cloned();
+    let mut extra = BTreeMap::new();
+    for (k, v) in r {
+        if !COLUMN_FIELDS.contains(&k.as_str()) {
+            extra.insert(k.clone(), v.clone());
+        }
+    }
+    Qso {
+        call: get("CALL").unwrap_or_default(),
+        qso_date: get("QSO_DATE").unwrap_or_default(),
+        time_on: get("TIME_ON").unwrap_or_default(),
+        band: get("BAND").unwrap_or_default(),
+        mode: get("MODE").unwrap_or_default(),
+        submode: get("SUBMODE"),
+        freq_hz: get("FREQ").as_deref().and_then(mhz_string_to_hz),
+        freq_rx_hz: get("FREQ_RX").as_deref().and_then(mhz_string_to_hz),
+        band_rx: get("BAND_RX"),
+        rst_sent: get("RST_SENT"),
+        rst_rcvd: get("RST_RCVD"),
+        gridsquare: get("GRIDSQUARE"),
+        dxcc: get("DXCC").and_then(|s| s.trim().parse().ok()),
+        extra,
+    }
+}
+
+/// Hz → ADIF `FREQ` (MHz, 6 decimal places = 1 Hz resolution).
+pub fn hz_to_mhz_string(hz: u64) -> String {
+    format!("{:.6}", hz as f64 / 1_000_000.0)
+}
+
+/// ADIF `FREQ` (MHz) → Hz, rounded to the nearest Hz. Returns `None` if the
+/// value isn't a number.
+pub fn mhz_string_to_hz(mhz: &str) -> Option<u64> {
+    let v: f64 = mhz.trim().parse().ok()?;
+    if v < 0.0 {
+        return None;
+    }
+    Some((v * 1_000_000.0).round() as u64)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_basic_fields_and_lengths() {
+        let recs = parse_adif("<CALL:4>W1AW <QSO_DATE:8>20260711<EOR>").unwrap();
+        assert_eq!(recs.len(), 1);
+        assert_eq!(recs[0]["CALL"], "W1AW");
+        assert_eq!(recs[0]["QSO_DATE"], "20260711");
+    }
+
+    #[test]
+    fn parse_skips_header_and_comments() {
+        let text = "Generated by X\n<ADIF_VER:5>3.1.6<PROGRAMID:1>X<EOH>\n\
+                    <CALL:4>K5ZD<EOR>\n";
+        let recs = parse_adif(text).unwrap();
+        assert_eq!(recs.len(), 1);
+        assert_eq!(recs[0]["CALL"], "K5ZD");
+        // Header fields must not leak into the record.
+        assert!(!recs[0].contains_key("ADIF_VER"));
+        assert!(!recs[0].contains_key("PROGRAMID"));
+    }
+
+    #[test]
+    fn parse_type_indicator_is_ignored() {
+        let recs = parse_adif("<FREQ:9:N>14.074000<EOR>").unwrap();
+        assert_eq!(recs[0]["FREQ"], "14.074000");
+    }
+
+    #[test]
+    fn parse_value_with_embedded_angle_bracket() {
+        // Length-prefix means '<' inside a value is data, not a tag.
+        let recs = parse_adif("<COMMENT:5>a<b>c<EOR>").unwrap();
+        assert_eq!(recs[0]["COMMENT"], "a<b>c");
+    }
+
+    #[test]
+    fn parse_intl_utf8_byte_length() {
+        // "José" is 5 bytes in UTF-8 (é = 2 bytes).
+        let recs = parse_adif("<NAME_INTL:5>José<EOR>").unwrap();
+        assert_eq!(recs[0]["NAME_INTL"], "José");
+    }
+
+    #[test]
+    fn parse_truncated_value_errors() {
+        let err = parse_adif("<CALL:10>W1AW<EOR>").unwrap_err();
+        assert!(matches!(err, AdifError::TruncatedValue { .. }));
+    }
+
+    #[test]
+    fn parse_field_missing_length_errors() {
+        assert!(matches!(
+            parse_adif("<CALL>W1AW<EOR>").unwrap_err(),
+            AdifError::MissingLength(_)
+        ));
+    }
+
+    #[test]
+    fn parse_two_records() {
+        let recs = parse_adif("<CALL:4>W1AW<EOR><CALL:4>K5ZD<EOR>").unwrap();
+        assert_eq!(recs.len(), 2);
+        assert_eq!(recs[1]["CALL"], "K5ZD");
+    }
+
+    #[test]
+    fn freq_roundtrip() {
+        for hz in [
+            1_840_000u64,
+            14_074_000,
+            21_074_000,
+            50_313_000,
+            144_174_000,
+        ] {
+            assert_eq!(mhz_string_to_hz(&hz_to_mhz_string(hz)), Some(hz));
+        }
+    }
+
+    fn sample_qso() -> Qso {
+        let mut extra = BTreeMap::new();
+        extra.insert("APP_RIGFLOW_FOO".into(), "bar".into());
+        extra.insert("NAME_INTL".into(), "José".into());
+        extra.insert("MY_GRIDSQUARE".into(), "EM12".into());
+        Qso {
+            call: "W1AW".into(),
+            qso_date: "20260711".into(),
+            time_on: "142300".into(),
+            band: "20m".into(),
+            mode: "SSB".into(),
+            submode: None,
+            freq_hz: Some(14_207_000),
+            freq_rx_hz: Some(14_200_000),
+            band_rx: Some("20m".into()),
+            rst_sent: Some("59".into()),
+            rst_rcvd: Some("57".into()),
+            gridsquare: Some("FN31".into()),
+            dxcc: Some(291),
+            extra,
+        }
+    }
+
+    #[test]
+    fn write_parse_write_byte_identical() {
+        let q = sample_qso();
+        let first = write_record(&qso_to_record(&q));
+        let reparsed = record_to_qso(&parse_adif(&first).unwrap()[0]);
+        let second = write_record(&qso_to_record(&reparsed));
+        assert_eq!(first, second, "round-trip must be byte-identical");
+    }
+
+    #[test]
+    fn roundtrip_preserves_app_intl_my_fields() {
+        let q = sample_qso();
+        let reparsed = record_to_qso(&parse_adif(&write_record(&qso_to_record(&q))).unwrap()[0]);
+        assert_eq!(
+            reparsed.extra.get("APP_RIGFLOW_FOO"),
+            Some(&"bar".to_string())
+        );
+        assert_eq!(reparsed.extra.get("NAME_INTL"), Some(&"José".to_string()));
+        assert_eq!(
+            reparsed.extra.get("MY_GRIDSQUARE"),
+            Some(&"EM12".to_string())
+        );
+        // Whole Qso round-trips (no column lost, none invented).
+        assert_eq!(reparsed, q);
+    }
+
+    #[test]
+    fn simplex_omits_rx_fields() {
+        let mut q = sample_qso();
+        q.freq_rx_hz = None;
+        q.band_rx = None;
+        let rec = qso_to_record(&q);
+        assert!(!rec.contains_key("FREQ_RX"));
+        assert!(!rec.contains_key("BAND_RX"));
+    }
+}

--- a/rigflow-log/src/capture.rs
+++ b/rigflow-log/src/capture.rs
@@ -1,0 +1,184 @@
+//! Split-frequency capture: deriving the ADIF `FREQ` (TX) and `FREQ_RX` (RX)
+//! from a snapshot of the radio's receivers.
+//!
+//! rigflow is an SDR that may run more than one receive channel (dual-watch
+//! played as stereo). Only one of them is the station being worked. The client
+//! builds a [`CapturedRadioState`] from its live UI state — marking which
+//! receiver transmits via the *effective-TX* rule (split → the TX VFO's target
+//! plus XIT), never VFO-A blindly — and this module turns it into the two
+//! logged frequencies. Keeping the derivation here (with no client/egui deps)
+//! makes it unit-testable.
+
+use crate::normalize::band_for_freq_hz;
+
+/// One receive channel's state at capture time.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Receiver {
+    pub freq_hz: u64,
+    /// True for the receiver selected for transmit. In split you also *receive*
+    /// on your TX frequency (to hear the pileup); that receiver must be marked
+    /// `is_tx` so it's excluded from the `FREQ_RX` search.
+    pub is_tx: bool,
+}
+
+/// A frozen snapshot of the radio's operating state, captured the instant the
+/// log entry opens.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CapturedRadioState {
+    /// Effective transmit frequency (Hz) — becomes ADIF `FREQ`.
+    pub tx_freq_hz: u64,
+    /// Normalized ADIF transmit mode (the client maps `DemodMode` → ADIF).
+    pub tx_mode: String,
+    /// Whether split TX is active. `FREQ_RX` is a split field: when this is
+    /// false, `derive_freq_rx` returns `None` regardless of how many receivers
+    /// are producing audio (plain dual-watch is not split).
+    pub split_active: bool,
+    /// Every receive channel currently active (1 or 2 on today's hardware, but
+    /// the derivation is general over N).
+    pub receivers: Vec<Receiver>,
+}
+
+impl CapturedRadioState {
+    /// ADIF `FREQ`: the effective transmit frequency.
+    pub fn derive_freq_tx(&self) -> u64 {
+        self.tx_freq_hz
+    }
+
+    /// ADIF `FREQ_RX`: the frequency of the receiver most likely copying the
+    /// worked station.
+    ///
+    /// Rule: among receivers that are **(a)** not the TX receiver and **(b)** on
+    /// the same band as TX, pick the one **nearest in frequency to TX**. Gated
+    /// on [`split_active`](Self::split_active) — simplex TX yields `None` (write
+    /// `FREQ_RX`/`BAND_RX` as NULL). It is a *default*, meant to be shown
+    /// editable in the UI: no heuristic can be certain which receiver copied the
+    /// DX, only that it's overwhelmingly likely.
+    pub fn derive_freq_rx(&self) -> Option<u64> {
+        if !self.split_active {
+            return None;
+        }
+        let tx_band = band_for_freq_hz(self.tx_freq_hz)?;
+        self.receivers
+            .iter()
+            .filter(|r| !r.is_tx)
+            .filter(|r| band_for_freq_hz(r.freq_hz) == Some(tx_band))
+            .min_by_key(|r| r.freq_hz.abs_diff(self.tx_freq_hz))
+            .map(|r| r.freq_hz)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn rx(freq_hz: u64, is_tx: bool) -> Receiver {
+        Receiver { freq_hz, is_tx }
+    }
+
+    fn state(tx: u64, split: bool, receivers: Vec<Receiver>) -> CapturedRadioState {
+        CapturedRadioState {
+            tx_freq_hz: tx,
+            tx_mode: "SSB".into(),
+            split_active: split,
+            receivers,
+        }
+    }
+
+    // (a) Two VFOs, one is TX → picks the other.
+    #[test]
+    fn two_vfos_picks_non_tx() {
+        let s = state(
+            14_207_000,
+            true,
+            vec![rx(14_207_000, true), rx(14_200_000, false)],
+        );
+        assert_eq!(s.derive_freq_rx(), Some(14_200_000));
+    }
+
+    // (b) A receiver sitting on the TX frequency (the pileup echo) is excluded,
+    //     so the far DX receiver wins rather than collapsing split→simplex.
+    #[test]
+    fn tx_echo_receiver_excluded() {
+        let s = state(
+            14_207_000,
+            true,
+            vec![
+                rx(14_207_000, true),  // TX / pileup echo — excluded
+                rx(14_200_000, false), // the DX
+            ],
+        );
+        let rxf = s.derive_freq_rx().unwrap();
+        assert_eq!(rxf, 14_200_000);
+        assert_ne!(rxf, s.derive_freq_tx(), "must not collapse to simplex");
+    }
+
+    // (c) A receiver on a different band is excluded even if numerically nearer
+    //     in raw Hz.
+    #[test]
+    fn other_band_receiver_excluded_even_if_nearer() {
+        // A 30m receiver at 10.150 is only 50 kHz from a (hypothetical) tx, but
+        // it's a different band; the same-band 20m receiver must win.
+        let s = state(
+            14_100_000,
+            true,
+            vec![
+                rx(14_100_000, true),  // TX
+                rx(10_150_000, false), // 30m — nearer in raw Hz? no, but different band
+                rx(14_050_000, false), // 20m — same band, the real DX
+            ],
+        );
+        assert_eq!(s.derive_freq_rx(), Some(14_050_000));
+    }
+
+    // Sharper version of (c): the other-band receiver is genuinely closer in raw Hz.
+    #[test]
+    fn other_band_nearer_in_hz_still_excluded() {
+        // TX 14.000 (20m band edge). A 17m receiver at 18.068 is 4.068 MHz away;
+        // put an out-of-band receiver 1 kHz away to prove raw-Hz nearness loses.
+        let s = state(
+            14_000_000,
+            true,
+            vec![
+                rx(14_000_000, true),  // TX
+                rx(13_999_000, false), // 1 kHz away but OUT of any ham band
+                rx(14_100_000, false), // 100 kHz away, same 20m band → must win
+            ],
+        );
+        assert_eq!(s.derive_freq_rx(), Some(14_100_000));
+    }
+
+    // (d) Three receivers → nearest-to-TX on the same band wins.
+    #[test]
+    fn three_receivers_nearest_on_band_wins() {
+        let s = state(
+            14_250_000,
+            true,
+            vec![
+                rx(14_250_000, true),  // TX
+                rx(14_100_000, false), // 150 kHz away
+                rx(14_240_000, false), // 10 kHz away → nearest, wins
+                rx(14_300_000, false), // 50 kHz away
+            ],
+        );
+        assert_eq!(s.derive_freq_rx(), Some(14_240_000));
+    }
+
+    // (e) Simplex TX → None even with multiple receivers active (dual-watch is
+    //     not split).
+    #[test]
+    fn simplex_multi_receiver_is_none() {
+        let s = state(
+            14_207_000,
+            false, // not split
+            vec![rx(14_207_000, true), rx(14_100_000, false)],
+        );
+        assert_eq!(s.derive_freq_rx(), None);
+    }
+
+    #[test]
+    fn split_but_no_non_tx_candidate_is_none() {
+        // Split active but only the TX receiver exists → nothing to derive.
+        let s = state(14_207_000, true, vec![rx(14_207_000, true)]);
+        assert_eq!(s.derive_freq_rx(), None);
+    }
+}

--- a/rigflow-log/src/dedupe.rs
+++ b/rigflow-log/src/dedupe.rs
@@ -1,0 +1,108 @@
+//! Duplicate detection: natural key `call + mode + band` within a time window.
+//!
+//! This is a **soft** signal, never a hard reject. Contests legitimately
+//! re-work the same station on the same band/mode, so the caller decides what
+//! to do with a match (typically warn the operator). It exists mainly to guard
+//! against double-logging the same QSO — e.g. a QSO logged both by rigflow and
+//! by GridTracker, or a WSJT-X "logged ADIF" packet arriving twice.
+
+use chrono::NaiveDateTime;
+
+use crate::model::Qso;
+
+/// Default match window: ±30 minutes.
+pub const DEFAULT_WINDOW_SECS: i64 = 30 * 60;
+
+/// Parse ADIF `qso_date` (`YYYYMMDD`) + `time_on` (`HHMM` or `HHMMSS`) into a
+/// naive UTC datetime. Returns `None` on malformed input.
+pub fn parse_dt(date: &str, time: &str) -> Option<NaiveDateTime> {
+    let t = match time.trim().len() {
+        4 => format!("{}00", time.trim()), // HHMM → HHMM00
+        6 => time.trim().to_string(),
+        _ => return None,
+    };
+    NaiveDateTime::parse_from_str(&format!("{}{}", date.trim(), t), "%Y%m%d%H%M%S").ok()
+}
+
+/// Same natural key: callsign (case-insensitive), mode, and band all match.
+pub fn same_natural_key(a: &Qso, b: &Qso) -> bool {
+    a.call.eq_ignore_ascii_case(b.call.trim()) && a.mode == b.mode && a.band == b.band
+}
+
+/// The two QSOs' start times are within `window_secs` of each other. If either
+/// timestamp is unparseable, they are treated as **not** within the window
+/// (conservative — don't suppress on bad data).
+pub fn within_window(a: &Qso, b: &Qso, window_secs: i64) -> bool {
+    match (
+        parse_dt(&a.qso_date, &a.time_on),
+        parse_dt(&b.qso_date, &b.time_on),
+    ) {
+        (Some(x), Some(y)) => (x - y).num_seconds().abs() <= window_secs,
+        _ => false,
+    }
+}
+
+/// Same natural key AND within the time window.
+pub fn is_duplicate(a: &Qso, b: &Qso, window_secs: i64) -> bool {
+    same_natural_key(a, b) && within_window(a, b, window_secs)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn q(call: &str, band: &str, mode: &str, date: &str, time: &str) -> Qso {
+        Qso {
+            call: call.into(),
+            band: band.into(),
+            mode: mode.into(),
+            qso_date: date.into(),
+            time_on: time.into(),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn same_contact_five_minutes_apart_is_dup() {
+        let a = q("W1AW", "20m", "SSB", "20260711", "142300");
+        let b = q("w1aw", "20m", "SSB", "20260711", "142800");
+        assert!(is_duplicate(&a, &b, DEFAULT_WINDOW_SECS));
+    }
+
+    #[test]
+    fn window_boundary_is_inclusive() {
+        let a = q("W1AW", "20m", "SSB", "20260711", "140000");
+        let exactly = q("W1AW", "20m", "SSB", "20260711", "143000"); // +30:00
+        let just_over = q("W1AW", "20m", "SSB", "20260711", "143001"); // +30:01
+        assert!(is_duplicate(&a, &exactly, DEFAULT_WINDOW_SECS));
+        assert!(!is_duplicate(&a, &just_over, DEFAULT_WINDOW_SECS));
+    }
+
+    #[test]
+    fn contest_rework_hours_later_is_not_dup() {
+        let a = q("W1AW", "20m", "SSB", "20260711", "142300");
+        let b = q("W1AW", "20m", "SSB", "20260711", "182300"); // 4h later
+        assert!(!is_duplicate(&a, &b, DEFAULT_WINDOW_SECS));
+    }
+
+    #[test]
+    fn different_band_is_not_dup() {
+        let a = q("W1AW", "20m", "SSB", "20260711", "142300");
+        let b = q("W1AW", "40m", "SSB", "20260711", "142400");
+        assert!(!is_duplicate(&a, &b, DEFAULT_WINDOW_SECS));
+    }
+
+    #[test]
+    fn different_mode_is_not_dup() {
+        let a = q("W1AW", "20m", "SSB", "20260711", "142300");
+        let b = q("W1AW", "20m", "CW", "20260711", "142400");
+        assert!(!is_duplicate(&a, &b, DEFAULT_WINDOW_SECS));
+    }
+
+    #[test]
+    fn dup_across_midnight() {
+        let a = q("W1AW", "20m", "SSB", "20260711", "235800");
+        let b = q("W1AW", "20m", "SSB", "20260712", "000200"); // +4 min over date line
+        assert!(is_duplicate(&a, &b, DEFAULT_WINDOW_SECS));
+    }
+}

--- a/rigflow-log/src/display.rs
+++ b/rigflow-log/src/display.rs
@@ -1,0 +1,122 @@
+//! Human-readable rendering of ADIF-native values.
+//!
+//! ADIF stores a date as `YYYYMMDD` and a time as `HHMMSS` — compact, sortable,
+//! and unpleasant to read at a glance (`20260712`, `2356`). These helpers are
+//! **presentation only**: the database, the journal, and every exported file keep
+//! the ADIF-native form, because that is what the spec (and every other logging
+//! program) requires. Nothing here ever feeds back into storage.
+//!
+//! Dates render ISO-style (`2026-07-12`) rather than a locale order: rigflow's
+//! log is UTC and international, and `07/12` means two different days depending
+//! on which side of the Atlantic the operator is on.
+//!
+//! Every function is **total** — a malformed value from an imported log is
+//! passed through unchanged rather than panicking or silently becoming wrong.
+//! Third-party ADIF is not guaranteed to be well-formed, and a log viewer that
+//! crashes on someone else's file is worse than one that shows an odd string.
+
+/// `20260712` → `2026-07-12`. Anything that isn't 8 digits is returned as-is.
+pub fn date(qso_date: &str) -> String {
+    let d = qso_date.trim();
+    if d.len() != 8 || !d.bytes().all(|b| b.is_ascii_digit()) {
+        return d.to_string();
+    }
+    format!("{}-{}-{}", &d[0..4], &d[4..6], &d[6..8])
+}
+
+/// `235612` or `2356` → `23:56`. Seconds are dropped: they're noise in a log
+/// list, and ADIF permits a 4-digit `HHMM` anyway. Anything that isn't 4 or 6
+/// digits is returned as-is.
+pub fn time_hhmm(time_on: &str) -> String {
+    let t = time_on.trim();
+    if !matches!(t.len(), 4 | 6) || !t.bytes().all(|b| b.is_ascii_digit()) {
+        return t.to_string();
+    }
+    format!("{}:{}", &t[0..2], &t[2..4])
+}
+
+/// `235612` → `23:56:12`, for the one place seconds matter (the frozen capture
+/// on the entry window, where the operator is checking the logged instant).
+pub fn time_hhmmss(time_on: &str) -> String {
+    let t = time_on.trim();
+    if t.len() != 6 || !t.bytes().all(|b| b.is_ascii_digit()) {
+        return time_hhmm(t);
+    }
+    format!("{}:{}:{}", &t[0..2], &t[2..4], &t[4..6])
+}
+
+/// `20260712` + `2356` → `2026-07-12 23:56Z`.
+pub fn datetime(qso_date: &str, time_on: &str) -> String {
+    format!("{} {}Z", date(qso_date), time_hhmm(time_on))
+}
+
+/// Accept a human-typed date and return the ADIF-native form.
+///
+/// The UI *shows* `2026-07-12`, so an operator will reasonably *type* that into
+/// a date filter — accepting only `20260712` there would be a small betrayal.
+/// Strips `-` / `/` separators; anything else is passed through for
+/// `ExportFilter::validate` to reject with a proper message.
+pub fn date_to_adif(input: &str) -> String {
+    input
+        .trim()
+        .chars()
+        .filter(|c| *c != '-' && *c != '/')
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn dates_render_iso() {
+        assert_eq!(date("20260712"), "2026-07-12");
+        assert_eq!(date(" 20260101 "), "2026-01-01");
+    }
+
+    #[test]
+    fn times_render_with_a_colon() {
+        assert_eq!(time_hhmm("235612"), "23:56");
+        assert_eq!(time_hhmm("2356"), "23:56"); // ADIF permits 4-digit HHMM
+        assert_eq!(time_hhmm("0007"), "00:07");
+        assert_eq!(time_hhmmss("235612"), "23:56:12");
+    }
+
+    #[test]
+    fn datetime_marks_utc() {
+        assert_eq!(datetime("20260712", "235612"), "2026-07-12 23:56Z");
+    }
+
+    #[test]
+    fn malformed_values_pass_through_rather_than_panic() {
+        // An imported log is not guaranteed well-formed. A viewer that panics on
+        // someone else's ADIF is worse than one that shows an odd string.
+        for junk in ["", "2026-07-12", "notadate", "202607", "1", "202607123"] {
+            assert_eq!(date(junk), junk.trim());
+        }
+        for junk in ["", "23", "23561", "abcd", "12345678"] {
+            assert_eq!(time_hhmm(junk), junk.trim());
+        }
+        // Crucially: no slicing panic on a short value (the old UI did `[..4]`).
+        assert_eq!(time_hhmm("2"), "2");
+        assert_eq!(time_hhmmss("2"), "2");
+    }
+
+    #[test]
+    fn typed_dates_come_back_adif_native() {
+        assert_eq!(date_to_adif("2026-07-12"), "20260712");
+        assert_eq!(date_to_adif("2026/07/12"), "20260712");
+        assert_eq!(date_to_adif("20260712"), "20260712");
+        assert_eq!(date_to_adif(" 2026-07-12 "), "20260712");
+        // Junk is preserved so validate() can reject it with a real message.
+        assert_eq!(date_to_adif("nope"), "nope");
+    }
+
+    #[test]
+    fn display_round_trips_with_the_input_parser() {
+        // What we render, we must accept back — otherwise the operator retypes
+        // what they see and gets an error.
+        let adif = "20260712";
+        assert_eq!(date_to_adif(&date(adif)), adif);
+    }
+}

--- a/rigflow-log/src/error.rs
+++ b/rigflow-log/src/error.rs
@@ -1,6 +1,7 @@
 //! Crate error type.
 
 use crate::adif::AdifError;
+use crate::export::FilterError;
 
 #[derive(Debug)]
 pub enum LogError {
@@ -8,6 +9,8 @@ pub enum LogError {
     Io(std::io::Error),
     Adif(AdifError),
     Json(serde_json::Error),
+    /// An export filter was rejected before it reached SQL.
+    Filter(FilterError),
     /// A database reported a `user_version` this build doesn't know how to
     /// migrate (e.g. opened by a newer rigflow).
     UnknownSchemaVersion(i64),
@@ -20,6 +23,7 @@ impl std::fmt::Display for LogError {
             LogError::Io(e) => write!(f, "io error: {e}"),
             LogError::Adif(e) => write!(f, "adif error: {e}"),
             LogError::Json(e) => write!(f, "json error: {e}"),
+            LogError::Filter(e) => write!(f, "export filter: {e}"),
             LogError::UnknownSchemaVersion(v) => {
                 write!(
                     f,
@@ -50,5 +54,10 @@ impl From<AdifError> for LogError {
 impl From<serde_json::Error> for LogError {
     fn from(e: serde_json::Error) -> Self {
         LogError::Json(e)
+    }
+}
+impl From<FilterError> for LogError {
+    fn from(e: FilterError) -> Self {
+        LogError::Filter(e)
     }
 }

--- a/rigflow-log/src/error.rs
+++ b/rigflow-log/src/error.rs
@@ -1,0 +1,54 @@
+//! Crate error type.
+
+use crate::adif::AdifError;
+
+#[derive(Debug)]
+pub enum LogError {
+    Db(rusqlite::Error),
+    Io(std::io::Error),
+    Adif(AdifError),
+    Json(serde_json::Error),
+    /// A database reported a `user_version` this build doesn't know how to
+    /// migrate (e.g. opened by a newer rigflow).
+    UnknownSchemaVersion(i64),
+}
+
+impl std::fmt::Display for LogError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            LogError::Db(e) => write!(f, "database error: {e}"),
+            LogError::Io(e) => write!(f, "io error: {e}"),
+            LogError::Adif(e) => write!(f, "adif error: {e}"),
+            LogError::Json(e) => write!(f, "json error: {e}"),
+            LogError::UnknownSchemaVersion(v) => {
+                write!(
+                    f,
+                    "unknown schema version {v} (database newer than this build?)"
+                )
+            }
+        }
+    }
+}
+
+impl std::error::Error for LogError {}
+
+impl From<rusqlite::Error> for LogError {
+    fn from(e: rusqlite::Error) -> Self {
+        LogError::Db(e)
+    }
+}
+impl From<std::io::Error> for LogError {
+    fn from(e: std::io::Error) -> Self {
+        LogError::Io(e)
+    }
+}
+impl From<AdifError> for LogError {
+    fn from(e: AdifError) -> Self {
+        LogError::Adif(e)
+    }
+}
+impl From<serde_json::Error> for LogError {
+    fn from(e: serde_json::Error) -> Self {
+        LogError::Json(e)
+    }
+}

--- a/rigflow-log/src/export/filter.rs
+++ b/rigflow-log/src/export/filter.rs
@@ -1,0 +1,512 @@
+//! [`ExportFilter`] — the public API of export — plus output options and
+//! up-front validation.
+//!
+//! Every filter field is `Option`: absent means "no constraint on this
+//! dimension", never "match nothing". The egui dialog and any programmatic
+//! caller both build one of these; [`crate::export::query`] is the only thing
+//! that knows how they become SQL.
+//!
+//! **Combining semantics** (fixed, relied on by the tests):
+//! - different filter *categories* combine with **AND**
+//! - multiple values *within* one filter combine with **OR** (`bands = [20m,
+//!   40m]` means 20m **or** 40m)
+//! - `not_*` variants negate.
+
+use std::path::PathBuf;
+
+use crate::normalize::{self, ModeClass};
+
+/// The ADIF `CONT` enumeration. Closed set, so a typo is a validation error
+/// rather than an export that silently matches nothing.
+pub const CONTINENTS: &[&str] = &["NA", "SA", "EU", "AF", "AS", "OC", "AN"];
+
+/// How much of a gridsquare to compare.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum GridPrecision {
+    /// First 2 chars — the Maidenhead *field* (e.g. `EM`).
+    Field,
+    /// First 4 chars — the *square* (e.g. `EM12`).
+    Square,
+    /// The whole stored gridsquare, exact.
+    #[default]
+    Full,
+}
+
+impl GridPrecision {
+    /// Number of leading characters to compare, or `None` for the whole value.
+    pub fn chars(self) -> Option<usize> {
+        match self {
+            GridPrecision::Field => Some(2),
+            GridPrecision::Square => Some(4),
+            GridPrecision::Full => None,
+        }
+    }
+}
+
+/// A QSL status filter: the status letters to match, optionally scoped to one
+/// service.
+///
+/// `service = None` matches the QSO-level `QSL_SENT` / `QSL_RCVD`;
+/// `service = Some("lotw")` matches `LOTW_QSL_SENT` / `LOTW_QSL_RCVD`.
+///
+/// **These come from the `extra` JSON, not from `qso_service`** — that table has
+/// no status column (it holds upload/confirm *timestamps*), and in ADIF the QSL
+/// status fields are QSO-level anyway. This is a deliberate deviation, confirmed
+/// with the user; see the crate-level export docs.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct QslStatusFilter {
+    /// `None` = the QSO-level field; `Some(svc)` = that service's variant.
+    pub service: Option<String>,
+    /// Status letters to match (ADIF: `Y`, `N`, `R`, `I`, `V`). ORed.
+    pub statuses: Vec<String>,
+}
+
+/// A full-precision UTC instant, ADIF-native.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Timestamp {
+    /// `YYYYMMDD`
+    pub date: String,
+    /// `HHMMSS` (a 4-digit `HHMM` is accepted and padded).
+    pub time: String,
+}
+
+impl Timestamp {
+    /// The 14-char `YYYYMMDDHHMMSS` key this compares as. Times are padded to 6
+    /// digits so a 4-digit ADIF `TIME_ON` still orders correctly.
+    pub fn key(&self) -> String {
+        let mut t = self.time.trim().to_string();
+        while t.len() < 6 {
+            t.push('0');
+        }
+        format!("{}{}", self.date.trim(), &t[..6])
+    }
+}
+
+/// Which ADIF fields an exported record carries.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub enum FieldProfile {
+    /// All modeled columns, plus the `extra` passthrough when
+    /// [`ExportOptions::include_extra`] is set.
+    #[default]
+    Full,
+    /// A minimal, self-sufficient set — see [`CORE_FIELDS`].
+    Core,
+    /// Exactly these ADIF fields (upper-cased), and nothing else.
+    Custom(Vec<String>),
+}
+
+/// The `Core` profile's field set.
+///
+/// Note `SUBMODE` is included even though the brief's Core list omits it:
+/// without it an FT4 QSO exports as bare `MODE=MFSK` and loses its identity on
+/// re-import, and an FT8-vs-FT4 distinction is not something a "minimal but
+/// correct" profile can afford to drop. `FREQ_RX`/`BAND_RX` are listed here but,
+/// like every field, only emitted when actually present on the record — so a
+/// simplex QSO still omits them.
+pub const CORE_FIELDS: &[&str] = &[
+    "CALL",
+    "QSO_DATE",
+    "TIME_ON",
+    "BAND",
+    "MODE",
+    "SUBMODE",
+    "FREQ",
+    "FREQ_RX",
+    "BAND_RX",
+    "RST_SENT",
+    "RST_RCVD",
+    "GRIDSQUARE",
+];
+
+/// Record ordering in the output file.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum Sort {
+    /// Oldest first (`qso_date`, `time_on` ascending) — the ADIF convention.
+    #[default]
+    Chronological,
+    /// Newest first.
+    Reverse,
+}
+
+/// The ADIF spec version stamped into the header.
+pub const DEFAULT_ADIF_VERSION: &str = "3.1.6";
+
+/// The incremental bookmark profile used when the caller doesn't name one.
+pub const DEFAULT_EXPORT_PROFILE: &str = "default";
+
+/// Output shape — *not* filters. These never affect which QSOs match, only how
+/// the matched ones are written.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExportOptions {
+    /// Destination file.
+    pub output_path: PathBuf,
+    pub field_profile: FieldProfile,
+    /// Emit the `extra` passthrough (`APP_*`, `MY_*`, unmodeled ADIF fields).
+    /// Only meaningful for [`FieldProfile::Full`] — `Core` and `Custom` are
+    /// explicit whitelists and ignore it.
+    pub include_extra: bool,
+    pub adif_version: String,
+    pub sort: Sort,
+}
+
+impl Default for ExportOptions {
+    fn default() -> Self {
+        ExportOptions {
+            output_path: PathBuf::new(),
+            field_profile: FieldProfile::Full,
+            include_extra: true,
+            adif_version: DEFAULT_ADIF_VERSION.to_string(),
+            sort: Sort::Chronological,
+        }
+    }
+}
+
+/// Which QSOs to export. All-optional; see the module docs for how the fields
+/// combine.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ExportFilter {
+    // ---- A. date / time (all UTC) ----
+    /// Inclusive `YYYYMMDD` lower bound on `qso_date`.
+    pub date_from: Option<String>,
+    /// Inclusive `YYYYMMDD` upper bound on `qso_date`.
+    pub date_to: Option<String>,
+    /// Inclusive full-precision lower bound (contest sessions).
+    pub datetime_from: Option<Timestamp>,
+    /// Inclusive full-precision upper bound.
+    pub datetime_to: Option<Timestamp>,
+    /// Export only QSOs newer than this named bookmark's position. Filters on
+    /// **insertion order** (`qso.id`), not `qso_date` — it's about export
+    /// progress, not contact time. `Some(profile_name)`; see
+    /// [`DEFAULT_EXPORT_PROFILE`].
+    pub since_last_export: Option<String>,
+
+    // ---- B. frequency / band / mode ----
+    /// ADIF `BAND` values. Matches the TX `band` column.
+    pub bands: Option<Vec<String>>,
+    /// Also match `band_rx` (the rare split-across-bands QSO). Only meaningful
+    /// alongside `bands`.
+    pub match_either_band: bool,
+    /// Inclusive Hz lower bound on `freq_hz` (TX).
+    pub freq_from: Option<u64>,
+    /// Inclusive Hz upper bound on `freq_hz` (TX).
+    pub freq_to: Option<u64>,
+    /// Exact canonical `MODE` values (`SSB`, `CW`, `FT8`, `MFSK`, …).
+    pub modes: Option<Vec<String>>,
+    /// Exact `SUBMODE` values (`FT4`, `PSK31`, …).
+    pub submodes: Option<Vec<String>>,
+    /// Coarse mode families; expanded to concrete modes via
+    /// [`normalize::modes_in_class`].
+    pub mode_classes: Option<Vec<ModeClass>>,
+
+    // ---- C. worked station / entity ----
+    pub call_exact: Option<String>,
+    /// User wildcard: `*` = any run, `?` = any one char. Passed as a bound
+    /// parameter — never interpolated.
+    pub call_pattern: Option<String>,
+    /// Starts-with (a rough DXCC-prefix filter, e.g. `JA`).
+    pub call_prefix: Option<String>,
+    pub dxcc: Option<Vec<i64>>,
+    /// ADIF `CONT` — see [`CONTINENTS`]. From `extra`.
+    pub continent: Option<Vec<String>>,
+    /// ADIF `CQZ`. From `extra`. Compared numerically, so a stored `"05"` and a
+    /// filter of `5` match.
+    pub cq_zone: Option<Vec<i64>>,
+    /// ADIF `ITUZ`. From `extra`. Compared numerically.
+    pub itu_zone: Option<Vec<i64>>,
+    /// The worked station's grid, compared at `grid_precision`.
+    pub gridsquare: Option<String>,
+    pub grid_precision: GridPrecision,
+    /// ADIF `STATE`. From `extra`.
+    pub state: Option<Vec<String>>,
+    /// ADIF `COUNTRY`. From `extra`.
+    pub country: Option<Vec<String>>,
+
+    // ---- D. my station ----
+    /// `station.id` values. NB this identifies **which callsign** was used, not
+    /// which location: the station row is keyed on callsign and updated in
+    /// place, so it holds the *current* location, not the one in force at QSO
+    /// time. Location filters below read the per-QSO snapshot instead.
+    pub station_ids: Option<Vec<i64>>,
+    /// `MY_GRIDSQUARE` **from the per-QSO snapshot in `extra`**, so a filter
+    /// still finds the QSOs made from a grid you've since moved away from.
+    pub my_gridsquare: Option<String>,
+    /// `OPERATOR` from the snapshot.
+    pub operator: Option<String>,
+    /// `STATION_CALLSIGN` from the snapshot (may differ from `OPERATOR`).
+    pub station_callsign: Option<String>,
+
+    // ---- E. confirmation / service ----
+    // These join `qso_service`, which is empty until a later phase populates it.
+    // That is correct, not a bug: `not_uploaded_to` then matches everything and
+    // `uploaded_to`/`confirmed_by` match nothing. They light up on their own.
+    pub uploaded_to: Option<Vec<String>>,
+    pub not_uploaded_to: Option<Vec<String>>,
+    pub confirmed_by: Option<Vec<String>>,
+    pub not_confirmed_by: Option<Vec<String>>,
+    pub qsl_sent: Option<QslStatusFilter>,
+    pub qsl_rcvd: Option<QslStatusFilter>,
+
+    // ---- F. contest ----
+    /// ADIF `CONTEST_ID`. From `extra`.
+    pub contest_ids: Option<Vec<String>>,
+
+    // ---- G. explicit selection ----
+    /// Explicit `qso.id` list (the rows a user multi-selected).
+    ///
+    /// **This ANDs with the other filters** — it's a selection you may further
+    /// narrow, not an override. The UI clears the other filters when exporting a
+    /// selection, so there is exactly one authoritative behavior here.
+    pub qso_ids: Option<Vec<i64>>,
+}
+
+/// Why a filter or option was rejected. Export validates up front and refuses,
+/// rather than running a query that silently matches nothing.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum FilterError {
+    BadDate(String),
+    BadTime(String),
+    /// A `from` bound is later than its `to` bound.
+    InvertedRange {
+        from: String,
+        to: String,
+    },
+    UnknownBand(String),
+    /// A mode that isn't canonical (e.g. `USB`, `FT4`) — with the canonical form
+    /// to use instead, so the message is actionable.
+    NonCanonicalMode {
+        given: String,
+        canonical: String,
+    },
+    UnknownContinent(String),
+    /// A list-valued filter was present but empty — almost certainly a UI bug,
+    /// and it would match nothing.
+    EmptyList(&'static str),
+    /// `FieldProfile::Custom` with no fields.
+    EmptyFieldList,
+    /// A service name with characters outside `[A-Za-z0-9_]`.
+    ///
+    /// Service names in [`QslStatusFilter::service`] are the one user value that
+    /// reaches SQL as *text* rather than as a bound parameter — they name an
+    /// ADIF field inside a `json_extract` path (`'$.LOTW_QSL_RCVD'`), and SQLite
+    /// takes no parameter there. So they are whitelisted at the door instead.
+    BadServiceName(String),
+}
+
+impl std::fmt::Display for FilterError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            FilterError::BadDate(d) => write!(f, "invalid date {d:?} (want YYYYMMDD)"),
+            FilterError::BadTime(t) => write!(f, "invalid time {t:?} (want HHMM or HHMMSS)"),
+            FilterError::InvertedRange { from, to } => {
+                write!(f, "range start {from:?} is after its end {to:?}")
+            }
+            FilterError::UnknownBand(b) => write!(f, "unknown band {b:?}"),
+            FilterError::NonCanonicalMode { given, canonical } => write!(
+                f,
+                "{given:?} is not a canonical ADIF MODE — use {canonical:?} \
+                 (or filter it as a submode)"
+            ),
+            FilterError::UnknownContinent(c) => {
+                write!(f, "unknown continent {c:?} (want one of {CONTINENTS:?})")
+            }
+            FilterError::EmptyList(which) => write!(f, "{which} filter is present but empty"),
+            FilterError::EmptyFieldList => write!(f, "custom field profile has no fields"),
+            FilterError::BadServiceName(s) => {
+                write!(f, "invalid service name {s:?} (letters, digits, _ only)")
+            }
+        }
+    }
+}
+
+/// Service names must be plain identifiers — see [`FilterError::BadServiceName`].
+pub(crate) fn valid_service_name(s: &str) -> bool {
+    let s = s.trim();
+    !s.is_empty() && s.bytes().all(|b| b.is_ascii_alphanumeric() || b == b'_')
+}
+
+impl std::error::Error for FilterError {}
+
+fn valid_date(d: &str) -> bool {
+    let d = d.trim();
+    d.len() == 8
+        && d.bytes().all(|b| b.is_ascii_digit())
+        && chrono::NaiveDate::parse_from_str(d, "%Y%m%d").is_ok()
+}
+
+fn valid_time(t: &str) -> bool {
+    let t = t.trim();
+    (t.len() == 4 || t.len() == 6) && t.bytes().all(|b| b.is_ascii_digit())
+}
+
+fn check_nonempty<T>(name: &'static str, v: &Option<Vec<T>>) -> Result<(), FilterError> {
+    match v {
+        Some(list) if list.is_empty() => Err(FilterError::EmptyList(name)),
+        _ => Ok(()),
+    }
+}
+
+impl ExportFilter {
+    /// Reject bad input up front. Called by every export/count entry point, so
+    /// a malformed filter can never reach SQL.
+    pub fn validate(&self) -> Result<(), FilterError> {
+        for (name, d) in [("date_from", &self.date_from), ("date_to", &self.date_to)] {
+            if let Some(d) = d
+                && !valid_date(d)
+            {
+                let _ = name;
+                return Err(FilterError::BadDate(d.clone()));
+            }
+        }
+        if let (Some(from), Some(to)) = (&self.date_from, &self.date_to)
+            && from.trim() > to.trim()
+        {
+            return Err(FilterError::InvertedRange {
+                from: from.clone(),
+                to: to.clone(),
+            });
+        }
+
+        for ts in [&self.datetime_from, &self.datetime_to]
+            .into_iter()
+            .flatten()
+        {
+            if !valid_date(&ts.date) {
+                return Err(FilterError::BadDate(ts.date.clone()));
+            }
+            if !valid_time(&ts.time) {
+                return Err(FilterError::BadTime(ts.time.clone()));
+            }
+        }
+        if let (Some(from), Some(to)) = (&self.datetime_from, &self.datetime_to)
+            && from.key() > to.key()
+        {
+            return Err(FilterError::InvertedRange {
+                from: from.key(),
+                to: to.key(),
+            });
+        }
+
+        if let (Some(from), Some(to)) = (self.freq_from, self.freq_to)
+            && from > to
+        {
+            return Err(FilterError::InvertedRange {
+                from: from.to_string(),
+                to: to.to_string(),
+            });
+        }
+
+        check_nonempty("bands", &self.bands)?;
+        check_nonempty("modes", &self.modes)?;
+        check_nonempty("submodes", &self.submodes)?;
+        check_nonempty("mode_classes", &self.mode_classes)?;
+        check_nonempty("dxcc", &self.dxcc)?;
+        check_nonempty("continent", &self.continent)?;
+        check_nonempty("cq_zone", &self.cq_zone)?;
+        check_nonempty("itu_zone", &self.itu_zone)?;
+        check_nonempty("state", &self.state)?;
+        check_nonempty("country", &self.country)?;
+        check_nonempty("station_ids", &self.station_ids)?;
+        check_nonempty("contest_ids", &self.contest_ids)?;
+        check_nonempty("qso_ids", &self.qso_ids)?;
+        check_nonempty("uploaded_to", &self.uploaded_to)?;
+        check_nonempty("not_uploaded_to", &self.not_uploaded_to)?;
+        check_nonempty("confirmed_by", &self.confirmed_by)?;
+        check_nonempty("not_confirmed_by", &self.not_confirmed_by)?;
+
+        for b in self.bands.iter().flatten() {
+            if !normalize::is_known_band(b) {
+                return Err(FilterError::UnknownBand(b.clone()));
+            }
+        }
+
+        // A mode filter compares against the stored canonical `mode` column, so
+        // a non-canonical value (USB, FT4) would match zero rows however many
+        // such QSOs are logged. Reject it and say what to use instead.
+        for m in self.modes.iter().flatten() {
+            let (canonical, submode) = normalize::normalize_mode(m, None);
+            if canonical != m.trim().to_ascii_uppercase() || submode.is_some() {
+                return Err(FilterError::NonCanonicalMode {
+                    given: m.clone(),
+                    canonical,
+                });
+            }
+        }
+
+        for c in self.continent.iter().flatten() {
+            let c_uc = c.trim().to_ascii_uppercase();
+            if !CONTINENTS.contains(&c_uc.as_str()) {
+                return Err(FilterError::UnknownContinent(c.clone()));
+            }
+        }
+
+        // Every service name, whether it ends up bound (uploaded_to &c.) or
+        // interpolated into a JSON path (qsl_sent/qsl_rcvd). Checking all of
+        // them keeps the rule one rule instead of two.
+        let services = [
+            &self.uploaded_to,
+            &self.not_uploaded_to,
+            &self.confirmed_by,
+            &self.not_confirmed_by,
+        ];
+        for svc in services.into_iter().flatten().flatten() {
+            if !valid_service_name(svc) {
+                return Err(FilterError::BadServiceName(svc.clone()));
+            }
+        }
+        for q in [&self.qsl_sent, &self.qsl_rcvd].into_iter().flatten() {
+            if let Some(svc) = &q.service
+                && !valid_service_name(svc)
+            {
+                return Err(FilterError::BadServiceName(svc.clone()));
+            }
+            if q.statuses.is_empty() {
+                return Err(FilterError::EmptyList("qsl status"));
+            }
+        }
+
+        Ok(())
+    }
+
+    /// The bookmark profile this filter reads, if it is an incremental export.
+    pub fn incremental_profile(&self) -> Option<&str> {
+        self.since_last_export.as_deref()
+    }
+}
+
+impl ExportOptions {
+    pub fn validate(&self) -> Result<(), FilterError> {
+        if let FieldProfile::Custom(fields) = &self.field_profile
+            && fields.is_empty()
+        {
+            return Err(FilterError::EmptyFieldList);
+        }
+        Ok(())
+    }
+
+    /// Project a record down to this profile's fields.
+    ///
+    /// This is a **projection over the shared writer's output**, not a second
+    /// serializer: the record has already been built by
+    /// [`crate::adif::qso_to_record`], so the split-frequency rule
+    /// (`FREQ_RX`/`BAND_RX` only when present) and the modeled-column-wins rule
+    /// are applied identically here and in the journal.
+    pub fn project(&self, record: &mut crate::adif::AdifRecord) {
+        match &self.field_profile {
+            FieldProfile::Full => {
+                if !self.include_extra {
+                    record.retain(|k, _| crate::adif::COLUMN_FIELDS.contains(&k.as_str()));
+                }
+            }
+            FieldProfile::Core => {
+                record.retain(|k, _| CORE_FIELDS.contains(&k.as_str()));
+            }
+            FieldProfile::Custom(fields) => {
+                let want: Vec<String> = fields
+                    .iter()
+                    .map(|f| f.trim().to_ascii_uppercase())
+                    .collect();
+                record.retain(|k, _| want.contains(k));
+            }
+        }
+    }
+}

--- a/rigflow-log/src/export/mod.rs
+++ b/rigflow-log/src/export/mod.rs
@@ -1,0 +1,48 @@
+//! ADIF export: filters, the streaming writer, and incremental bookmarks.
+//!
+//! Four invariants hold across this module. They are deliberate, and each one
+//! encodes a failure mode:
+//!
+//! 1. **Export is generated from SQLite, never by replaying the ADIF journal.**
+//!    The journal is an append-only tape (superseded records, deleted QSOs,
+//!    log-time order); the DB is the materialized current state. See
+//!    [`writer`].
+//!
+//! 2. **Export reuses the shared ADIF record-writer**
+//!    ([`crate::adif::qso_to_record`] + [`crate::adif::write_record`]) rather
+//!    than serializing a second time. One serializer, two callers (journal +
+//!    export) — which is what guarantees the split-frequency rule
+//!    (`FREQ_RX`/`BAND_RX` iff `freq_rx_hz` is set) is applied identically in
+//!    both. Field profiles are a *projection* over that writer's output
+//!    ([`filter::ExportOptions::project`]), not a rewrite of it.
+//!
+//! 3. **Export is strictly read-only**, enforced by SQLite rather than by
+//!    convention: [`Exporter`] holds a `SQLITE_OPEN_READ_ONLY` connection.
+//!
+//! 4. **Only an incremental export advances an incremental bookmark**, and only
+//!    on a successful non-dry-run write. This is structural too: the exporter's
+//!    connection *cannot* write, so it reports [`ExportSummary::max_qso_id`] and
+//!    the caller advances the bookmark on the read-write [`crate::LogStore`]
+//!    ([`crate::LogStore::advance_export_bookmark`]). An ad-hoc "export my 20m
+//!    QSOs" therefore has no code path that could corrupt an operator's
+//!    incremental position.
+//!
+//! Filters over fields that aren't modeled as columns (continent, zones,
+//! contest id, QSL status, and the `MY_*` station snapshot) read the `extra`
+//! JSON. In particular `my_gridsquare` reads the **per-QSO snapshot**, not the
+//! `station` table: that row is keyed on callsign and updated in place, so it
+//! holds today's location, and joining it would mis-attribute every QSO made
+//! before an operator moved.
+
+pub mod filter;
+pub mod query;
+pub mod writer;
+
+pub use filter::{
+    CORE_FIELDS, DEFAULT_ADIF_VERSION, DEFAULT_EXPORT_PROFILE, ExportFilter, ExportOptions,
+    FieldProfile, FilterError, GridPrecision, QslStatusFilter, Sort, Timestamp,
+};
+pub use writer::{ExportSummary, Exporter, PROGRAM_VERSION};
+
+#[cfg(test)]
+mod tests;

--- a/rigflow-log/src/export/mod.rs
+++ b/rigflow-log/src/export/mod.rs
@@ -42,7 +42,7 @@ pub use filter::{
     CORE_FIELDS, DEFAULT_ADIF_VERSION, DEFAULT_EXPORT_PROFILE, ExportFilter, ExportOptions,
     FieldProfile, FilterError, GridPrecision, QslStatusFilter, Sort, Timestamp,
 };
-pub use writer::{ExportSummary, Exporter, PROGRAM_VERSION};
+pub use writer::{ContactPage, ExportSummary, Exporter, PROGRAM_VERSION};
 
 #[cfg(test)]
 mod tests;

--- a/rigflow-log/src/export/query.rs
+++ b/rigflow-log/src/export/query.rs
@@ -1,0 +1,372 @@
+//! Filter → SQL. The **only** place that knows how an [`ExportFilter`] becomes a
+//! `WHERE` clause.
+//!
+//! Two rules hold everywhere in this file:
+//!
+//! 1. **Every user value is a bound parameter.** Nothing a human typed is ever
+//!    formatted into the SQL string. The single exception is a service name
+//!    inside a `json_extract` path (SQLite takes no parameter in a path
+//!    literal), and those are whitelisted to `[A-Za-z0-9_]` by
+//!    [`ExportFilter::validate`] before they get here.
+//! 2. **Categories AND, values within a category OR, `not_*` negates.**
+//!
+//! Filters over fields that aren't columns (continent, zones, contest id, the
+//! `MY_*` snapshot, QSL status) read the `extra` JSON via [`json_field`]. Those
+//! are unindexed — fine for a file export, and why the UI debounces its live
+//! count.
+
+use rusqlite::types::Value;
+
+use super::filter::ExportFilter;
+use crate::normalize;
+
+/// The 14-char sortable `YYYYMMDDHHMMSS` key of a row. `time_on` is padded
+/// because ADIF permits a 4-digit `HHMM`, which would otherwise sort wrong
+/// against a 6-digit one.
+pub(crate) const TS_EXPR: &str = "(qso_date || substr(time_on || '000000', 1, 6))";
+
+/// A SQL expression reading one ADIF field out of the `extra` JSON blob.
+///
+/// `field` is always one of our own constants or a validated service-qualified
+/// name — never raw user text. Kept in one place so these can be promoted to
+/// real (indexed) columns later without touching any call site.
+fn json_field(field: &str) -> String {
+    format!("json_extract(extra, '$.{field}')")
+}
+
+/// A `WHERE` clause and the parameters to bind to it, in order.
+pub struct BuiltQuery {
+    /// Never empty — `"1=1"` when the filter is unconstrained, so callers can
+    /// always splice it in.
+    pub where_sql: String,
+    pub params: Vec<Value>,
+}
+
+#[derive(Default)]
+struct Builder {
+    clauses: Vec<String>,
+    params: Vec<Value>,
+}
+
+impl Builder {
+    /// Add a clause with its bound parameters.
+    fn push(&mut self, clause: impl Into<String>, params: impl IntoIterator<Item = Value>) {
+        self.clauses.push(clause.into());
+        self.params.extend(params);
+    }
+
+    /// `expr IN (?,?,?)` — the within-a-category OR.
+    fn push_in(&mut self, expr: &str, values: impl IntoIterator<Item = Value>) {
+        let values: Vec<Value> = values.into_iter().collect();
+        if values.is_empty() {
+            return; // validate() already rejects this; belt and braces.
+        }
+        let holes = std::iter::repeat_n("?", values.len())
+            .collect::<Vec<_>>()
+            .join(",");
+        self.push(format!("{expr} IN ({holes})"), values);
+    }
+
+    fn build(self) -> BuiltQuery {
+        let where_sql = if self.clauses.is_empty() {
+            "1=1".to_string()
+        } else {
+            self.clauses.join(" AND ")
+        };
+        BuiltQuery {
+            where_sql,
+            params: self.params,
+        }
+    }
+}
+
+fn text(s: &str) -> Value {
+    Value::Text(s.trim().to_string())
+}
+fn text_uc(s: &str) -> Value {
+    Value::Text(s.trim().to_ascii_uppercase())
+}
+fn int(i: i64) -> Value {
+    Value::Integer(i)
+}
+
+/// Escape the SQL `LIKE` metacharacters in a literal, so a user's `%` or `_`
+/// matches itself. Pairs with `ESCAPE '\'`.
+fn escape_like_literal(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for c in s.chars() {
+        if c == '\\' || c == '%' || c == '_' {
+            out.push('\\');
+        }
+        out.push(c);
+    }
+    out
+}
+
+/// Translate a user wildcard (`*` = any run, `?` = any one char) into a SQL
+/// `LIKE` pattern, escaping everything else. The result is **bound**, never
+/// interpolated — so an input like `'; DROP TABLE qso;--` is just a (fruitless)
+/// literal pattern.
+pub(crate) fn wildcard_to_like(pattern: &str) -> String {
+    let mut out = String::with_capacity(pattern.len());
+    for c in pattern.trim().chars() {
+        match c {
+            '*' => out.push('%'),
+            '?' => out.push('_'),
+            '\\' | '%' | '_' => {
+                out.push('\\');
+                out.push(c);
+            }
+            _ => out.push(c),
+        }
+    }
+    out
+}
+
+/// The `extra` field name a QSL-status filter reads:
+/// unscoped → `QSL_SENT`; scoped to a service → `LOTW_QSL_SENT`.
+fn qsl_field(service: Option<&str>, suffix: &str) -> String {
+    match service {
+        Some(svc) => format!("{}_QSL_{suffix}", svc.trim().to_ascii_uppercase()),
+        None => format!("QSL_{suffix}"),
+    }
+}
+
+/// An `EXISTS` / `NOT EXISTS` correlated subquery against `qso_service`.
+///
+/// `qso_service` is empty until a later phase populates it, which makes these
+/// correctly inert rather than broken: `NOT EXISTS` matches every QSO, `EXISTS`
+/// matches none. They start working on their own when the table fills.
+fn service_exists(negate: bool, when: &str, n: usize) -> String {
+    let holes = std::iter::repeat_n("?", n).collect::<Vec<_>>().join(",");
+    let not = if negate { "NOT " } else { "" };
+    format!(
+        "{not}EXISTS (SELECT 1 FROM qso_service s \
+         WHERE s.qso_id = qso.id AND s.service IN ({holes}) AND s.{when} IS NOT NULL)"
+    )
+}
+
+/// Translate a validated filter into `WHERE` + params.
+///
+/// `bookmark` is the resolved `since_last_export` position — the caller reads it
+/// from `export_state` and passes it in, so this stays a pure function.
+/// `None` (no bookmark row yet) means "everything", not "nothing": the first
+/// incremental export of a fresh profile exports the whole log.
+pub fn build(filter: &ExportFilter, bookmark: Option<i64>) -> BuiltQuery {
+    let mut b = Builder::default();
+
+    // ---- A. date / time ----
+    if let Some(d) = &filter.date_from {
+        b.push("qso_date >= ?", [text(d)]);
+    }
+    if let Some(d) = &filter.date_to {
+        b.push("qso_date <= ?", [text(d)]);
+    }
+    if let Some(ts) = &filter.datetime_from {
+        b.push(format!("{TS_EXPR} >= ?"), [Value::Text(ts.key())]);
+    }
+    if let Some(ts) = &filter.datetime_to {
+        b.push(format!("{TS_EXPR} <= ?"), [Value::Text(ts.key())]);
+    }
+    if filter.since_last_export.is_some()
+        && let Some(last_id) = bookmark
+    {
+        // Insertion order, not contact time: this is export progress.
+        b.push("id > ?", [int(last_id)]);
+    }
+
+    // ---- B. frequency / band / mode ----
+    if let Some(bands) = &filter.bands {
+        let holes = std::iter::repeat_n("?", bands.len())
+            .collect::<Vec<_>>()
+            .join(",");
+        if filter.match_either_band {
+            // The rare split-across-bands QSO: match if either side is in the set.
+            b.push(
+                format!(
+                    "(band COLLATE NOCASE IN ({holes}) OR band_rx COLLATE NOCASE IN ({holes}))"
+                ),
+                bands
+                    .iter()
+                    .map(|s| text(s))
+                    .chain(bands.iter().map(|s| text(s))),
+            );
+        } else {
+            b.push_in("band COLLATE NOCASE", bands.iter().map(|s| text(s)));
+        }
+    }
+    if let Some(f) = filter.freq_from {
+        b.push("freq_hz >= ?", [int(f as i64)]);
+    }
+    if let Some(f) = filter.freq_to {
+        b.push("freq_hz <= ?", [int(f as i64)]);
+    }
+    if let Some(modes) = &filter.modes {
+        b.push_in("mode COLLATE NOCASE", modes.iter().map(|s| text_uc(s)));
+    }
+    if let Some(subs) = &filter.submodes {
+        b.push_in("submode COLLATE NOCASE", subs.iter().map(|s| text_uc(s)));
+    }
+    if let Some(classes) = &filter.mode_classes {
+        // Expanded through the normalizer's table, never hardcoded here.
+        let modes: Vec<Value> = classes
+            .iter()
+            .flat_map(|c| normalize::modes_in_class(*c))
+            .map(|m| Value::Text(m.to_string()))
+            .collect();
+        b.push_in("mode COLLATE NOCASE", modes);
+    }
+
+    // ---- C. worked station / entity ----
+    if let Some(c) = &filter.call_exact {
+        b.push("call = ? COLLATE NOCASE", [text_uc(c)]);
+    }
+    if let Some(p) = &filter.call_pattern {
+        b.push(
+            r"call LIKE ? ESCAPE '\'",
+            [Value::Text(wildcard_to_like(p))],
+        );
+    }
+    if let Some(p) = &filter.call_prefix {
+        b.push(
+            r"call LIKE ? ESCAPE '\'",
+            [Value::Text(format!("{}%", escape_like_literal(p.trim())))],
+        );
+    }
+    if let Some(d) = &filter.dxcc {
+        b.push_in("dxcc", d.iter().map(|v| int(*v)));
+    }
+    if let Some(c) = &filter.continent {
+        b.push_in(
+            &format!("upper({})", json_field("CONT")),
+            c.iter().map(|s| text_uc(s)),
+        );
+    }
+    if let Some(z) = &filter.cq_zone {
+        // CAST both sides: a log may store "05" where the user filters 5.
+        b.push_in(
+            &format!("CAST({} AS INTEGER)", json_field("CQZ")),
+            z.iter().map(|v| int(*v)),
+        );
+    }
+    if let Some(z) = &filter.itu_zone {
+        b.push_in(
+            &format!("CAST({} AS INTEGER)", json_field("ITUZ")),
+            z.iter().map(|v| int(*v)),
+        );
+    }
+    if let Some(g) = &filter.gridsquare {
+        push_grid(&mut b, "gridsquare", g, filter.grid_precision);
+    }
+    if let Some(s) = &filter.state {
+        b.push_in(
+            &format!("upper({})", json_field("STATE")),
+            s.iter().map(|s| text_uc(s)),
+        );
+    }
+    if let Some(c) = &filter.country {
+        b.push_in(
+            &format!("upper({})", json_field("COUNTRY")),
+            c.iter().map(|s| text_uc(s)),
+        );
+    }
+
+    // ---- D. my station ----
+    //
+    // These read the per-QSO `extra` snapshot, NOT the `station` table. The
+    // station row is keyed on callsign and updated in place, so joining it would
+    // return today's grid for every historical QSO — the exact failure the
+    // snapshot exists to prevent. Filtering "QSOs I made from EM12" must still
+    // find them after the operator moves to FN31.
+    if let Some(ids) = &filter.station_ids {
+        b.push_in("station_id", ids.iter().map(|v| int(*v)));
+    }
+    if let Some(g) = &filter.my_gridsquare {
+        push_grid(
+            &mut b,
+            &json_field("MY_GRIDSQUARE"),
+            g,
+            filter.grid_precision,
+        );
+    }
+    if let Some(op) = &filter.operator {
+        b.push(
+            format!("upper({}) = ?", json_field("OPERATOR")),
+            [text_uc(op)],
+        );
+    }
+    if let Some(sc) = &filter.station_callsign {
+        b.push(
+            format!("upper({}) = ?", json_field("STATION_CALLSIGN")),
+            [text_uc(sc)],
+        );
+    }
+
+    // ---- E. confirmation / service ----
+    for (services, negate, when) in [
+        (&filter.uploaded_to, false, "uploaded_at"),
+        (&filter.not_uploaded_to, true, "uploaded_at"),
+        (&filter.confirmed_by, false, "confirmed_at"),
+        (&filter.not_confirmed_by, true, "confirmed_at"),
+    ] {
+        if let Some(svcs) = services {
+            b.push(
+                service_exists(negate, when, svcs.len()),
+                svcs.iter().map(|s| Value::Text(s.trim().to_lowercase())),
+            );
+        }
+    }
+    for (q, suffix) in [(&filter.qsl_sent, "SENT"), (&filter.qsl_rcvd, "RCVD")] {
+        if let Some(q) = q {
+            let field = qsl_field(q.service.as_deref(), suffix);
+            b.push_in(
+                &format!("upper({})", json_field(&field)),
+                q.statuses.iter().map(|s| text_uc(s)),
+            );
+        }
+    }
+
+    // ---- F. contest ----
+    if let Some(ids) = &filter.contest_ids {
+        b.push_in(
+            &format!("upper({})", json_field("CONTEST_ID")),
+            ids.iter().map(|s| text_uc(s)),
+        );
+    }
+
+    // ---- G. explicit selection ----
+    // ANDs with everything else: a selection you may further narrow.
+    if let Some(ids) = &filter.qso_ids {
+        b.push_in("id", ids.iter().map(|v| int(*v)));
+    }
+
+    b.build()
+}
+
+/// Compare a grid expression at the requested precision. `Field`/`Square` clip
+/// both sides to 2/4 chars so `EM` matches `EM12ab`.
+fn push_grid(b: &mut Builder, expr: &str, value: &str, precision: super::filter::GridPrecision) {
+    match precision.chars() {
+        Some(n) => b.push(
+            format!("upper(substr({expr}, 1, {n})) = ?"),
+            [Value::Text(
+                value
+                    .trim()
+                    .to_ascii_uppercase()
+                    .chars()
+                    .take(n)
+                    .collect::<String>(),
+            )],
+        ),
+        None => b.push(format!("upper({expr}) = ?"), [text_uc(value)]),
+    }
+}
+
+/// `ORDER BY` for the requested sort. Ties break on `id` so the output is
+/// deterministic (two QSOs can share a date+time).
+pub fn order_by(sort: super::filter::Sort) -> &'static str {
+    match sort {
+        super::filter::Sort::Chronological => "ORDER BY qso_date ASC, time_on ASC, id ASC",
+        super::filter::Sort::Reverse => "ORDER BY qso_date DESC, time_on DESC, id DESC",
+    }
+}

--- a/rigflow-log/src/export/tests.rs
+++ b/rigflow-log/src/export/tests.rs
@@ -404,6 +404,136 @@ fn filter_by_explicit_qso_ids_and_it_ands() {
     assert_eq!(exported_calls(&dir, &f), ["JA1XYZ"]);
 }
 
+// ------------------------------------------------- the view IS the export --
+
+#[test]
+fn the_page_the_view_shows_is_the_set_the_export_writes() {
+    // The contact view and the export share one WHERE builder, so for any filter
+    // the listed calls and the exported calls must be the same set. This is the
+    // property the shared-filter UI promises the operator ("you see what you are
+    // exporting"); if it ever breaks, it breaks silently, so pin it.
+    let dir = TmpDir::new();
+    let _s = store_with(&dir, fleet());
+    let ex = Exporter::open(dir.db()).unwrap();
+
+    let filters = [
+        ExportFilter::default(),
+        ExportFilter {
+            bands: Some(vec!["20m".into()]),
+            ..Default::default()
+        },
+        ExportFilter {
+            modes: Some(vec!["SSB".into()]),
+            ..Default::default()
+        },
+        ExportFilter {
+            call_pattern: Some("*1*".into()),
+            ..Default::default()
+        },
+        ExportFilter {
+            call_exact: Some("NOBODY".into()), // empty set
+            ..Default::default()
+        },
+    ];
+
+    for f in filters {
+        let page = ex.page(&f, 500, Sort::Reverse).unwrap();
+        let exported = exported_calls(&dir, &f);
+
+        assert_eq!(
+            page.total,
+            exported.len(),
+            "view total disagrees with what the export wrote, filter {f:?}"
+        );
+
+        let mut listed: Vec<String> = page.rows.iter().map(|r| r.qso.call.clone()).collect();
+        let mut written = exported.clone();
+        listed.sort();
+        written.sort();
+        assert_eq!(listed, written, "view rows != exported rows, filter {f:?}");
+    }
+}
+
+#[test]
+fn the_page_total_is_honest_about_the_row_cap() {
+    // The view caps its rows; the export does not. So `total` must report the
+    // real match count, not the number of rows returned — otherwise a capped view
+    // silently implies it is showing everything the export will write.
+    let dir = TmpDir::new();
+    let _s = store_with(&dir, fleet()); // 4 QSOs
+    let ex = Exporter::open(dir.db()).unwrap();
+
+    let page = ex.page(&ExportFilter::default(), 2, Sort::Reverse).unwrap();
+    assert_eq!(page.rows.len(), 2, "capped by limit");
+    assert_eq!(page.total, 4, "but the total is the whole match set");
+}
+
+#[test]
+fn view_page_is_newest_first() {
+    let dir = TmpDir::new();
+    let _s = store_with(&dir, fleet());
+    let ex = Exporter::open(dir.db()).unwrap();
+    let page = ex
+        .page(&ExportFilter::default(), 500, Sort::Reverse)
+        .unwrap();
+    let calls: Vec<&str> = page.rows.iter().map(|r| r.qso.call.as_str()).collect();
+    assert_eq!(calls, ["VK3ABC", "JA1XYZ", "K5ZD", "W1AW"]);
+}
+
+#[test]
+fn call_lookup_searches_the_whole_log_ignoring_any_view_filter() {
+    // The call-lookup popup answers "have I EVER worked this station?", so it is
+    // built from a filter of its own (call_exact alone) rather than from the view
+    // filter. A 20m-only view must not hide the 40m QSO with the same station.
+    let dir = TmpDir::new();
+    let mut a = qso("DX1ABC");
+    a.qso_date = "20260701".into();
+    let mut b = qso("DX1ABC");
+    b.qso_date = "20260702".into();
+    b.band = "40m".into();
+    b.mode = "CW".into();
+    b.freq_hz = Some(7_030_000);
+    let _s = store_with(&dir, vec![a, b, qso("OTHER")]);
+
+    let lookup = ExportFilter {
+        call_exact: Some("dx1abc".into()),
+        ..Default::default()
+    };
+    let ex = Exporter::open(dir.db()).unwrap();
+    let page = ex.page(&lookup, 100, Sort::Reverse).unwrap();
+
+    assert_eq!(page.total, 2, "both bands, regardless of any view filter");
+    let bands: Vec<&str> = page.rows.iter().map(|r| r.qso.band.as_str()).collect();
+    assert_eq!(bands, ["40m", "20m"]);
+}
+
+#[test]
+fn store_filtered_query_matches_the_exporter() {
+    // The read-write store and the read-only exporter must agree — they are two
+    // connections onto one builder.
+    let dir = TmpDir::new();
+    let s = store_with(&dir, fleet());
+    let f = ExportFilter {
+        bands: Some(vec!["20m".into()]),
+        ..Default::default()
+    };
+    let via_store: Vec<String> = s
+        .query_contacts_filtered(&f, 500)
+        .unwrap()
+        .iter()
+        .map(|r| r.qso.call.clone())
+        .collect();
+    let via_exporter: Vec<String> = Exporter::open(dir.db())
+        .unwrap()
+        .page(&f, 500, Sort::Reverse)
+        .unwrap()
+        .rows
+        .iter()
+        .map(|r| r.qso.call.clone())
+        .collect();
+    assert_eq!(via_store, via_exporter);
+}
+
 // --------------------------------------------------------- my-station (D) --
 
 #[test]

--- a/rigflow-log/src/export/tests.rs
+++ b/rigflow-log/src/export/tests.rs
@@ -133,6 +133,83 @@ fn read_calls(path: &std::path::Path) -> Vec<String> {
         .collect()
 }
 
+/// Insert one QSO, record confirmations for it, and export with `opts`; return
+/// the parsed records of the written file.
+fn export_with_confirmations(
+    dir: &TmpDir,
+    confs: &[(&str, &str)],
+    opts_profile: FieldProfile,
+) -> Vec<adif::AdifRecord> {
+    let mut s = LogStore::open(dir.db(), dir.adi()).unwrap();
+    let out = s.insert(&qso("W1AW"), &station()).unwrap();
+    let confirmations: Vec<_> = confs
+        .iter()
+        .map(|(svc, date)| crate::import::Confirmation {
+            qso_id: out.id,
+            service: (*svc).into(),
+            confirmed_at: Some((*date).into()),
+        })
+        .collect();
+    s.commit_import(&[], &confirmations, &station()).unwrap();
+    drop(s);
+
+    let opts = ExportOptions {
+        output_path: dir.out(),
+        field_profile: opts_profile,
+        ..Default::default()
+    };
+    Exporter::open(dir.db())
+        .unwrap()
+        .export(&ExportFilter::default(), &opts)
+        .unwrap();
+    adif::parse_adif(&std::fs::read_to_string(dir.out()).unwrap()).unwrap()
+}
+
+#[test]
+fn export_stamps_a_lotw_confirmation_as_service_qsl_fields() {
+    let dir = TmpDir::new();
+    let recs = export_with_confirmations(&dir, &[("lotw", "20260723")], FieldProfile::Full);
+    assert_eq!(recs.len(), 1);
+    assert_eq!(recs[0].get("LOTW_QSL_RCVD").map(String::as_str), Some("Y"));
+    assert_eq!(
+        recs[0].get("LOTW_QSLRDATE").map(String::as_str),
+        Some("20260723")
+    );
+    // The generic (paper card) QSL_RCVD is a *different* thing and wasn't set.
+    assert!(!recs[0].contains_key("QSL_RCVD"));
+}
+
+#[test]
+fn export_carries_confirmations_even_under_the_core_profile() {
+    // Confirmation state is authoritative export data; a narrow field profile
+    // (which drops most extras) must not silently strip it.
+    let dir = TmpDir::new();
+    let recs = export_with_confirmations(&dir, &[("lotw", "20260723")], FieldProfile::Core);
+    assert_eq!(recs[0].get("LOTW_QSL_RCVD").map(String::as_str), Some("Y"));
+}
+
+#[test]
+fn export_stamps_every_confirming_service() {
+    // Both LoTW and eQSL confirmed the same QSO: both must survive the
+    // group_concat packing and reappear as their own fields.
+    let dir = TmpDir::new();
+    let recs = export_with_confirmations(
+        &dir,
+        &[("lotw", "20260723"), ("eqsl", "20260724")],
+        FieldProfile::Full,
+    );
+    assert_eq!(recs[0].get("LOTW_QSL_RCVD").map(String::as_str), Some("Y"));
+    assert_eq!(recs[0].get("EQSL_QSL_RCVD").map(String::as_str), Some("Y"));
+    assert_eq!(
+        recs[0].get("LOTW_QSLRDATE").map(String::as_str),
+        Some("20260723")
+    );
+    assert_eq!(
+        recs[0].get("EQSL_QSLRDATE").map(String::as_str),
+        Some("20260724")
+    );
+}
+
 fn count(dir: &TmpDir, filter: &ExportFilter) -> usize {
     Exporter::open(dir.db()).unwrap().count(filter).unwrap()
 }

--- a/rigflow-log/src/export/tests.rs
+++ b/rigflow-log/src/export/tests.rs
@@ -1,0 +1,1268 @@
+//! Export tests.
+//!
+//! These run against **on-disk** databases (not `open_in_memory`), because the
+//! read-only-connection invariant is only real against a file — an in-memory DB
+//! would let a bug in `Exporter::open` pass unnoticed.
+
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicU32, Ordering};
+
+use super::filter::*;
+use super::writer::*;
+use crate::adif;
+use crate::model::{Qso, Station};
+use crate::normalize::ModeClass;
+use crate::store::LogStore;
+
+// ---------------------------------------------------------------- fixtures --
+
+static SEQ: AtomicU32 = AtomicU32::new(0);
+
+/// A fresh temp dir, unique per test (no `tempfile` dev-dep in this crate).
+struct TmpDir(PathBuf);
+
+impl TmpDir {
+    fn new() -> TmpDir {
+        let n = SEQ.fetch_add(1, Ordering::SeqCst);
+        let dir =
+            std::env::temp_dir().join(format!("rigflow-log-export-{}-{}", std::process::id(), n));
+        std::fs::create_dir_all(&dir).unwrap();
+        TmpDir(dir)
+    }
+    fn join(&self, name: &str) -> PathBuf {
+        self.0.join(name)
+    }
+    fn db(&self) -> PathBuf {
+        self.join("rigflow_log.db")
+    }
+    fn adi(&self) -> PathBuf {
+        self.join("rigflow_log.adi")
+    }
+    fn out(&self) -> PathBuf {
+        self.join("out.adi")
+    }
+}
+
+impl Drop for TmpDir {
+    fn drop(&mut self) {
+        std::fs::remove_dir_all(&self.0).ok();
+    }
+}
+
+fn station() -> Station {
+    Station {
+        station_call: "N0CALL".into(),
+        gridsquare: Some("EM12".into()),
+        name: Some("Dave".into()),
+        ..Default::default()
+    }
+}
+
+/// A QSO builder that starts from a sane 20m SSB contact.
+fn qso(call: &str) -> Qso {
+    Qso {
+        call: call.into(),
+        qso_date: "20260711".into(),
+        time_on: "140000".into(),
+        band: "20m".into(),
+        mode: "SSB".into(),
+        freq_hz: Some(14_207_000),
+        rst_sent: Some("59".into()),
+        rst_rcvd: Some("59".into()),
+        ..Default::default()
+    }
+}
+
+fn with_extra(mut q: Qso, kvs: &[(&str, &str)]) -> Qso {
+    for (k, v) in kvs {
+        q.extra.insert((*k).to_string(), (*v).to_string());
+    }
+    q
+}
+
+/// Open a store, insert `qsos`, return the store (still open, for bookmarks).
+fn store_with(dir: &TmpDir, qsos: Vec<Qso>) -> LogStore {
+    let mut s = LogStore::open(dir.db(), dir.adi()).unwrap();
+    for q in qsos {
+        s.insert(&q, &station()).unwrap();
+    }
+    s
+}
+
+/// The default fleet: 20m SSB, 40m CW, 20m FT8, 15m SSB.
+fn fleet() -> Vec<Qso> {
+    let mut ssb20 = qso("W1AW");
+    ssb20.qso_date = "20260701".into();
+
+    let mut cw40 = qso("K5ZD");
+    cw40.qso_date = "20260702".into();
+    cw40.band = "40m".into();
+    cw40.mode = "CW".into();
+    cw40.freq_hz = Some(7_030_000);
+
+    let mut ft8 = qso("JA1XYZ");
+    ft8.qso_date = "20260703".into();
+    ft8.mode = "FT8".into();
+    ft8.freq_hz = Some(14_074_000);
+
+    let mut ssb15 = qso("VK3ABC");
+    ssb15.qso_date = "20260704".into();
+    ssb15.band = "15m".into();
+    ssb15.freq_hz = Some(21_300_000);
+
+    vec![ssb20, cw40, ft8, ssb15]
+}
+
+/// Export with a filter and return the calls in the written file, in file order.
+fn exported_calls(dir: &TmpDir, filter: &ExportFilter) -> Vec<String> {
+    let opts = ExportOptions {
+        output_path: dir.out(),
+        ..Default::default()
+    };
+    let ex = Exporter::open(dir.db()).unwrap();
+    ex.export(filter, &opts).unwrap();
+    read_calls(&dir.out())
+}
+
+fn read_calls(path: &std::path::Path) -> Vec<String> {
+    let text = std::fs::read_to_string(path).unwrap();
+    adif::parse_adif(&text)
+        .unwrap()
+        .iter()
+        .map(|r| r.get("CALL").cloned().unwrap_or_default())
+        .collect()
+}
+
+fn count(dir: &TmpDir, filter: &ExportFilter) -> usize {
+    Exporter::open(dir.db()).unwrap().count(filter).unwrap()
+}
+
+// ------------------------------------------------------------ each filter --
+
+#[test]
+fn filter_by_band() {
+    let dir = TmpDir::new();
+    let _s = store_with(&dir, fleet());
+    let f = ExportFilter {
+        bands: Some(vec!["20m".into()]),
+        ..Default::default()
+    };
+    assert_eq!(exported_calls(&dir, &f), ["W1AW", "JA1XYZ"]);
+}
+
+#[test]
+fn filter_multi_value_within_a_category_ors() {
+    let dir = TmpDir::new();
+    let _s = store_with(&dir, fleet());
+    let f = ExportFilter {
+        bands: Some(vec!["40m".into(), "15m".into()]),
+        ..Default::default()
+    };
+    assert_eq!(exported_calls(&dir, &f), ["K5ZD", "VK3ABC"]);
+}
+
+#[test]
+fn filter_categories_and() {
+    let dir = TmpDir::new();
+    let _s = store_with(&dir, fleet());
+    // 20m AND SSB → only W1AW (JA1XYZ is 20m but FT8).
+    let f = ExportFilter {
+        bands: Some(vec!["20m".into()]),
+        modes: Some(vec!["SSB".into()]),
+        ..Default::default()
+    };
+    assert_eq!(exported_calls(&dir, &f), ["W1AW"]);
+}
+
+#[test]
+fn filter_by_mode_class_expands_through_the_normalizer() {
+    let dir = TmpDir::new();
+    let mut fleet = fleet();
+    // An FT4 QSO stores as MODE=MFSK / SUBMODE=FT4. A "digital" class filter has
+    // to find it via MFSK, which is exactly what the shared class table is for.
+    let mut ft4 = qso("EA1AAA");
+    ft4.qso_date = "20260705".into();
+    ft4.mode = "FT4".into();
+    ft4.normalize();
+    assert_eq!(ft4.mode, "MFSK");
+    fleet.push(ft4);
+    let _s = store_with(&dir, fleet);
+
+    let f = ExportFilter {
+        mode_classes: Some(vec![ModeClass::Digital]),
+        ..Default::default()
+    };
+    assert_eq!(exported_calls(&dir, &f), ["JA1XYZ", "EA1AAA"]);
+
+    let f = ExportFilter {
+        mode_classes: Some(vec![ModeClass::Phone, ModeClass::Cw]),
+        ..Default::default()
+    };
+    assert_eq!(exported_calls(&dir, &f), ["W1AW", "K5ZD", "VK3ABC"]);
+}
+
+#[test]
+fn filter_by_date_range_inclusive() {
+    let dir = TmpDir::new();
+    let _s = store_with(&dir, fleet());
+    let f = ExportFilter {
+        date_from: Some("20260702".into()),
+        date_to: Some("20260703".into()),
+        ..Default::default()
+    };
+    assert_eq!(exported_calls(&dir, &f), ["K5ZD", "JA1XYZ"]);
+}
+
+#[test]
+fn filter_by_datetime_range() {
+    let dir = TmpDir::new();
+    let mut a = qso("AAA");
+    a.qso_date = "20260701".into();
+    a.time_on = "115900".into();
+    let mut b = qso("BBB");
+    b.qso_date = "20260701".into();
+    b.time_on = "120100".into();
+    let _s = store_with(&dir, vec![a, b]);
+
+    let f = ExportFilter {
+        datetime_from: Some(Timestamp {
+            date: "20260701".into(),
+            time: "120000".into(),
+        }),
+        ..Default::default()
+    };
+    assert_eq!(exported_calls(&dir, &f), ["BBB"]);
+}
+
+#[test]
+fn filter_by_freq_range() {
+    let dir = TmpDir::new();
+    let _s = store_with(&dir, fleet());
+    let f = ExportFilter {
+        freq_from: Some(14_000_000),
+        freq_to: Some(14_100_000),
+        ..Default::default()
+    };
+    assert_eq!(exported_calls(&dir, &f), ["JA1XYZ"]);
+}
+
+#[test]
+fn filter_by_call_exact_and_prefix() {
+    let dir = TmpDir::new();
+    let _s = store_with(&dir, fleet());
+
+    let f = ExportFilter {
+        call_exact: Some("k5zd".into()), // case-insensitive
+        ..Default::default()
+    };
+    assert_eq!(exported_calls(&dir, &f), ["K5ZD"]);
+
+    let f = ExportFilter {
+        call_prefix: Some("JA".into()),
+        ..Default::default()
+    };
+    assert_eq!(exported_calls(&dir, &f), ["JA1XYZ"]);
+}
+
+#[test]
+fn filter_by_call_pattern_wildcards() {
+    let dir = TmpDir::new();
+    let _s = store_with(&dir, fleet());
+
+    let f = ExportFilter {
+        call_pattern: Some("*1*".into()),
+        ..Default::default()
+    };
+    assert_eq!(exported_calls(&dir, &f), ["W1AW", "JA1XYZ"]);
+
+    // '?' is exactly one char: "K?ZD" matches K5ZD.
+    let f = ExportFilter {
+        call_pattern: Some("K?ZD".into()),
+        ..Default::default()
+    };
+    assert_eq!(exported_calls(&dir, &f), ["K5ZD"]);
+}
+
+#[test]
+fn filter_by_dxcc_and_extra_backed_entity_fields() {
+    let dir = TmpDir::new();
+    let qsos = vec![
+        with_extra(
+            qso("JA1XYZ"),
+            &[("CONT", "AS"), ("CQZ", "25"), ("STATE", "13")],
+        ),
+        with_extra(
+            qso("W1AW"),
+            &[("CONT", "NA"), ("CQZ", "05"), ("STATE", "CT")],
+        ),
+    ];
+    let mut qsos = qsos;
+    qsos[0].dxcc = Some(339);
+    qsos[1].dxcc = Some(291);
+    let _s = store_with(&dir, qsos);
+
+    let f = ExportFilter {
+        dxcc: Some(vec![339]),
+        ..Default::default()
+    };
+    assert_eq!(exported_calls(&dir, &f), ["JA1XYZ"]);
+
+    let f = ExportFilter {
+        continent: Some(vec!["NA".into()]),
+        ..Default::default()
+    };
+    assert_eq!(exported_calls(&dir, &f), ["W1AW"]);
+
+    // Zones compare numerically: stored "05" must match a filter of 5.
+    let f = ExportFilter {
+        cq_zone: Some(vec![5]),
+        ..Default::default()
+    };
+    assert_eq!(exported_calls(&dir, &f), ["W1AW"]);
+
+    let f = ExportFilter {
+        state: Some(vec!["CT".into()]),
+        ..Default::default()
+    };
+    assert_eq!(exported_calls(&dir, &f), ["W1AW"]);
+}
+
+#[test]
+fn filter_by_gridsquare_precision() {
+    let dir = TmpDir::new();
+    let mut a = qso("AAA");
+    a.gridsquare = Some("EM12ab".into());
+    let mut b = qso("BBB");
+    b.gridsquare = Some("FN31pr".into());
+    let _s = store_with(&dir, vec![a, b]);
+
+    // Field (2 chars).
+    let f = ExportFilter {
+        gridsquare: Some("EM".into()),
+        grid_precision: GridPrecision::Field,
+        ..Default::default()
+    };
+    assert_eq!(exported_calls(&dir, &f), ["AAA"]);
+
+    // Square (4 chars).
+    let f = ExportFilter {
+        gridsquare: Some("FN31".into()),
+        grid_precision: GridPrecision::Square,
+        ..Default::default()
+    };
+    assert_eq!(exported_calls(&dir, &f), ["BBB"]);
+
+    // Full: exact.
+    let f = ExportFilter {
+        gridsquare: Some("EM12AB".into()),
+        grid_precision: GridPrecision::Full,
+        ..Default::default()
+    };
+    assert_eq!(exported_calls(&dir, &f), ["AAA"]);
+}
+
+#[test]
+fn filter_by_contest_id_from_extra_json() {
+    let dir = TmpDir::new();
+    let _s = store_with(
+        &dir,
+        vec![
+            with_extra(qso("AAA"), &[("CONTEST_ID", "CQ-WW-SSB")]),
+            qso("BBB"),
+        ],
+    );
+    let f = ExportFilter {
+        contest_ids: Some(vec!["CQ-WW-SSB".into()]),
+        ..Default::default()
+    };
+    assert_eq!(exported_calls(&dir, &f), ["AAA"]);
+}
+
+#[test]
+fn filter_by_explicit_qso_ids_and_it_ands() {
+    let dir = TmpDir::new();
+    let mut s = LogStore::open(dir.db(), dir.adi()).unwrap();
+    let ids: Vec<i64> = fleet()
+        .into_iter()
+        .map(|q| s.insert(&q, &station()).unwrap().id)
+        .collect();
+    drop(s);
+
+    // Selection alone.
+    let f = ExportFilter {
+        qso_ids: Some(vec![ids[0], ids[2]]),
+        ..Default::default()
+    };
+    assert_eq!(exported_calls(&dir, &f), ["W1AW", "JA1XYZ"]);
+
+    // Selection AND another filter narrows it (documented behavior).
+    let f = ExportFilter {
+        qso_ids: Some(vec![ids[0], ids[2]]),
+        modes: Some(vec!["FT8".into()]),
+        ..Default::default()
+    };
+    assert_eq!(exported_calls(&dir, &f), ["JA1XYZ"]);
+}
+
+// --------------------------------------------------------- my-station (D) --
+
+#[test]
+fn my_gridsquare_filters_the_snapshot_not_the_current_station_row() {
+    // THE regression test for the station-table trap. `upsert_station` keys on
+    // callsign and updates the row IN PLACE, so after an operator moves QTH the
+    // station row holds the NEW grid for every historical QSO. Filtering
+    // "QSOs I made from EM12" must still find the ones made before the move —
+    // which only works because we filter the per-QSO MY_GRIDSQUARE snapshot.
+    let dir = TmpDir::new();
+    let mut s = LogStore::open(dir.db(), dir.adi()).unwrap();
+
+    let from_em12 = Station {
+        gridsquare: Some("EM12".into()),
+        ..station()
+    };
+    s.insert(&qso("OLDQTH"), &from_em12).unwrap();
+
+    // Operator moves. Same callsign → the SAME station row is rewritten.
+    let from_fn31 = Station {
+        gridsquare: Some("FN31".into()),
+        ..station()
+    };
+    s.insert(&qso("NEWQTH"), &from_fn31).unwrap();
+
+    let n: i64 = s
+        .conn()
+        .query_row("SELECT COUNT(*) FROM station", [], |r| r.get(0))
+        .unwrap();
+    assert_eq!(
+        n, 1,
+        "same callsign must reuse (and mutate) one station row"
+    );
+    let current: String = s
+        .conn()
+        .query_row("SELECT gridsquare FROM station", [], |r| r.get(0))
+        .unwrap();
+    assert_eq!(
+        current, "FN31",
+        "the station row now holds only the new grid"
+    );
+    drop(s);
+
+    // The old QSO is still findable by the grid it was actually made from.
+    let f = ExportFilter {
+        my_gridsquare: Some("EM12".into()),
+        ..Default::default()
+    };
+    assert_eq!(exported_calls(&dir, &f), ["OLDQTH"]);
+
+    let f = ExportFilter {
+        my_gridsquare: Some("FN31".into()),
+        ..Default::default()
+    };
+    assert_eq!(exported_calls(&dir, &f), ["NEWQTH"]);
+}
+
+#[test]
+fn filter_by_operator_and_station_callsign_snapshot() {
+    let dir = TmpDir::new();
+    let _s = store_with(&dir, fleet());
+    let f = ExportFilter {
+        operator: Some("n0call".into()),
+        ..Default::default()
+    };
+    assert_eq!(count(&dir, &f), 4);
+
+    let f = ExportFilter {
+        station_callsign: Some("W9XYZ".into()),
+        ..Default::default()
+    };
+    assert_eq!(count(&dir, &f), 0);
+}
+
+// ------------------------------------------------------- services (E) ------
+
+#[test]
+fn service_filters_are_inert_against_an_empty_qso_service() {
+    // qso_service stays empty until a later phase populates it. That must make
+    // these filters CORRECT-but-inert, not broken.
+    let dir = TmpDir::new();
+    let _s = store_with(&dir, fleet());
+
+    // Nothing has been uploaded, so "not uploaded to LoTW" is everything.
+    let f = ExportFilter {
+        not_uploaded_to: Some(vec!["lotw".into()]),
+        ..Default::default()
+    };
+    assert_eq!(count(&dir, &f), 4);
+
+    // ...and "uploaded to LoTW" / "confirmed by LoTW" are nothing.
+    let f = ExportFilter {
+        uploaded_to: Some(vec!["lotw".into()]),
+        ..Default::default()
+    };
+    assert_eq!(count(&dir, &f), 0);
+
+    let f = ExportFilter {
+        confirmed_by: Some(vec!["lotw".into()]),
+        ..Default::default()
+    };
+    assert_eq!(count(&dir, &f), 0);
+
+    let f = ExportFilter {
+        not_confirmed_by: Some(vec!["lotw".into()]),
+        ..Default::default()
+    };
+    assert_eq!(count(&dir, &f), 4);
+}
+
+#[test]
+fn service_filters_light_up_when_the_table_fills() {
+    // Same filters, now with a populated qso_service — no code change, they just
+    // start selecting. This is what "the seam is real" means.
+    let dir = TmpDir::new();
+    let mut s = LogStore::open(dir.db(), dir.adi()).unwrap();
+    let ids: Vec<i64> = fleet()
+        .into_iter()
+        .map(|q| s.insert(&q, &station()).unwrap().id)
+        .collect();
+    s.conn()
+        .execute(
+            "INSERT INTO qso_service (qso_id, service, uploaded_at, confirmed_at) \
+             VALUES (?1, 'lotw', '2026-07-12T00:00:00Z', NULL)",
+            [ids[0]],
+        )
+        .unwrap();
+    s.conn()
+        .execute(
+            "INSERT INTO qso_service (qso_id, service, uploaded_at, confirmed_at) \
+             VALUES (?1, 'lotw', '2026-07-12T00:00:00Z', '2026-07-12T01:00:00Z')",
+            [ids[1]],
+        )
+        .unwrap();
+    drop(s);
+
+    let f = ExportFilter {
+        uploaded_to: Some(vec!["lotw".into()]),
+        ..Default::default()
+    };
+    assert_eq!(exported_calls(&dir, &f), ["W1AW", "K5ZD"]);
+
+    let f = ExportFilter {
+        confirmed_by: Some(vec!["lotw".into()]),
+        ..Default::default()
+    };
+    assert_eq!(exported_calls(&dir, &f), ["K5ZD"]);
+
+    // The complement: the two never uploaded.
+    let f = ExportFilter {
+        not_uploaded_to: Some(vec!["lotw".into()]),
+        ..Default::default()
+    };
+    assert_eq!(exported_calls(&dir, &f), ["JA1XYZ", "VK3ABC"]);
+}
+
+#[test]
+fn qsl_status_filters_read_extra_not_qso_service() {
+    let dir = TmpDir::new();
+    let _s = store_with(
+        &dir,
+        vec![
+            with_extra(qso("AAA"), &[("QSL_RCVD", "Y")]),
+            with_extra(qso("BBB"), &[("QSL_RCVD", "N")]),
+            with_extra(qso("CCC"), &[("LOTW_QSL_RCVD", "Y")]),
+        ],
+    );
+
+    // QSO-level.
+    let f = ExportFilter {
+        qsl_rcvd: Some(QslStatusFilter {
+            service: None,
+            statuses: vec!["Y".into()],
+        }),
+        ..Default::default()
+    };
+    assert_eq!(exported_calls(&dir, &f), ["AAA"]);
+
+    // Service-qualified → LOTW_QSL_RCVD.
+    let f = ExportFilter {
+        qsl_rcvd: Some(QslStatusFilter {
+            service: Some("lotw".into()),
+            statuses: vec!["Y".into()],
+        }),
+        ..Default::default()
+    };
+    assert_eq!(exported_calls(&dir, &f), ["CCC"]);
+}
+
+// ---------------------------------------------------------- incremental ----
+
+#[test]
+fn incremental_export_advances_only_on_the_incremental_path() {
+    let dir = TmpDir::new();
+    let mut s = store_with(&dir, fleet());
+    let profile = DEFAULT_EXPORT_PROFILE;
+
+    assert_eq!(s.export_bookmark(profile).unwrap(), None);
+
+    // --- an ad-hoc filtered export must NOT move the bookmark ---
+    let adhoc = ExportFilter {
+        bands: Some(vec!["20m".into()]),
+        ..Default::default()
+    };
+    let ex = Exporter::open(dir.db()).unwrap();
+    let opts = ExportOptions {
+        output_path: dir.out(),
+        ..Default::default()
+    };
+    let summary = ex.export(&adhoc, &opts).unwrap();
+    assert_eq!(summary.count, 2);
+    // The caller only advances on the incremental path — it isn't one, so it doesn't.
+    assert_eq!(
+        s.export_bookmark(profile).unwrap(),
+        None,
+        "an ad-hoc export must never move the incremental position"
+    );
+
+    // --- a dry run must NOT move it either ---
+    let incremental = ExportFilter {
+        since_last_export: Some(profile.to_string()),
+        ..Default::default()
+    };
+    assert_eq!(ex.count(&incremental).unwrap(), 4, "first run: whole log");
+    assert_eq!(s.export_bookmark(profile).unwrap(), None);
+
+    // --- the real incremental export ---
+    let summary = ex.export(&incremental, &opts).unwrap();
+    assert_eq!(summary.count, 4);
+    let max_id = summary.max_qso_id.unwrap();
+    s.advance_export_bookmark(profile, max_id).unwrap();
+    assert_eq!(s.export_bookmark(profile).unwrap(), Some(max_id));
+
+    // --- a second incremental returns only what's newer ---
+    assert_eq!(
+        ex.count(&incremental).unwrap(),
+        0,
+        "nothing new since the bookmark"
+    );
+
+    let mut newer = qso("NEW1");
+    newer.qso_date = "20260710".into();
+    s.insert(&newer, &station()).unwrap();
+
+    let ex = Exporter::open(dir.db()).unwrap();
+    let summary = ex.export(&incremental, &opts).unwrap();
+    assert_eq!(summary.count, 1);
+    assert_eq!(read_calls(&dir.out()), ["NEW1"]);
+}
+
+#[test]
+fn bookmarks_are_per_profile_and_never_rewind() {
+    let dir = TmpDir::new();
+    let mut s = store_with(&dir, fleet());
+
+    s.advance_export_bookmark("wavelog", 3).unwrap();
+    assert_eq!(s.export_bookmark("wavelog").unwrap(), Some(3));
+    // A different stream is untouched — independent positions don't collide.
+    assert_eq!(s.export_bookmark("club-log").unwrap(), None);
+
+    // Re-exporting an older slice must not rewind the position.
+    s.advance_export_bookmark("wavelog", 1).unwrap();
+    assert_eq!(s.export_bookmark("wavelog").unwrap(), Some(3));
+}
+
+// ------------------------------------------------------- output mechanics --
+
+#[test]
+fn empty_match_set_writes_a_valid_zero_record_file() {
+    let dir = TmpDir::new();
+    let _s = store_with(&dir, fleet());
+    let f = ExportFilter {
+        call_exact: Some("NOBODY".into()),
+        ..Default::default()
+    };
+    let ex = Exporter::open(dir.db()).unwrap();
+    let summary = ex
+        .export(
+            &f,
+            &ExportOptions {
+                output_path: dir.out(),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+    assert_eq!(summary.count, 0);
+    let text = std::fs::read_to_string(dir.out()).unwrap();
+    assert!(text.contains("<EOH>"), "header present");
+    assert!(!text.contains("<EOR>"), "no records");
+    // ...and it still parses as ADIF.
+    assert!(adif::parse_adif(&text).unwrap().is_empty());
+}
+
+#[test]
+fn dry_run_counts_without_writing_a_file() {
+    let dir = TmpDir::new();
+    let _s = store_with(&dir, fleet());
+    let f = ExportFilter {
+        bands: Some(vec!["20m".into()]),
+        ..Default::default()
+    };
+    assert_eq!(count(&dir, &f), 2);
+    assert!(
+        !dir.out().exists(),
+        "a dry run must not create the output file"
+    );
+}
+
+#[test]
+fn header_carries_version_program_and_created_timestamp() {
+    let dir = TmpDir::new();
+    let _s = store_with(&dir, fleet());
+    let ex = Exporter::open(dir.db()).unwrap();
+    let summary = ex
+        .export(
+            &ExportFilter::default(),
+            &ExportOptions {
+                output_path: dir.out(),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+    let text = std::fs::read_to_string(dir.out()).unwrap();
+    assert!(text.contains("<ADIF_VER:5>3.1.6"));
+    assert!(text.contains("<PROGRAMID:7>rigflow"));
+    assert!(text.contains(&format!(
+        "<PROGRAMVERSION:{}>{}",
+        PROGRAM_VERSION.len(),
+        PROGRAM_VERSION
+    )));
+    assert!(text.contains(&format!(
+        "<CREATED_TIMESTAMP:15>{}",
+        summary.created_timestamp
+    )));
+    assert_eq!(summary.created_timestamp.len(), 15, "YYYYMMDD HHMMSS");
+}
+
+#[test]
+fn sort_order() {
+    let dir = TmpDir::new();
+    let _s = store_with(&dir, fleet());
+
+    let chrono = ExportOptions {
+        output_path: dir.out(),
+        sort: Sort::Chronological,
+        ..Default::default()
+    };
+    let ex = Exporter::open(dir.db()).unwrap();
+    ex.export(&ExportFilter::default(), &chrono).unwrap();
+    assert_eq!(read_calls(&dir.out()), ["W1AW", "K5ZD", "JA1XYZ", "VK3ABC"]);
+
+    let rev = ExportOptions {
+        sort: Sort::Reverse,
+        ..chrono
+    };
+    ex.export(&ExportFilter::default(), &rev).unwrap();
+    assert_eq!(read_calls(&dir.out()), ["VK3ABC", "JA1XYZ", "K5ZD", "W1AW"]);
+}
+
+#[test]
+fn split_fields_only_on_split_qsos() {
+    let dir = TmpDir::new();
+    let mut split = qso("DX1SPLIT");
+    split.freq_rx_hz = Some(14_195_000);
+    split.normalize();
+    assert_eq!(split.band_rx.as_deref(), Some("20m"));
+    let _s = store_with(&dir, vec![qso("SIMPLEX"), split]);
+
+    let ex = Exporter::open(dir.db()).unwrap();
+    ex.export(
+        &ExportFilter::default(),
+        &ExportOptions {
+            output_path: dir.out(),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+
+    let text = std::fs::read_to_string(dir.out()).unwrap();
+    let records = adif::parse_adif(&text).unwrap();
+    let simplex = records.iter().find(|r| r["CALL"] == "SIMPLEX").unwrap();
+    let split_rec = records.iter().find(|r| r["CALL"] == "DX1SPLIT").unwrap();
+
+    assert!(!simplex.contains_key("FREQ_RX"), "simplex omits FREQ_RX");
+    assert!(!simplex.contains_key("BAND_RX"), "simplex omits BAND_RX");
+    assert_eq!(split_rec.get("FREQ_RX").unwrap(), "14.195000");
+    assert_eq!(split_rec.get("BAND_RX").unwrap(), "20m");
+}
+
+// --------------------------------------------------------- field profiles --
+
+#[test]
+fn field_profile_core_emits_only_the_core_subset() {
+    let dir = TmpDir::new();
+    let _s = store_with(&dir, vec![with_extra(qso("AAA"), &[("MY_CITY", "Austin")])]);
+
+    let ex = Exporter::open(dir.db()).unwrap();
+    ex.export(
+        &ExportFilter::default(),
+        &ExportOptions {
+            output_path: dir.out(),
+            field_profile: FieldProfile::Core,
+            ..Default::default()
+        },
+    )
+    .unwrap();
+
+    let text = std::fs::read_to_string(dir.out()).unwrap();
+    let rec = &adif::parse_adif(&text).unwrap()[0];
+    for k in rec.keys() {
+        assert!(
+            CORE_FIELDS.contains(&k.as_str()),
+            "Core emitted a non-core field: {k}"
+        );
+    }
+    assert!(rec.contains_key("CALL") && rec.contains_key("BAND"));
+    // The station snapshot and extras are not core.
+    assert!(!rec.contains_key("MY_CITY"));
+    assert!(!rec.contains_key("STATION_CALLSIGN"));
+}
+
+#[test]
+fn field_profile_core_keeps_submode_so_ft4_survives() {
+    // Core deliberately includes SUBMODE (the brief's list omitted it): without
+    // it an FT4 QSO exports as bare MODE=MFSK and comes back as something else.
+    let dir = TmpDir::new();
+    let mut ft4 = qso("EA1AAA");
+    ft4.mode = "FT4".into();
+    ft4.normalize();
+    let _s = store_with(&dir, vec![ft4]);
+
+    let ex = Exporter::open(dir.db()).unwrap();
+    ex.export(
+        &ExportFilter::default(),
+        &ExportOptions {
+            output_path: dir.out(),
+            field_profile: FieldProfile::Core,
+            ..Default::default()
+        },
+    )
+    .unwrap();
+
+    let text = std::fs::read_to_string(dir.out()).unwrap();
+    let rec = &adif::parse_adif(&text).unwrap()[0];
+    assert_eq!(rec.get("MODE").unwrap(), "MFSK");
+    assert_eq!(rec.get("SUBMODE").unwrap(), "FT4");
+}
+
+#[test]
+fn field_profile_custom_emits_exactly_the_requested_fields() {
+    let dir = TmpDir::new();
+    let _s = store_with(&dir, vec![qso("AAA")]);
+
+    let ex = Exporter::open(dir.db()).unwrap();
+    ex.export(
+        &ExportFilter::default(),
+        &ExportOptions {
+            output_path: dir.out(),
+            field_profile: FieldProfile::Custom(vec!["call".into(), "band".into()]),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+
+    let text = std::fs::read_to_string(dir.out()).unwrap();
+    let rec = &adif::parse_adif(&text).unwrap()[0];
+    let mut keys: Vec<&str> = rec.keys().map(|s| s.as_str()).collect();
+    keys.sort();
+    assert_eq!(keys, ["BAND", "CALL"]);
+}
+
+#[test]
+fn include_extra_false_drops_the_passthrough() {
+    let dir = TmpDir::new();
+    let _s = store_with(&dir, vec![with_extra(qso("AAA"), &[("APP_X", "1")])]);
+
+    let ex = Exporter::open(dir.db()).unwrap();
+    for (include, want) in [(true, true), (false, false)] {
+        ex.export(
+            &ExportFilter::default(),
+            &ExportOptions {
+                output_path: dir.out(),
+                field_profile: FieldProfile::Full,
+                include_extra: include,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        let text = std::fs::read_to_string(dir.out()).unwrap();
+        let rec = &adif::parse_adif(&text).unwrap()[0];
+        assert_eq!(rec.contains_key("APP_X"), want);
+        assert_eq!(rec.contains_key("STATION_CALLSIGN"), want);
+        assert!(rec.contains_key("CALL"), "modeled columns always survive");
+    }
+}
+
+// ------------------------------------------------------------- round-trip --
+
+#[test]
+fn round_trip_export_then_import_into_a_clean_db() {
+    let src = TmpDir::new();
+    let mut split = qso("DX1SPLIT");
+    split.freq_rx_hz = Some(14_195_000);
+    split.normalize();
+    let qsos = vec![
+        with_extra(qso("W1AW"), &[("COMMENT", "nice sig")]),
+        split,
+        with_extra(qso("OH2ÄÄ"), &[("NAME_INTL", "Jörg")]), // UTF-8 / _INTL
+    ];
+    let _s = store_with(&src, qsos.clone());
+
+    let ex = Exporter::open(src.db()).unwrap();
+    let summary = ex
+        .export(
+            &ExportFilter::default(),
+            &ExportOptions {
+                output_path: src.out(),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+    assert_eq!(summary.count, 3);
+
+    // Re-import into a clean DB via the shared parser.
+    let dst = TmpDir::new();
+    let text = std::fs::read_to_string(src.out()).unwrap();
+    let imported = adif::parse_adif_to_qsos(&text).unwrap();
+    let mut s2 = LogStore::open(dst.db(), dst.adi()).unwrap();
+    for q in &imported {
+        s2.insert(q, &station()).unwrap();
+    }
+
+    let round_tripped = s2.query_contacts(100).unwrap();
+    assert_eq!(round_tripped.len(), 3);
+
+    // Every source QSO survives, with its split fields and its extras.
+    let by_call = |call: &str| {
+        round_tripped
+            .iter()
+            .find(|lq| lq.qso.call == call)
+            .unwrap()
+            .qso
+            .clone()
+    };
+
+    let split_back = by_call("DX1SPLIT");
+    assert_eq!(split_back.freq_rx_hz, Some(14_195_000));
+    assert_eq!(split_back.band_rx.as_deref(), Some("20m"));
+
+    let w1aw = by_call("W1AW");
+    assert_eq!(w1aw.freq_rx_hz, None, "simplex stays simplex");
+    assert_eq!(w1aw.extra.get("COMMENT").unwrap(), "nice sig");
+
+    let intl = by_call("OH2ÄÄ");
+    assert_eq!(intl.extra.get("NAME_INTL").unwrap(), "Jörg");
+
+    // The modeled columns match the source exactly.
+    for src_q in &qsos {
+        let back = by_call(&src_q.call);
+        assert_eq!(back.band, src_q.band);
+        assert_eq!(back.mode, src_q.mode);
+        assert_eq!(back.freq_hz, src_q.freq_hz);
+        assert_eq!(back.freq_rx_hz, src_q.freq_rx_hz);
+        assert_eq!(back.rst_sent, src_q.rst_sent);
+    }
+}
+
+// -------------------------------------------------------------- injection --
+
+#[test]
+fn call_pattern_is_parameterized_against_injection() {
+    let dir = TmpDir::new();
+    let _s = store_with(&dir, fleet());
+
+    let nasty = "'; DROP TABLE qso;--";
+    let f = ExportFilter {
+        call_pattern: Some(nasty.into()),
+        ..Default::default()
+    };
+    // Matches nothing (no call looks like that) and, crucially, does no damage.
+    assert_eq!(count(&dir, &f), 0);
+
+    let s = LogStore::open(dir.db(), dir.adi()).unwrap();
+    let n: i64 = s
+        .conn()
+        .query_row("SELECT COUNT(*) FROM qso", [], |r| r.get(0))
+        .unwrap();
+    assert_eq!(n, 4, "the table is still there with all its rows");
+
+    // A literal % in a call must match a literal %, not act as a wildcard.
+    let mut odd = qso("W%AW");
+    odd.qso_date = "20260709".into();
+    let mut s = s;
+    s.insert(&odd, &station()).unwrap();
+    drop(s);
+
+    let f = ExportFilter {
+        call_exact: Some("W%AW".into()),
+        ..Default::default()
+    };
+    assert_eq!(exported_calls(&dir, &f), ["W%AW"]);
+
+    // '*' is the user's wildcard; a raw '%' is escaped to a literal.
+    let f = ExportFilter {
+        call_pattern: Some("W%*".into()),
+        ..Default::default()
+    };
+    assert_eq!(
+        exported_calls(&dir, &f),
+        ["W%AW"],
+        "the % is literal, the * is the wildcard"
+    );
+}
+
+#[test]
+fn service_name_with_sql_in_it_is_rejected_not_interpolated() {
+    // A service name reaches SQL as text (inside a json_extract path), so it is
+    // whitelisted at the door rather than bound.
+    let f = ExportFilter {
+        qsl_rcvd: Some(QslStatusFilter {
+            service: Some("lotw'); DROP TABLE qso;--".into()),
+            statuses: vec!["Y".into()],
+        }),
+        ..Default::default()
+    };
+    assert!(matches!(f.validate(), Err(FilterError::BadServiceName(_))));
+}
+
+// ------------------------------------------------------------ validation ---
+
+#[test]
+fn validation_rejects_bad_input_up_front() {
+    let bad_date = ExportFilter {
+        date_from: Some("2026-07-01".into()),
+        ..Default::default()
+    };
+    assert!(matches!(bad_date.validate(), Err(FilterError::BadDate(_))));
+
+    let not_a_day = ExportFilter {
+        date_from: Some("20260231".into()), // Feb 31st
+        ..Default::default()
+    };
+    assert!(matches!(not_a_day.validate(), Err(FilterError::BadDate(_))));
+
+    let inverted = ExportFilter {
+        date_from: Some("20260710".into()),
+        date_to: Some("20260701".into()),
+        ..Default::default()
+    };
+    assert!(matches!(
+        inverted.validate(),
+        Err(FilterError::InvertedRange { .. })
+    ));
+
+    let bad_band = ExportFilter {
+        bands: Some(vec!["17.5m".into()]),
+        ..Default::default()
+    };
+    assert!(matches!(
+        bad_band.validate(),
+        Err(FilterError::UnknownBand(_))
+    ));
+
+    let empty = ExportFilter {
+        bands: Some(vec![]),
+        ..Default::default()
+    };
+    assert!(matches!(empty.validate(), Err(FilterError::EmptyList(_))));
+
+    let bad_cont = ExportFilter {
+        continent: Some(vec!["XX".into()]),
+        ..Default::default()
+    };
+    assert!(matches!(
+        bad_cont.validate(),
+        Err(FilterError::UnknownContinent(_))
+    ));
+}
+
+#[test]
+fn validation_rejects_non_canonical_modes_with_the_fix() {
+    // USB is a sideband, not an ADIF mode: the column holds SSB, so filtering
+    // USB would silently match zero of the operator's hundreds of SSB QSOs.
+    let f = ExportFilter {
+        modes: Some(vec!["USB".into()]),
+        ..Default::default()
+    };
+    match f.validate() {
+        Err(FilterError::NonCanonicalMode { given, canonical }) => {
+            assert_eq!(given, "USB");
+            assert_eq!(canonical, "SSB");
+        }
+        other => panic!("expected NonCanonicalMode, got {other:?}"),
+    }
+
+    // FT4 is stored as MFSK/FT4 — filter it as a submode (or by class).
+    let f = ExportFilter {
+        modes: Some(vec!["FT4".into()]),
+        ..Default::default()
+    };
+    assert!(matches!(
+        f.validate(),
+        Err(FilterError::NonCanonicalMode { .. })
+    ));
+
+    // The canonical ones pass.
+    let f = ExportFilter {
+        modes: Some(vec!["SSB".into(), "CW".into(), "FT8".into(), "MFSK".into()]),
+        ..Default::default()
+    };
+    assert!(f.validate().is_ok());
+}
+
+#[test]
+fn custom_profile_with_no_fields_is_rejected() {
+    let opts = ExportOptions {
+        field_profile: FieldProfile::Custom(vec![]),
+        ..Default::default()
+    };
+    assert!(matches!(opts.validate(), Err(FilterError::EmptyFieldList)));
+}
+
+// ----------------------------------------------------------- read-only -----
+
+#[test]
+fn the_exporter_connection_cannot_write() {
+    // The read-only invariant is enforced by SQLite, not by our discipline.
+    let dir = TmpDir::new();
+    let _s = store_with(&dir, fleet());
+
+    let ex = Exporter::open(dir.db()).unwrap();
+    ex.export(
+        &ExportFilter::default(),
+        &ExportOptions {
+            output_path: dir.out(),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+
+    // Prove it: a write on that connection is refused by the engine.
+    let err = ex
+        .conn_for_test()
+        .execute("UPDATE qso SET call = 'HACKED'", [])
+        .unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("readonly") || msg.contains("read-only"),
+        "expected a read-only refusal, got: {msg}"
+    );
+
+    // And the log is untouched.
+    let s = LogStore::open(dir.db(), dir.adi()).unwrap();
+    let n: i64 = s
+        .conn()
+        .query_row("SELECT COUNT(*) FROM qso WHERE call = 'HACKED'", [], |r| {
+            r.get(0)
+        })
+        .unwrap();
+    assert_eq!(n, 0);
+}
+
+#[test]
+fn export_does_not_touch_updated_at() {
+    let dir = TmpDir::new();
+    let _s = store_with(&dir, fleet());
+
+    let before: Vec<String> = {
+        let s = LogStore::open(dir.db(), dir.adi()).unwrap();
+        let mut stmt = s
+            .conn()
+            .prepare("SELECT updated_at FROM qso ORDER BY id")
+            .unwrap();
+        let v = stmt
+            .query_map([], |r| r.get::<_, String>(0))
+            .unwrap()
+            .map(|r| r.unwrap())
+            .collect();
+        v
+    };
+
+    let ex = Exporter::open(dir.db()).unwrap();
+    ex.export(
+        &ExportFilter::default(),
+        &ExportOptions {
+            output_path: dir.out(),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+
+    let after: Vec<String> = {
+        let s = LogStore::open(dir.db(), dir.adi()).unwrap();
+        let mut stmt = s
+            .conn()
+            .prepare("SELECT updated_at FROM qso ORDER BY id")
+            .unwrap();
+        let v = stmt
+            .query_map([], |r| r.get::<_, String>(0))
+            .unwrap()
+            .map(|r| r.unwrap())
+            .collect();
+        v
+    };
+
+    assert_eq!(before, after, "export must not restamp updated_at");
+}
+
+// ------------------------------------------------------------- streaming ---
+
+#[test]
+fn large_export_streams_without_materializing_the_log() {
+    // 20k QSOs. The point isn't speed — it's that the writer holds one record at
+    // a time, so peak memory is a buffer, not a heap of 20k records.
+    //
+    // Seeded with raw SQL in one transaction rather than through `insert()`:
+    // `insert()` fsyncs the ADIF journal per contact (correct for a real QSO,
+    // 20k fsyncs here), and this test is about the *export* path, not the insert
+    // path — which the other tests cover.
+    let dir = TmpDir::new();
+    let mut s = LogStore::open(dir.db(), dir.adi()).unwrap();
+    s.insert(&qso("SEED"), &station()).unwrap(); // creates the station row
+
+    const N: usize = 20_000;
+    {
+        let conn = s.conn();
+        conn.execute_batch("BEGIN").unwrap();
+        let mut stmt = conn
+            .prepare(
+                "INSERT INTO qso (call,qso_date,time_on,band,mode,freq_hz,station_id,extra,\
+                 created_at,updated_at) \
+                 VALUES (?1,'20260711',?2,'20m','SSB',14207000,1,'{}','x','x')",
+            )
+            .unwrap();
+        for i in 0..N - 1 {
+            let time_on = format!("{:02}{:02}{:02}", i / 3600 % 24, (i / 60) % 60, i % 60);
+            stmt.execute(rusqlite::params![format!("T{i:05}"), time_on])
+                .unwrap();
+        }
+        drop(stmt);
+        conn.execute_batch("COMMIT").unwrap();
+    }
+    drop(s);
+
+    let ex = Exporter::open(dir.db()).unwrap();
+    let summary = ex
+        .export(
+            &ExportFilter::default(),
+            &ExportOptions {
+                output_path: dir.out(),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+    assert_eq!(summary.count, N);
+    let text = std::fs::read_to_string(dir.out()).unwrap();
+    assert_eq!(text.matches("<EOR>").count(), N);
+    assert_eq!(summary.max_qso_id, Some(N as i64));
+}

--- a/rigflow-log/src/export/tests.rs
+++ b/rigflow-log/src/export/tests.rs
@@ -210,6 +210,29 @@ fn export_stamps_every_confirming_service() {
     );
 }
 
+#[test]
+fn all_matching_gathers_the_not_uploaded_set() {
+    // The upload path asks for "everything not yet sent to this service".
+    let dir = TmpDir::new();
+    let mut s = LogStore::open(dir.db(), dir.adi()).unwrap();
+    let a = s.insert(&qso("W1AW"), &station()).unwrap();
+    s.insert(&qso("K5ZD"), &station()).unwrap();
+    s.mark_uploaded(&[a.id], "eqsl").unwrap(); // W1AW already on eQSL
+    drop(s);
+
+    let ex = Exporter::open(dir.db()).unwrap();
+    let f = ExportFilter {
+        not_uploaded_to: Some(vec!["eqsl".into()]),
+        ..Default::default()
+    };
+    let rows = ex.all_matching(&f).unwrap();
+    assert_eq!(rows.len(), 1, "only the un-uploaded one");
+    assert_eq!(rows[0].qso.call, "K5ZD");
+
+    // Uncapped: with no filter it returns every QSO.
+    assert_eq!(ex.all_matching(&ExportFilter::default()).unwrap().len(), 2);
+}
+
 fn count(dir: &TmpDir, filter: &ExportFilter) -> usize {
     Exporter::open(dir.db()).unwrap().count(filter).unwrap()
 }

--- a/rigflow-log/src/export/writer.rs
+++ b/rigflow-log/src/export/writer.rs
@@ -86,6 +86,23 @@ impl Exporter {
         read_bookmark(&self.conn, profile)
     }
 
+    /// A page of matching contacts for the contact view, plus the total match
+    /// count so the view can say "showing 500 of 1,483".
+    ///
+    /// Counting and paging run against the same filter in one call, so the two
+    /// numbers are always consistent with each other (and with what an export of
+    /// the same filter would write).
+    pub fn page(
+        &self,
+        filter: &ExportFilter,
+        limit: usize,
+        sort: super::filter::Sort,
+    ) -> Result<ContactPage, LogError> {
+        let total = count_with(&self.conn, filter)?;
+        let rows = query_with(&self.conn, filter, limit, sort)?;
+        Ok(ContactPage { rows, total })
+    }
+
     /// Test-only handle, used to prove SQLite itself refuses a write here.
     #[cfg(test)]
     pub(crate) fn conn_for_test(&self) -> &Connection {
@@ -124,6 +141,52 @@ pub(crate) fn count_with(conn: &Connection, filter: &ExportFilter) -> Result<usi
     let sql = format!("SELECT COUNT(*) FROM qso WHERE {}", q.where_sql);
     let n: i64 = conn.query_row(&sql, params_from_iter(q.params.iter()), |r| r.get(0))?;
     Ok(n as usize)
+}
+
+/// One page of matching QSOs, plus how many matched in total.
+///
+/// The contact view shows `rows` (capped by its limit) but reports `total`, so
+/// "showing 500 of 1,483 matching" is honest about the cap. Without `total` the
+/// view would silently imply it was showing everything the export will write.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ContactPage {
+    pub rows: Vec<crate::store::LoggedQso>,
+    /// Total matches, ignoring `limit`. This is the number the export writes.
+    pub total: usize,
+}
+
+/// Read a page of matching QSOs.
+///
+/// Goes through [`query::build`] — the same WHERE clause [`export_with`] and
+/// [`count_with`] use — so what the contact view lists, what the count promises,
+/// and what the export writes cannot drift apart. That single-builder property
+/// is the whole point of filtering the view and the export with one type.
+pub(crate) fn query_with(
+    conn: &Connection,
+    filter: &ExportFilter,
+    limit: usize,
+    sort: super::filter::Sort,
+) -> Result<Vec<crate::store::LoggedQso>, LogError> {
+    filter.validate()?;
+    let bookmark = resolve_bookmark(conn, filter)?;
+    let q = query::build(filter, bookmark);
+    let sql = format!(
+        "SELECT {} FROM qso WHERE {} {} LIMIT ?",
+        store::QSO_COLUMNS,
+        q.where_sql,
+        query::order_by(sort),
+    );
+
+    let mut params = q.params;
+    params.push(rusqlite::types::Value::Integer(limit as i64));
+
+    let mut stmt = conn.prepare(&sql)?;
+    let mut rows = stmt.query(params_from_iter(params.iter()))?;
+    let mut out = Vec::new();
+    while let Some(row) = rows.next()? {
+        out.push(store::row_to_logged_qso(row)??);
+    }
+    Ok(out)
 }
 
 /// Write the matching QSOs to `opts.output_path` as ADIF.

--- a/rigflow-log/src/export/writer.rs
+++ b/rigflow-log/src/export/writer.rs
@@ -31,6 +31,44 @@ use crate::{adif, store};
 /// This build's `PROGRAMVERSION`.
 pub const PROGRAM_VERSION: &str = env!("CARGO_PKG_VERSION");
 
+/// Trailing SELECT column that packs a QSO's confirmations into one string:
+/// `service␟date` entries joined by `␞`, from `qso_service`. Control chars
+/// (unit/record separators, 0x1f/0x1e) can't occur in a service name or an ADIF
+/// date, so the split in [`inject_confirmations`] is unambiguous. Empty (`NULL`)
+/// when the QSO has no confirmations.
+const CONFIRMATIONS_AGG: &str = "(SELECT group_concat(service || char(31) || \
+     coalesce(confirmed_at,''), char(30)) \
+     FROM qso_service s WHERE s.qso_id = qso.id AND s.confirmed_at IS NOT NULL)";
+
+/// Column index of [`CONFIRMATIONS_AGG`] in the export SELECT: it follows the
+/// fixed `QSO_COLUMNS` (15 columns, indices 0–14), so it is 15.
+const CONFIRMATIONS_COL: usize = 15;
+
+/// Stamp each `qso_service` confirmation onto an export record as the ADIF field
+/// its service uses: `LOTW_QSL_RCVD`/`LOTW_QSLRDATE`, `EQSL_QSL_RCVD`/
+/// `EQSL_QSLRDATE`, or the generic `QSL_RCVD`/`QSLRDATE`. `packed` is the
+/// [`CONFIRMATIONS_AGG`] value. Mirrors what import's confirmation detection
+/// reads, so an export of ours round-trips back to the same `qso_service` rows.
+fn inject_confirmations(record: &mut adif::AdifRecord, packed: Option<&str>) {
+    let Some(packed) = packed.filter(|s| !s.is_empty()) else {
+        return;
+    };
+    for entry in packed.split('\u{1e}') {
+        let (service, date) = entry.split_once('\u{1f}').unwrap_or((entry, ""));
+        let (rcvd, rdate) = match service {
+            "qsl" => ("QSL_RCVD".to_string(), "QSLRDATE".to_string()),
+            s => {
+                let s = s.to_ascii_uppercase();
+                (format!("{s}_QSL_RCVD"), format!("{s}_QSLRDATE"))
+            }
+        };
+        record.insert(rcvd, "Y".to_string());
+        if !date.is_empty() {
+            record.insert(rdate, date.to_string());
+        }
+    }
+}
+
 /// What an export did.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ExportSummary {
@@ -226,9 +264,13 @@ pub(crate) fn export_with(
 
     let bookmark = resolve_bookmark(conn, filter)?;
     let q = query::build(filter, bookmark);
+    // Confirmations ride along as a trailing aggregate column (index after the
+    // fixed QSO_COLUMNS), so a single streaming pass carries them — no per-row
+    // query against `qso_service`.
     let sql = format!(
-        "SELECT {} FROM qso WHERE {} {}",
+        "SELECT {}, {} FROM qso WHERE {} {}",
         store::QSO_COLUMNS,
+        CONFIRMATIONS_AGG,
         q.where_sql,
         query::order_by(opts.sort),
     );
@@ -246,6 +288,7 @@ pub(crate) fn export_with(
     let mut count = 0usize;
     let mut max_qso_id: Option<i64> = None;
     while let Some(row) = rows.next()? {
+        let confs: Option<String> = row.get(CONFIRMATIONS_COL)?;
         let lq = store::row_to_logged_qso(row)??;
 
         // The shared record-writer — the same one the journal appends through.
@@ -253,6 +296,9 @@ pub(crate) fn export_with(
         // wins are applied in there, once, for both callers.
         let mut record = adif::qso_to_record(&lq.qso);
         opts.project(&mut record);
+        // AFTER project: confirmation state is authoritative export data and must
+        // survive even a narrow field profile (Core, Full-without-extra).
+        inject_confirmations(&mut record, confs.as_deref());
         w.write_all(adif::write_record(&record).as_bytes())?;
 
         count += 1;

--- a/rigflow-log/src/export/writer.rs
+++ b/rigflow-log/src/export/writer.rs
@@ -1,0 +1,189 @@
+//! The streaming ADIF export writer, the dry-run counter, and the
+//! incremental-bookmark reader.
+//!
+//! **Export derives from SQLite. It never replays `rigflow_log.adi`.** The
+//! journal is an append-only event tape: it still holds superseded (corrected)
+//! records and records for since-deleted QSOs, ordered by log time rather than
+//! contact time. The database is the materialized current state — corrections
+//! applied, deletions gone, one row per QSO. The journal is replayed in exactly
+//! one situation, and it is not this one: rebuilding a lost or corrupt `.db`.
+//!
+//! **Export is read-only, and [`Exporter`] makes that structural** rather than a
+//! promise: it opens its own connection with `SQLITE_OPEN_READ_ONLY`, so SQLite
+//! itself refuses any write. It therefore *cannot* touch `updated_at`, cannot
+//! write `qso_service`, and — see [`crate::export`] — cannot advance the
+//! incremental bookmark. It also means export can run on a worker thread while
+//! the app's read-write `LogStore` keeps logging on the UI thread; WAL gives
+//! concurrent readers for free.
+
+use std::fs::File;
+use std::io::{BufWriter, Write};
+use std::path::{Path, PathBuf};
+
+use chrono::Utc;
+use rusqlite::{Connection, OpenFlags, params_from_iter};
+
+use super::filter::{ExportFilter, ExportOptions};
+use super::query;
+use crate::error::LogError;
+use crate::{adif, store};
+
+/// This build's `PROGRAMVERSION`.
+pub const PROGRAM_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+/// What an export did.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExportSummary {
+    /// Records written (0 is a success, not an error — see [`export_with`]).
+    pub count: usize,
+    pub path: PathBuf,
+    /// The filter that produced it, for the UI to show back and for a log line.
+    pub filter: ExportFilter,
+    /// ADIF `CREATED_TIMESTAMP` stamped in the header (`YYYYMMDD HHMMSS`, UTC).
+    pub created_timestamp: String,
+    /// Highest `qso.id` written. This is what an incremental bookmark advances
+    /// to — but *this* type only reports it; advancing is the caller's job on a
+    /// write connection. `None` when nothing matched.
+    pub max_qso_id: Option<i64>,
+}
+
+/// A read-only view of a log database, for counting and exporting.
+///
+/// Owns its own `SQLITE_OPEN_READ_ONLY` connection, so it is safe to hand to a
+/// worker thread even while the app's `LogStore` is inserting on another.
+pub struct Exporter {
+    conn: Connection,
+}
+
+impl Exporter {
+    /// Open `db_path` read-only. Fails if the database doesn't exist — an export
+    /// of a log that was never created is a caller bug, not an empty export.
+    pub fn open(db_path: impl AsRef<Path>) -> Result<Self, LogError> {
+        let conn = Connection::open_with_flags(
+            db_path.as_ref(),
+            OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_NO_MUTEX,
+        )?;
+        Ok(Exporter { conn })
+    }
+
+    /// Dry run: how many QSOs match, without writing anything. This is what the
+    /// dialog's live "1,483 QSOs match" count calls.
+    pub fn count(&self, filter: &ExportFilter) -> Result<usize, LogError> {
+        count_with(&self.conn, filter)
+    }
+
+    /// Stream the matching QSOs to `opts.output_path`.
+    pub fn export(
+        &self,
+        filter: &ExportFilter,
+        opts: &ExportOptions,
+    ) -> Result<ExportSummary, LogError> {
+        export_with(&self.conn, filter, opts)
+    }
+
+    /// The current position of a named incremental bookmark, if it has one.
+    pub fn bookmark(&self, profile: &str) -> Result<Option<i64>, LogError> {
+        read_bookmark(&self.conn, profile)
+    }
+
+    /// Test-only handle, used to prove SQLite itself refuses a write here.
+    #[cfg(test)]
+    pub(crate) fn conn_for_test(&self) -> &Connection {
+        &self.conn
+    }
+}
+
+/// Read a named bookmark's `last_qso_id`. `None` = no such profile yet, which
+/// means a first incremental export covers the whole log.
+pub(crate) fn read_bookmark(conn: &Connection, profile: &str) -> Result<Option<i64>, LogError> {
+    use rusqlite::OptionalExtension;
+    Ok(conn
+        .query_row(
+            "SELECT last_qso_id FROM export_state WHERE profile = ?1",
+            [profile],
+            |r| r.get(0),
+        )
+        .optional()?)
+}
+
+/// Resolve the bookmark a filter needs (if it is an incremental export).
+fn resolve_bookmark(conn: &Connection, filter: &ExportFilter) -> Result<Option<i64>, LogError> {
+    match filter.incremental_profile() {
+        Some(profile) => read_bookmark(conn, profile),
+        None => Ok(None),
+    }
+}
+
+/// Count matching QSOs. Same filter → same `WHERE` as [`export_with`], because
+/// both go through [`query::build`]; a count that disagreed with the subsequent
+/// export would be worse than no count at all.
+pub(crate) fn count_with(conn: &Connection, filter: &ExportFilter) -> Result<usize, LogError> {
+    filter.validate()?;
+    let bookmark = resolve_bookmark(conn, filter)?;
+    let q = query::build(filter, bookmark);
+    let sql = format!("SELECT COUNT(*) FROM qso WHERE {}", q.where_sql);
+    let n: i64 = conn.query_row(&sql, params_from_iter(q.params.iter()), |r| r.get(0))?;
+    Ok(n as usize)
+}
+
+/// Write the matching QSOs to `opts.output_path` as ADIF.
+///
+/// Streams: one record is in memory at a time, so a 200k-QSO export costs a
+/// buffer, not a heap of records.
+///
+/// An empty match set writes a **valid, importable ADIF file with a header and
+/// zero records** and returns `count: 0`. That is not an error: "no QSOs matched
+/// your filter" is a legitimate answer, and a caller that wants to treat it as
+/// noteworthy can check `count`.
+pub(crate) fn export_with(
+    conn: &Connection,
+    filter: &ExportFilter,
+    opts: &ExportOptions,
+) -> Result<ExportSummary, LogError> {
+    filter.validate()?;
+    opts.validate()?;
+
+    let bookmark = resolve_bookmark(conn, filter)?;
+    let q = query::build(filter, bookmark);
+    let sql = format!(
+        "SELECT {} FROM qso WHERE {} {}",
+        store::QSO_COLUMNS,
+        q.where_sql,
+        query::order_by(opts.sort),
+    );
+
+    let created_timestamp = Utc::now().format("%Y%m%d %H%M%S").to_string();
+
+    let mut stmt = conn.prepare(&sql)?;
+    let mut rows = stmt.query(params_from_iter(q.params.iter()))?;
+
+    let mut w = BufWriter::new(File::create(&opts.output_path)?);
+    w.write_all(
+        adif::export_header(&opts.adif_version, PROGRAM_VERSION, &created_timestamp).as_bytes(),
+    )?;
+
+    let mut count = 0usize;
+    let mut max_qso_id: Option<i64> = None;
+    while let Some(row) = rows.next()? {
+        let lq = store::row_to_logged_qso(row)??;
+
+        // The shared record-writer — the same one the journal appends through.
+        // Split fields (FREQ_RX/BAND_RX only when present) and modeled-column-
+        // wins are applied in there, once, for both callers.
+        let mut record = adif::qso_to_record(&lq.qso);
+        opts.project(&mut record);
+        w.write_all(adif::write_record(&record).as_bytes())?;
+
+        count += 1;
+        max_qso_id = Some(max_qso_id.map_or(lq.id, |m: i64| m.max(lq.id)));
+    }
+    w.flush()?;
+
+    Ok(ExportSummary {
+        count,
+        path: opts.output_path.clone(),
+        filter: filter.clone(),
+        created_timestamp,
+        max_qso_id,
+    })
+}

--- a/rigflow-log/src/export/writer.rs
+++ b/rigflow-log/src/export/writer.rs
@@ -103,6 +103,21 @@ impl Exporter {
         Ok(ContactPage { rows, total })
     }
 
+    /// Work out what importing an ADIF document *would* do, without writing.
+    ///
+    /// Lives on `Exporter` because it needs exactly what `Exporter` has: a
+    /// **read-only** connection. Planning an import must not be able to touch the
+    /// log — the operator hasn't agreed to anything yet — and running it here
+    /// makes that structural rather than a promise. The commit is a separate call
+    /// on the read-write [`crate::LogStore`].
+    pub fn plan_import(
+        &self,
+        text: &str,
+        window_secs: i64,
+    ) -> Result<crate::import::ImportPlan, LogError> {
+        crate::import::plan(&self.conn, text, window_secs)
+    }
+
     /// Test-only handle, used to prove SQLite itself refuses a write here.
     #[cfg(test)]
     pub(crate) fn conn_for_test(&self) -> &Connection {

--- a/rigflow-log/src/export/writer.rs
+++ b/rigflow-log/src/export/writer.rs
@@ -99,7 +99,10 @@ impl Exporter {
         sort: super::filter::Sort,
     ) -> Result<ContactPage, LogError> {
         let total = count_with(&self.conn, filter)?;
-        let rows = query_with(&self.conn, filter, limit, sort)?;
+        let mut rows = query_with(&self.conn, filter, limit, sort)?;
+        // The contact view runs on this read-only path, so its confirmation
+        // column has to be filled here as well as on the read-write store.
+        crate::store::attach_confirmations(&self.conn, &mut rows)?;
         Ok(ContactPage { rows, total })
     }
 

--- a/rigflow-log/src/export/writer.rs
+++ b/rigflow-log/src/export/writer.rs
@@ -144,6 +144,16 @@ impl Exporter {
         Ok(ContactPage { rows, total })
     }
 
+    /// Every QSO matching `filter`, uncapped and oldest-first — for building an
+    /// upload batch on the worker thread (e.g. everything `not_uploaded_to` a
+    /// service). Read-only, like the rest of `Exporter`.
+    pub fn all_matching(
+        &self,
+        filter: &ExportFilter,
+    ) -> Result<Vec<crate::store::LoggedQso>, LogError> {
+        query_all_with(&self.conn, filter)
+    }
+
     /// Work out what importing an ADIF document *would* do, without writing.
     ///
     /// Lives on `Exporter` because it needs exactly what `Exporter` has: a
@@ -238,6 +248,32 @@ pub(crate) fn query_with(
 
     let mut stmt = conn.prepare(&sql)?;
     let mut rows = stmt.query(params_from_iter(params.iter()))?;
+    let mut out = Vec::new();
+    while let Some(row) = rows.next()? {
+        out.push(store::row_to_logged_qso(row)??);
+    }
+    Ok(out)
+}
+
+/// Every matching QSO, uncapped — for building an upload batch (all the QSOs not
+/// yet sent to a service). Oldest first, so an upload sends contacts in the order
+/// they were made. Unlike [`query_with`] this has no `LIMIT`: an upload must
+/// cover the whole set, not a page of it.
+pub(crate) fn query_all_with(
+    conn: &Connection,
+    filter: &ExportFilter,
+) -> Result<Vec<crate::store::LoggedQso>, LogError> {
+    filter.validate()?;
+    let bookmark = resolve_bookmark(conn, filter)?;
+    let q = query::build(filter, bookmark);
+    let sql = format!(
+        "SELECT {} FROM qso WHERE {} {}",
+        store::QSO_COLUMNS,
+        q.where_sql,
+        query::order_by(super::filter::Sort::Chronological),
+    );
+    let mut stmt = conn.prepare(&sql)?;
+    let mut rows = stmt.query(params_from_iter(q.params.iter()))?;
     let mut out = Vec::new();
     while let Some(row) = rows.next()? {
         out.push(store::row_to_logged_qso(row)??);

--- a/rigflow-log/src/export/writer.rs
+++ b/rigflow-log/src/export/writer.rs
@@ -169,6 +169,17 @@ impl Exporter {
         crate::import::plan(&self.conn, text, window_secs)
     }
 
+    /// Like [`plan_import`](Self::plan_import), but for a confirmation download
+    /// (LoTW/eQSL/QRZ): applies the confirmations records carry and ignores
+    /// records that carry none, so a full-logbook fetch never adds new contacts.
+    pub fn plan_download(
+        &self,
+        text: &str,
+        window_secs: i64,
+    ) -> Result<crate::import::ImportPlan, LogError> {
+        crate::import::plan_download(&self.conn, text, window_secs)
+    }
+
     /// Test-only handle, used to prove SQLite itself refuses a write here.
     #[cfg(test)]
     pub(crate) fn conn_for_test(&self) -> &Connection {

--- a/rigflow-log/src/import.rs
+++ b/rigflow-log/src/import.rs
@@ -1,0 +1,219 @@
+//! ADIF file import: plan first, then commit.
+//!
+//! Import is two phases, and the split is the point:
+//!
+//! 1. [`plan`] — parse, normalize, validate, and dedupe against the existing log.
+//!    **Read-only**: it touches nothing, so it can run on the export worker's
+//!    read-only connection while the operator keeps logging. It answers "what
+//!    would this file do to my log?" — *1,483 records · 12 duplicates · 3
+//!    unusable* — before a single row is written.
+//! 2. [`crate::LogStore::commit_import`] — one transaction, one journal write, one
+//!    fsync, all-or-nothing.
+//!
+//! **Duplicates are skipped**, on the same ±30-minute call+band+mode rule the
+//! WSJT-X ingest path uses ([`crate::dedupe`]). That makes import *idempotent*:
+//! importing the same file twice adds nothing the second time, which is the
+//! property that lets an operator re-run an import without fear.
+//!
+//! **Bad records are skipped, not fatal.** A real twenty-year log exported from
+//! another program will contain some cruft; refusing a 20,000-QSO file over three
+//! junk rows would be hostile. They are counted and named in the plan so the
+//! operator can see exactly what was left behind.
+
+use std::collections::HashMap;
+
+use rusqlite::Connection;
+
+use crate::error::LogError;
+use crate::model::Qso;
+use crate::store::LoggedQso;
+use crate::{adif, dedupe};
+
+/// Why one record could not be imported.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ImportProblem {
+    /// 1-based position in the file, so the operator can find it.
+    pub record: usize,
+    /// The record's callsign, if it had one — the only thing that makes a bad
+    /// record identifiable to a human.
+    pub call: String,
+    pub reason: String,
+}
+
+impl std::fmt::Display for ImportProblem {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let call = if self.call.is_empty() {
+            "(no call)"
+        } else {
+            &self.call
+        };
+        write!(f, "record {} [{}]: {}", self.record, call, self.reason)
+    }
+}
+
+/// What an import *would* do. Produced without writing anything.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct ImportPlan {
+    /// Records found in the file.
+    pub total: usize,
+    /// Good, non-duplicate contacts, ready to commit.
+    pub importable: Vec<Qso>,
+    /// Records skipped because the log (or an earlier record in this same file)
+    /// already has them.
+    pub duplicates: usize,
+    /// Records that could not be made into a contact.
+    pub unusable: Vec<ImportProblem>,
+}
+
+impl ImportPlan {
+    /// One-line summary for the dialog.
+    pub fn summary(&self) -> String {
+        let mut s = format!(
+            "{} record{} · {} to import",
+            self.total,
+            if self.total == 1 { "" } else { "s" },
+            self.importable.len()
+        );
+        if self.duplicates > 0 {
+            s.push_str(&format!(" · {} duplicate", self.duplicates));
+            if self.duplicates != 1 {
+                s.push('s');
+            }
+            s.push_str(" (skipped)");
+        }
+        if !self.unusable.is_empty() {
+            s.push_str(&format!(" · {} unusable", self.unusable.len()));
+        }
+        s
+    }
+
+    /// Nothing to do — no good records at all.
+    pub fn is_empty(&self) -> bool {
+        self.importable.is_empty()
+    }
+}
+
+/// Validate a parsed record. `Err(reason)` = unusable.
+///
+/// The bar is deliberately low: only what the schema and any future matching
+/// genuinely require. A contact with no callsign identifies no one; one with no
+/// date/time cannot be matched against a QSL or a confirmation. Everything else
+/// (RST, grid, name…) is optional in ADIF and optional here.
+fn check(q: &Qso) -> Result<(), String> {
+    if q.call.trim().is_empty() {
+        return Err("no CALL".into());
+    }
+    let d = q.qso_date.trim();
+    if d.len() != 8 || !d.bytes().all(|b| b.is_ascii_digit()) {
+        return Err(format!("bad QSO_DATE {:?} (want YYYYMMDD)", q.qso_date));
+    }
+    let t = q.time_on.trim();
+    if !matches!(t.len(), 4 | 6) || !t.bytes().all(|b| b.is_ascii_digit()) {
+        return Err(format!("bad TIME_ON {:?} (want HHMM or HHMMSS)", q.time_on));
+    }
+    if q.mode.trim().is_empty() {
+        return Err("no MODE".into());
+    }
+    Ok(())
+}
+
+/// Existing contacts that duplicate `q`, read straight from the database.
+///
+/// Same natural key and window as the live dedupe path — one rule for WSJT-X
+/// ingest, manual entry, and import, so "already logged" means the same thing
+/// however a contact arrived.
+fn db_duplicates(conn: &Connection, q: &Qso, window_secs: i64) -> Result<Vec<LoggedQso>, LogError> {
+    let mut stmt = conn.prepare(
+        "SELECT id,call,qso_date,time_on,band,mode,submode,freq_hz,freq_rx_hz,band_rx,\
+         rst_sent,rst_rcvd,gridsquare,dxcc,extra \
+         FROM qso WHERE call = ?1 COLLATE NOCASE AND mode = ?2 AND band = ?3",
+    )?;
+    let rows = stmt.query_map(
+        rusqlite::params![q.call, q.mode, q.band],
+        crate::store::row_to_logged_qso,
+    )?;
+    let mut out = Vec::new();
+    for r in rows {
+        let lq = r??;
+        if dedupe::within_window(q, &lq.qso, window_secs) {
+            out.push(lq);
+        }
+    }
+    Ok(out)
+}
+
+/// Plan an import from ADIF `text`, against the log behind `conn`.
+///
+/// Read-only. Safe on a `SQLITE_OPEN_READ_ONLY` connection, which is how the
+/// client runs it (on the worker, off the UI thread).
+///
+/// A parse failure is fatal and returns `Err` — a file we cannot even tokenize is
+/// not an ADIF file, and guessing at it would be worse than refusing. Per-record
+/// problems are *not* fatal; they land in [`ImportPlan::unusable`].
+pub fn plan(conn: &Connection, text: &str, window_secs: i64) -> Result<ImportPlan, LogError> {
+    let records = adif::parse_adif(text)?;
+
+    let mut plan = ImportPlan {
+        total: records.len(),
+        ..Default::default()
+    };
+
+    // Within-file duplicates are checked against a natural-key index, NOT by
+    // scanning everything imported so far: that scan is O(n²), and on a 20k-record
+    // log it costs ~20 seconds of pure string comparison. Bucketing by
+    // (call, band, mode) — the same natural key the DB check uses — leaves only
+    // the handful of contacts with that same station on that same band and mode
+    // to compare timestamps against.
+    let mut seen: HashMap<(String, String, String), Vec<usize>> = HashMap::new();
+
+    for (i, rec) in records.iter().enumerate() {
+        let mut q = adif::record_to_qso(rec);
+        q.normalize();
+
+        if let Err(reason) = check(&q) {
+            plan.unusable.push(ImportProblem {
+                record: i + 1,
+                call: q.call.trim().to_string(),
+                reason,
+            });
+            continue;
+        }
+
+        // Already in the log?
+        if !db_duplicates(conn, &q, window_secs)?.is_empty() {
+            plan.duplicates += 1;
+            continue;
+        }
+
+        // …or already earlier in THIS file? A log exported from another program
+        // can carry its own internal duplicates, and the DB check cannot see the
+        // records we are about to add in the same batch.
+        let key = natural_key(&q);
+        let dup = seen.get(&key).is_some_and(|idxs| {
+            idxs.iter()
+                .any(|&j| dedupe::within_window(&q, &plan.importable[j], window_secs))
+        });
+        if dup {
+            plan.duplicates += 1;
+            continue;
+        }
+
+        seen.entry(key).or_default().push(plan.importable.len());
+        plan.importable.push(q);
+    }
+
+    Ok(plan)
+}
+
+/// The dedupe natural key: call + band + mode, normalized the way the SQL check
+/// compares them (`call` case-insensitively).
+fn natural_key(q: &Qso) -> (String, String, String) {
+    (
+        q.call.trim().to_ascii_uppercase(),
+        q.band.trim().to_string(),
+        q.mode.trim().to_string(),
+    )
+}
+
+#[cfg(test)]
+mod tests;

--- a/rigflow-log/src/import.rs
+++ b/rigflow-log/src/import.rs
@@ -51,6 +51,20 @@ impl std::fmt::Display for ImportProblem {
     }
 }
 
+/// A QSL confirmation to record against an already-logged QSO. Produced by
+/// [`plan`] when a record carries `QSL_RCVD = Y` and matches a contact already
+/// in the log — a LoTW/eQSL report *confirms* existing QSOs, it does not add new
+/// ones. Committed into the `qso_service` table, keyed by `(qso_id, service)`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Confirmation {
+    /// The matched `qso.id` this confirmation attaches to.
+    pub qso_id: i64,
+    /// The confirming service, lower-case: `lotw`, `eqsl`, or generic `qsl`.
+    pub service: String,
+    /// The service's confirmation date if the record carried one (`QSLRDATE`).
+    pub confirmed_at: Option<String>,
+}
+
 /// What an import *would* do. Produced without writing anything.
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct ImportPlan {
@@ -61,6 +75,15 @@ pub struct ImportPlan {
     /// Records skipped because the log (or an earlier record in this same file)
     /// already has them.
     pub duplicates: usize,
+    /// QSL confirmations matched to existing QSOs, ready to record. These do
+    /// **not** insert contacts — they mark ones the log already has as confirmed.
+    pub confirmations: Vec<Confirmation>,
+    /// Confirmation records whose QSO is already marked confirmed for that
+    /// service — skipped, so re-importing a report is idempotent.
+    pub already_confirmed: usize,
+    /// Confirmation records that matched no contact in the log. Surfaced, not
+    /// inserted: a QSL for a QSO we never logged is an anomaly worth showing.
+    pub unmatched_confirmations: usize,
     /// Records that could not be made into a contact.
     pub unusable: Vec<ImportProblem>,
 }
@@ -74,6 +97,20 @@ impl ImportPlan {
             if self.total == 1 { "" } else { "s" },
             self.importable.len()
         );
+        if !self.confirmations.is_empty() {
+            s.push_str(&format!(
+                " · {} confirmation{}",
+                self.confirmations.len(),
+                if self.confirmations.len() == 1 {
+                    ""
+                } else {
+                    "s"
+                }
+            ));
+        }
+        if self.already_confirmed > 0 {
+            s.push_str(&format!(" · {} already confirmed", self.already_confirmed));
+        }
         if self.duplicates > 0 {
             s.push_str(&format!(" · {} duplicate", self.duplicates));
             if self.duplicates != 1 {
@@ -81,15 +118,26 @@ impl ImportPlan {
             }
             s.push_str(" (skipped)");
         }
+        if self.unmatched_confirmations > 0 {
+            s.push_str(&format!(
+                " · {} confirmation{} unmatched",
+                self.unmatched_confirmations,
+                if self.unmatched_confirmations == 1 {
+                    ""
+                } else {
+                    "s"
+                }
+            ));
+        }
         if !self.unusable.is_empty() {
             s.push_str(&format!(" · {} unusable", self.unusable.len()));
         }
         s
     }
 
-    /// Nothing to do — no good records at all.
+    /// Nothing to do — no contacts to add and no confirmations to record.
     pub fn is_empty(&self) -> bool {
-        self.importable.is_empty()
+        self.importable.is_empty() && self.confirmations.is_empty()
     }
 }
 
@@ -179,8 +227,32 @@ pub fn plan(conn: &Connection, text: &str, window_secs: i64) -> Result<ImportPla
             continue;
         }
 
+        let existing = db_duplicates(conn, &q, window_secs)?;
+
+        // A record carrying `QSL_RCVD = Y` is a *confirmation* of an existing
+        // QSO (a LoTW/eQSL report), not a new contact. Match it and record the
+        // confirmation; never insert. This is the whole reason a confirmation
+        // report differs from a log import.
+        if let Some((service, confirmed_at)) = confirmation_in(&q) {
+            match existing.first() {
+                Some(m) => {
+                    if service_recorded(conn, m.id, &service)? {
+                        plan.already_confirmed += 1; // idempotent re-import
+                    } else {
+                        plan.confirmations.push(Confirmation {
+                            qso_id: m.id,
+                            service,
+                            confirmed_at,
+                        });
+                    }
+                }
+                None => plan.unmatched_confirmations += 1,
+            }
+            continue;
+        }
+
         // Already in the log?
-        if !db_duplicates(conn, &q, window_secs)?.is_empty() {
+        if !existing.is_empty() {
             plan.duplicates += 1;
             continue;
         }
@@ -203,6 +275,41 @@ pub fn plan(conn: &Connection, text: &str, window_secs: i64) -> Result<ImportPla
     }
 
     Ok(plan)
+}
+
+/// If `q` carries QSL confirmation data, the `(service, confirmed_at)` it
+/// implies. Keyed on the ADIF-standard `QSL_RCVD = Y` (the only value that means
+/// *confirmed*; `N`/`R`/`I` do not). The service is inferred from which program's
+/// `APP_*` fields ride along — LoTW and eQSL both stamp their own — falling back
+/// to a generic `qsl`. All fields live in [`Qso::extra`] after `record_to_qso`.
+fn confirmation_in(q: &Qso) -> Option<(String, Option<String>)> {
+    let confirmed = q
+        .extra
+        .get("QSL_RCVD")
+        .is_some_and(|v| v.trim().eq_ignore_ascii_case("Y"));
+    if !confirmed {
+        return None;
+    }
+    let service = if q.extra.keys().any(|k| k.starts_with("APP_LOTW")) {
+        "lotw"
+    } else if q.extra.keys().any(|k| k.starts_with("APP_EQSL")) {
+        "eqsl"
+    } else {
+        "qsl"
+    };
+    let confirmed_at = q.extra.get("QSLRDATE").map(|s| s.trim().to_string());
+    Some((service.to_string(), confirmed_at))
+}
+
+/// Whether QSO `qso_id` already has a confirmation recorded for `service`, so a
+/// re-imported report skips it rather than churning the row.
+fn service_recorded(conn: &Connection, qso_id: i64, service: &str) -> Result<bool, LogError> {
+    let n: i64 = conn.query_row(
+        "SELECT COUNT(*) FROM qso_service WHERE qso_id = ?1 AND service = ?2",
+        rusqlite::params![qso_id, service],
+        |r| r.get(0),
+    )?;
+    Ok(n > 0)
 }
 
 /// The dedupe natural key: call + band + mode, normalized the way the SQL check

--- a/rigflow-log/src/import.rs
+++ b/rigflow-log/src/import.rs
@@ -229,24 +229,28 @@ pub fn plan(conn: &Connection, text: &str, window_secs: i64) -> Result<ImportPla
 
         let existing = db_duplicates(conn, &q, window_secs)?;
 
-        // A record carrying `QSL_RCVD = Y` is a *confirmation* of an existing
-        // QSO (a LoTW/eQSL report), not a new contact. Match it and record the
-        // confirmation; never insert. This is the whole reason a confirmation
-        // report differs from a log import.
-        if let Some((service, confirmed_at)) = confirmation_in(&q) {
+        // A record carrying a `QSL_RCVD = Y` (or `LOTW_QSL_RCVD` / `EQSL_QSL_RCVD`)
+        // is a *confirmation* of an existing QSO — a LoTW/eQSL report, or an
+        // export of ours round-tripping — not a new contact. Match it and record
+        // each service's confirmation; never insert. One record can confirm more
+        // than one service (LoTW *and* eQSL), so this is a list.
+        let confs = confirmations_in(&q);
+        if !confs.is_empty() {
             match existing.first() {
                 Some(m) => {
-                    if service_recorded(conn, m.id, &service)? {
-                        plan.already_confirmed += 1; // idempotent re-import
-                    } else {
-                        plan.confirmations.push(Confirmation {
-                            qso_id: m.id,
-                            service,
-                            confirmed_at,
-                        });
+                    for (service, confirmed_at) in confs {
+                        if service_recorded(conn, m.id, &service)? {
+                            plan.already_confirmed += 1; // idempotent re-import
+                        } else {
+                            plan.confirmations.push(Confirmation {
+                                qso_id: m.id,
+                                service,
+                                confirmed_at,
+                            });
+                        }
                     }
                 }
-                None => plan.unmatched_confirmations += 1,
+                None => plan.unmatched_confirmations += confs.len(),
             }
             continue;
         }
@@ -277,28 +281,51 @@ pub fn plan(conn: &Connection, text: &str, window_secs: i64) -> Result<ImportPla
     Ok(plan)
 }
 
-/// If `q` carries QSL confirmation data, the `(service, confirmed_at)` it
-/// implies. Keyed on the ADIF-standard `QSL_RCVD = Y` (the only value that means
-/// *confirmed*; `N`/`R`/`I` do not). The service is inferred from which program's
-/// `APP_*` fields ride along — LoTW and eQSL both stamp their own — falling back
-/// to a generic `qsl`. All fields live in [`Qso::extra`] after `record_to_qso`.
-fn confirmation_in(q: &Qso) -> Option<(String, Option<String>)> {
-    let confirmed = q
-        .extra
-        .get("QSL_RCVD")
-        .is_some_and(|v| v.trim().eq_ignore_ascii_case("Y"));
-    if !confirmed {
-        return None;
-    }
-    let service = if q.extra.keys().any(|k| k.starts_with("APP_LOTW")) {
-        "lotw"
-    } else if q.extra.keys().any(|k| k.starts_with("APP_EQSL")) {
-        "eqsl"
-    } else {
-        "qsl"
+/// Every QSL confirmation `q` carries, as `(service, confirmed_at)` pairs. A
+/// single record can confirm more than one service (LoTW *and* eQSL), so this is
+/// a list. Recognizes, in priority order per service:
+///
+/// - `LOTW_QSL_RCVD = Y` → `lotw` (date from `LOTW_QSLRDATE`). This is what our
+///   own export writes, and what most loggers use, so it round-trips.
+/// - `EQSL_QSL_RCVD = Y` → `eqsl` (date from `EQSL_QSLRDATE`).
+/// - `QSL_RCVD = Y` → the generic/paper card, unless the record carries a LoTW or
+///   eQSL `APP_*` marker (a LoTW report stamps `APP_LoTW_*` alongside a bare
+///   `QSL_RCVD`), in which case it is attributed to that service. Date from
+///   `QSLRDATE`. Skipped if that service was already captured above, so a file
+///   with both `LOTW_QSL_RCVD` and a LoTW-stamped `QSL_RCVD` isn't double-counted.
+///
+/// `Y` is the only value that means *confirmed*; `N`/`R`/`I` do not. All fields
+/// live in [`Qso::extra`] after [`adif::record_to_qso`].
+fn confirmations_in(q: &Qso) -> Vec<(String, Option<String>)> {
+    let is_y = |k: &str| {
+        q.extra
+            .get(k)
+            .is_some_and(|v| v.trim().eq_ignore_ascii_case("Y"))
     };
-    let confirmed_at = q.extra.get("QSLRDATE").map(|s| s.trim().to_string());
-    Some((service.to_string(), confirmed_at))
+    let date = |k: &str| q.extra.get(k).map(|s| s.trim().to_string());
+
+    let mut out: Vec<(String, Option<String>)> = Vec::new();
+    if is_y("LOTW_QSL_RCVD") {
+        out.push(("lotw".into(), date("LOTW_QSLRDATE")));
+    }
+    if is_y("EQSL_QSL_RCVD") {
+        out.push(("eqsl".into(), date("EQSL_QSLRDATE")));
+    }
+    if is_y("QSL_RCVD") {
+        // Attribute a bare QSL_RCVD to the service its APP_* marker names (LoTW
+        // reports do this), else the generic paper card.
+        let service = if q.extra.keys().any(|k| k.starts_with("APP_LOTW")) {
+            "lotw"
+        } else if q.extra.keys().any(|k| k.starts_with("APP_EQSL")) {
+            "eqsl"
+        } else {
+            "qsl"
+        };
+        if !out.iter().any(|(s, _)| s == service) {
+            out.push((service.to_string(), date("QSLRDATE")));
+        }
+    }
+    out
 }
 
 /// Whether QSO `qso_id` already has a confirmation recorded for `service`, so a

--- a/rigflow-log/src/import.rs
+++ b/rigflow-log/src/import.rs
@@ -20,7 +20,7 @@
 //! junk rows would be hostile. They are counted and named in the plan so the
 //! operator can see exactly what was left behind.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use rusqlite::Connection;
 
@@ -75,13 +75,15 @@ pub struct ImportPlan {
     /// Records skipped because the log (or an earlier record in this same file)
     /// already has them.
     pub duplicates: usize,
-    /// QSL confirmations matched to existing QSOs, ready to record. These do
-    /// **not** insert contacts — they mark ones the log already has as confirmed.
+    /// QSL confirmations matched to existing QSOs, ready to record — one per
+    /// distinct (QSO, service). These do **not** insert contacts; they mark ones
+    /// the log already has as confirmed.
     pub confirmations: Vec<Confirmation>,
-    /// Confirmation records whose QSO is already marked confirmed for that
-    /// service — skipped, so re-importing a report is idempotent.
+    /// Distinct QSOs already marked confirmed for a service — skipped, so
+    /// re-importing a report is idempotent. Counted per QSO, not per fetched
+    /// record (a service may hold several confirmed records for one contact).
     pub already_confirmed: usize,
-    /// Confirmation records that matched no contact in the log. Surfaced, not
+    /// Distinct confirmed QSOs that matched no contact in the log. Surfaced, not
     /// inserted: a QSL for a QSO we never logged is an anomaly worth showing.
     pub unmatched_confirmations: usize,
     /// Records that could not be made into a contact.
@@ -240,6 +242,14 @@ fn plan_inner(
     // to compare timestamps against.
     let mut seen: HashMap<(String, String, String), Vec<usize>> = HashMap::new();
 
+    // Confirmations are counted per distinct QSO, not per fetched record: a
+    // service (QRZ especially) can hold near-duplicate confirmed records that all
+    // match one logged contact, and the operator sees one badge, so the tally
+    // must agree. Matched confirmations dedupe by (qso_id, service); unmatched
+    // ones — no qso_id — by (call, band, mode, service).
+    let mut seen_confirmed: HashSet<(i64, String)> = HashSet::new();
+    let mut seen_unmatched: HashSet<(String, String, String, String)> = HashSet::new();
+
     for (i, rec) in records.iter().enumerate() {
         let mut q = adif::record_to_qso(rec);
         q.normalize();
@@ -265,6 +275,11 @@ fn plan_inner(
             match existing.first() {
                 Some(m) => {
                     for (service, confirmed_at) in confs {
+                        // One tally per (QSO, service), however many fetch records
+                        // matched it.
+                        if !seen_confirmed.insert((m.id, service.clone())) {
+                            continue;
+                        }
                         if service_recorded(conn, m.id, &service)? {
                             plan.already_confirmed += 1; // idempotent re-import
                         } else {
@@ -276,7 +291,19 @@ fn plan_inner(
                         }
                     }
                 }
-                None => plan.unmatched_confirmations += confs.len(),
+                None => {
+                    for (service, _) in confs {
+                        let key = (
+                            q.call.trim().to_ascii_uppercase(),
+                            q.band.clone(),
+                            q.mode.clone(),
+                            service,
+                        );
+                        if seen_unmatched.insert(key) {
+                            plan.unmatched_confirmations += 1;
+                        }
+                    }
+                }
             }
             continue;
         }

--- a/rigflow-log/src/import.rs
+++ b/rigflow-log/src/import.rs
@@ -199,6 +199,32 @@ fn db_duplicates(conn: &Connection, q: &Qso, window_secs: i64) -> Result<Vec<Log
 /// not an ADIF file, and guessing at it would be worse than refusing. Per-record
 /// problems are *not* fatal; they land in [`ImportPlan::unusable`].
 pub fn plan(conn: &Connection, text: &str, window_secs: i64) -> Result<ImportPlan, LogError> {
+    plan_inner(conn, text, window_secs, false)
+}
+
+/// Plan applying a **confirmation download** (LoTW/eQSL/QRZ): apply the QSL
+/// confirmations each record carries, and **ignore records that carry none**.
+///
+/// This differs from [`plan`] in the last part: a download like QRZ's FETCH
+/// returns your *entire* logbook, most of it unconfirmed. A file import would add
+/// those unconfirmed strangers as new contacts; a confirmation download must
+/// only ever update confirmation state, never insert. Which records are
+/// confirmations is decided per-record by [`confirmations_in`] (e.g. QRZ's
+/// `APP_QRZLOG_STATUS = C`).
+pub fn plan_download(
+    conn: &Connection,
+    text: &str,
+    window_secs: i64,
+) -> Result<ImportPlan, LogError> {
+    plan_inner(conn, text, window_secs, true)
+}
+
+fn plan_inner(
+    conn: &Connection,
+    text: &str,
+    window_secs: i64,
+    confirmations_only: bool,
+) -> Result<ImportPlan, LogError> {
     let records = adif::parse_adif(text)?;
 
     let mut plan = ImportPlan {
@@ -229,11 +255,11 @@ pub fn plan(conn: &Connection, text: &str, window_secs: i64) -> Result<ImportPla
 
         let existing = db_duplicates(conn, &q, window_secs)?;
 
-        // A record carrying a `QSL_RCVD = Y` (or `LOTW_QSL_RCVD` / `EQSL_QSL_RCVD`)
-        // is a *confirmation* of an existing QSO — a LoTW/eQSL report, or an
-        // export of ours round-tripping — not a new contact. Match it and record
-        // each service's confirmation; never insert. One record can confirm more
-        // than one service (LoTW *and* eQSL), so this is a list.
+        // A record carrying a `QSL_RCVD = Y` (or `LOTW_QSL_RCVD` / `EQSL_QSL_RCVD`
+        // / `APP_QRZLOG_STATUS = C` …) is a *confirmation* of an existing QSO — a
+        // service report, or an export of ours round-tripping — not a new contact.
+        // Match it and record each service's confirmation; never insert. One
+        // record can confirm more than one service, so this is a list.
         let confs = confirmations_in(&q);
         if !confs.is_empty() {
             match existing.first() {
@@ -252,6 +278,13 @@ pub fn plan(conn: &Connection, text: &str, window_secs: i64) -> Result<ImportPla
                 }
                 None => plan.unmatched_confirmations += confs.len(),
             }
+            continue;
+        }
+
+        // A confirmation download only ever updates confirmation state. A record
+        // that confirms nothing (e.g. an unconfirmed QSO in QRZ's full FETCH) is
+        // ignored — never added as a new contact the way a file import would.
+        if confirmations_only {
             continue;
         }
 
@@ -293,6 +326,9 @@ pub fn plan(conn: &Connection, text: &str, window_secs: i64) -> Result<ImportPla
 ///   tag. Any of those means confirmed by eQSL. Note eQSL records carry
 ///   `QSL_SENT = Y`, not `QSL_RCVD`, so the bare-`QSL_RCVD` rule below never
 ///   catches them.
+/// - **QRZ** — `APP_QRZLOG_STATUS = C` (date from `APP_QRZLOG_QSLDATE`). QRZ's
+///   FETCH puts this on each record; its `qsl_rcvd`/`lotw_qsl_rcvd`/`eqsl_qsl_rcvd`
+///   are all `N`, so this is the only QRZ signal.
 /// - **generic** — a bare `QSL_RCVD = Y` is the paper card, unless a LoTW/eQSL
 ///   `APP_*` marker attributes it to that service (a LoTW report stamps
 ///   `APP_LoTW_*` beside `QSL_RCVD`). Skipped if that service was already found.
@@ -327,6 +363,15 @@ fn confirmations_in(q: &Qso) -> Vec<(String, Option<String>)> {
     }
     if is_y("EQSL_QSL_RCVD") || has("EQSL_AG") || has_app("APP_EQSL") {
         out.push(("eqsl".into(), dated("EQSL_QSLRDATE")));
+    }
+    // QRZ marks its own confirmation with APP_QRZLOG_STATUS = C (Confirmed);
+    // date in APP_QRZLOG_QSLDATE. Y/N are its other statuses (not confirmed), and
+    // QRZ records carry qsl_rcvd=N etc., so nothing else here would catch it.
+    if q.extra
+        .get("APP_QRZLOG_STATUS")
+        .is_some_and(|v| v.trim().eq_ignore_ascii_case("C"))
+    {
+        out.push(("qrz".into(), dated("APP_QRZLOG_QSLDATE")));
     }
     if is_y("QSL_RCVD") {
         let service = if has_app("APP_LOTW") {

--- a/rigflow-log/src/import.rs
+++ b/rigflow-log/src/import.rs
@@ -283,16 +283,23 @@ pub fn plan(conn: &Connection, text: &str, window_secs: i64) -> Result<ImportPla
 
 /// Every QSL confirmation `q` carries, as `(service, confirmed_at)` pairs. A
 /// single record can confirm more than one service (LoTW *and* eQSL), so this is
-/// a list. Recognizes, in priority order per service:
+/// a list. Recognizes, per service:
 ///
-/// - `LOTW_QSL_RCVD = Y` → `lotw` (date from `LOTW_QSLRDATE`). This is what our
-///   own export writes, and what most loggers use, so it round-trips.
-/// - `EQSL_QSL_RCVD = Y` → `eqsl` (date from `EQSL_QSLRDATE`).
-/// - `QSL_RCVD = Y` → the generic/paper card, unless the record carries a LoTW or
-///   eQSL `APP_*` marker (a LoTW report stamps `APP_LoTW_*` alongside a bare
-///   `QSL_RCVD`), in which case it is attributed to that service. Date from
-///   `QSLRDATE`. Skipped if that service was already captured above, so a file
-///   with both `LOTW_QSL_RCVD` and a LoTW-stamped `QSL_RCVD` isn't double-counted.
+/// - **LoTW** — `LOTW_QSL_RCVD = Y` (date from `LOTW_QSLRDATE`); what our own
+///   export writes and what most loggers use, so it round-trips.
+/// - **eQSL** — an eQSL *inbox* record IS a received confirmation. eQSL marks it
+///   with `EQSL_QSL_RCVD = Y` + `EQSL_QSLRDATE` only when it stored a date;
+///   otherwise the only sign is `EQSL_AG` (present ⟺ confirmed) or an `APP_EQSL_*`
+///   tag. Any of those means confirmed by eQSL. Note eQSL records carry
+///   `QSL_SENT = Y`, not `QSL_RCVD`, so the bare-`QSL_RCVD` rule below never
+///   catches them.
+/// - **generic** — a bare `QSL_RCVD = Y` is the paper card, unless a LoTW/eQSL
+///   `APP_*` marker attributes it to that service (a LoTW report stamps
+///   `APP_LoTW_*` beside `QSL_RCVD`). Skipped if that service was already found.
+///
+/// `confirmed_at` falls back to the QSO's own date when the record carries no QSL
+/// date, so a detected confirmation always gets a **non-null** `confirmed_at` —
+/// the signal the contact-view badge shows (a null date would be invisible).
 ///
 /// `Y` is the only value that means *confirmed*; `N`/`R`/`I` do not. All fields
 /// live in [`Qso::extra`] after [`adif::record_to_qso`].
@@ -302,37 +309,49 @@ fn confirmations_in(q: &Qso) -> Vec<(String, Option<String>)> {
             .get(k)
             .is_some_and(|v| v.trim().eq_ignore_ascii_case("Y"))
     };
-    let date = |k: &str| q.extra.get(k).map(|s| s.trim().to_string());
+    let has = |k: &str| q.extra.contains_key(k);
+    let has_app = |prefix: &str| q.extra.keys().any(|k| k.starts_with(prefix));
+    // A stored date, else the QSO's own date, so `confirmed_at` is never null for
+    // a real confirmation.
+    let dated = |k: &str| {
+        q.extra
+            .get(k)
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty())
+            .or_else(|| Some(q.qso_date.trim().to_string()).filter(|s| !s.is_empty()))
+    };
 
     let mut out: Vec<(String, Option<String>)> = Vec::new();
     if is_y("LOTW_QSL_RCVD") {
-        out.push(("lotw".into(), date("LOTW_QSLRDATE")));
+        out.push(("lotw".into(), dated("LOTW_QSLRDATE")));
     }
-    if is_y("EQSL_QSL_RCVD") {
-        out.push(("eqsl".into(), date("EQSL_QSLRDATE")));
+    if is_y("EQSL_QSL_RCVD") || has("EQSL_AG") || has_app("APP_EQSL") {
+        out.push(("eqsl".into(), dated("EQSL_QSLRDATE")));
     }
     if is_y("QSL_RCVD") {
-        // Attribute a bare QSL_RCVD to the service its APP_* marker names (LoTW
-        // reports do this), else the generic paper card.
-        let service = if q.extra.keys().any(|k| k.starts_with("APP_LOTW")) {
+        let service = if has_app("APP_LOTW") {
             "lotw"
-        } else if q.extra.keys().any(|k| k.starts_with("APP_EQSL")) {
+        } else if has_app("APP_EQSL") {
             "eqsl"
         } else {
             "qsl"
         };
         if !out.iter().any(|(s, _)| s == service) {
-            out.push((service.to_string(), date("QSLRDATE")));
+            out.push((service.to_string(), dated("QSLRDATE")));
         }
     }
     out
 }
 
-/// Whether QSO `qso_id` already has a confirmation recorded for `service`, so a
-/// re-imported report skips it rather than churning the row.
+/// Whether QSO `qso_id` is already *confirmed* by `service`, so a re-imported
+/// report skips it. Keyed on `confirmed_at` being set, NOT mere row existence: a
+/// row can exist from an upload (`uploaded_at` set, `confirmed_at` null), and a
+/// later confirmation download must still fill in `confirmed_at` rather than be
+/// skipped as "already confirmed".
 fn service_recorded(conn: &Connection, qso_id: i64, service: &str) -> Result<bool, LogError> {
     let n: i64 = conn.query_row(
-        "SELECT COUNT(*) FROM qso_service WHERE qso_id = ?1 AND service = ?2",
+        "SELECT COUNT(*) FROM qso_service \
+         WHERE qso_id = ?1 AND service = ?2 AND confirmed_at IS NOT NULL",
         rusqlite::params![qso_id, service],
         |r| r.get(0),
     )?;

--- a/rigflow-log/src/import/tests.rs
+++ b/rigflow-log/src/import/tests.rs
@@ -1,0 +1,544 @@
+//! Import tests. On-disk databases throughout — the plan runs on a read-only
+//! connection in the client, and that is only real against a file.
+
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicU32, Ordering};
+
+use super::*;
+use crate::dedupe::DEFAULT_WINDOW_SECS;
+use crate::export::{ExportFilter, ExportOptions, Exporter};
+use crate::model::Station;
+use crate::store::LogStore;
+
+// ---------------------------------------------------------------- fixtures --
+
+static SEQ: AtomicU32 = AtomicU32::new(0);
+
+struct TmpDir(PathBuf);
+
+impl TmpDir {
+    fn new() -> TmpDir {
+        let n = SEQ.fetch_add(1, Ordering::SeqCst);
+        let dir =
+            std::env::temp_dir().join(format!("rigflow-log-import-{}-{}", std::process::id(), n));
+        std::fs::create_dir_all(&dir).unwrap();
+        TmpDir(dir)
+    }
+    fn db(&self) -> PathBuf {
+        self.0.join("rigflow_log.db")
+    }
+    fn adi(&self) -> PathBuf {
+        self.0.join("rigflow_log.adi")
+    }
+    fn out(&self) -> PathBuf {
+        self.0.join("out.adi")
+    }
+}
+
+impl Drop for TmpDir {
+    fn drop(&mut self) {
+        std::fs::remove_dir_all(&self.0).ok();
+    }
+}
+
+fn station() -> Station {
+    Station {
+        station_call: "N0CALL".into(),
+        gridsquare: Some("EM12".into()),
+        ..Default::default()
+    }
+}
+
+/// A minimal well-formed ADIF document with the given record bodies.
+fn adif_doc(records: &[&str]) -> String {
+    let mut s = String::from("<ADIF_VER:5>3.1.6 <EOH>\n");
+    for r in records {
+        s.push_str(r);
+        s.push_str("<EOR>\n");
+    }
+    s
+}
+
+fn rec(call: &str, date: &str, time: &str, band: &str, mode: &str) -> String {
+    format!(
+        "<CALL:{}>{} <QSO_DATE:8>{} <TIME_ON:{}>{} <BAND:{}>{} <MODE:{}>{} ",
+        call.len(),
+        call,
+        date,
+        time.len(),
+        time,
+        band.len(),
+        band,
+        mode.len(),
+        mode
+    )
+}
+
+fn plan_of(dir: &TmpDir, text: &str) -> ImportPlan {
+    let store = LogStore::open(dir.db(), dir.adi()).unwrap();
+    let p = plan(store.conn(), text, DEFAULT_WINDOW_SECS).unwrap();
+    p
+}
+
+// -------------------------------------------------------------------- plan --
+
+#[test]
+fn plan_reads_records_without_writing_anything() {
+    let dir = TmpDir::new();
+    let doc = adif_doc(&[
+        &rec("W1AW", "20260701", "140000", "20m", "SSB"),
+        &rec("K5ZD", "20260702", "150000", "40m", "CW"),
+    ]);
+
+    let plan = plan_of(&dir, &doc);
+    assert_eq!(plan.total, 2);
+    assert_eq!(plan.importable.len(), 2);
+    assert_eq!(plan.duplicates, 0);
+    assert!(plan.unusable.is_empty());
+
+    // Planning is read-only: the log is still empty.
+    let store = LogStore::open(dir.db(), dir.adi()).unwrap();
+    let n: i64 = store
+        .conn()
+        .query_row("SELECT COUNT(*) FROM qso", [], |r| r.get(0))
+        .unwrap();
+    assert_eq!(n, 0, "plan must not write");
+}
+
+#[test]
+fn plan_normalizes_on_the_way_in() {
+    let dir = TmpDir::new();
+    // USB is a sideband, not an ADIF mode; FT4 is MFSK/FT4. Both must be
+    // canonicalized at import or they'd never match a filter or a dupe check.
+    let doc = adif_doc(&[
+        &rec("W1AW", "20260701", "140000", "20m", "USB"),
+        &rec("EA1AAA", "20260701", "141000", "20m", "FT4"),
+    ]);
+    let plan = plan_of(&dir, &doc);
+    assert_eq!(plan.importable[0].mode, "SSB");
+    assert_eq!(plan.importable[1].mode, "MFSK");
+    assert_eq!(plan.importable[1].submode.as_deref(), Some("FT4"));
+}
+
+#[test]
+fn plan_derives_band_from_freq_when_the_file_omits_it() {
+    let dir = TmpDir::new();
+    let doc = adif_doc(&[
+        "<CALL:4>W1AW <QSO_DATE:8>20260701 <TIME_ON:6>140000 <MODE:3>SSB <FREQ:9>14.207000 ",
+    ]);
+    let plan = plan_of(&dir, &doc);
+    assert_eq!(plan.importable.len(), 1);
+    assert_eq!(plan.importable[0].band, "20m");
+    assert_eq!(plan.importable[0].freq_hz, Some(14_207_000));
+}
+
+#[test]
+fn plan_skips_bad_records_and_names_them() {
+    // A twenty-year log from another program will have cruft. Import the good
+    // ones; do not refuse the file.
+    let dir = TmpDir::new();
+    let doc = adif_doc(&[
+        &rec("W1AW", "20260701", "140000", "20m", "SSB"), // good
+        "<QSO_DATE:8>20260701 <TIME_ON:6>141000 <BAND:3>20m <MODE:3>SSB ", // no CALL
+        &rec("K5ZD", "notadate", "150000", "40m", "CW"),  // bad date
+        &rec("VK3ABC", "20260702", "99", "15m", "SSB"),   // bad time
+        "<CALL:5>JA1XY <QSO_DATE:8>20260703 <TIME_ON:6>160000 <BAND:3>10m ", // no MODE
+        &rec("G0ABC", "20260704", "170000", "80m", "CW"), // good
+    ]);
+
+    let plan = plan_of(&dir, &doc);
+    assert_eq!(plan.total, 6);
+    assert_eq!(plan.importable.len(), 2, "the two good ones");
+    assert_eq!(plan.unusable.len(), 4);
+
+    // Problems are identifiable: position in the file, and the call if it had one.
+    assert_eq!(plan.unusable[0].record, 2);
+    assert_eq!(plan.unusable[0].call, "");
+    assert!(plan.unusable[0].reason.contains("CALL"));
+    assert_eq!(plan.unusable[1].call, "K5ZD");
+    assert!(plan.unusable[1].reason.contains("QSO_DATE"));
+    assert!(plan.unusable[2].reason.contains("TIME_ON"));
+    assert!(plan.unusable[3].reason.contains("MODE"));
+}
+
+#[test]
+fn plan_skips_contacts_already_in_the_log() {
+    let dir = TmpDir::new();
+    let mut store = LogStore::open(dir.db(), dir.adi()).unwrap();
+    let mut existing = crate::Qso {
+        call: "W1AW".into(),
+        qso_date: "20260701".into(),
+        time_on: "140000".into(),
+        band: "20m".into(),
+        mode: "SSB".into(),
+        ..Default::default()
+    };
+    existing.normalize();
+    store.insert(&existing, &station()).unwrap();
+    drop(store);
+
+    let doc = adif_doc(&[
+        &rec("W1AW", "20260701", "140500", "20m", "SSB"), // within ±30min → dupe
+        &rec("W1AW", "20260701", "190000", "20m", "SSB"), // hours later → NOT a dupe
+        &rec("K5ZD", "20260702", "150000", "40m", "CW"),  // new
+    ]);
+
+    let plan = plan_of(&dir, &doc);
+    assert_eq!(plan.duplicates, 1);
+    assert_eq!(plan.importable.len(), 2);
+}
+
+#[test]
+fn plan_catches_duplicates_within_the_file_itself() {
+    // Another program's export can carry its own internal duplicates, and the DB
+    // check cannot see rows we are about to add in the same batch.
+    let dir = TmpDir::new();
+    let doc = adif_doc(&[
+        &rec("W1AW", "20260701", "140000", "20m", "SSB"),
+        &rec("W1AW", "20260701", "140200", "20m", "SSB"), // same contact, again
+        &rec("W1AW", "20260701", "140000", "40m", "SSB"), // different band → keep
+    ]);
+    let plan = plan_of(&dir, &doc);
+    assert_eq!(plan.total, 3);
+    assert_eq!(plan.duplicates, 1);
+    assert_eq!(plan.importable.len(), 2);
+}
+
+#[test]
+fn a_file_that_is_not_adif_is_refused_outright() {
+    // Per-record problems are survivable; a file we cannot tokenize is not.
+    let dir = TmpDir::new();
+    let store = LogStore::open(dir.db(), dir.adi()).unwrap();
+    let err = plan(store.conn(), "<CALL:99>W1AW <EOR>", DEFAULT_WINDOW_SECS);
+    assert!(err.is_err(), "a truncated length must fail the whole parse");
+}
+
+#[test]
+fn plan_of_an_empty_file_is_empty_not_an_error() {
+    let dir = TmpDir::new();
+    let plan = plan_of(&dir, "<ADIF_VER:5>3.1.6 <EOH>\n");
+    assert_eq!(plan.total, 0);
+    assert!(plan.is_empty());
+}
+
+#[test]
+fn planning_works_on_a_read_only_connection() {
+    // This is the path the CLIENT actually uses: the plan runs on the export
+    // worker's read-only connection, off the UI thread. If it needed write access
+    // it would fail only in production, never in the tests above (which plan on
+    // the read-write store's connection).
+    let dir = TmpDir::new();
+    let mut store = LogStore::open(dir.db(), dir.adi()).unwrap();
+    let mut existing = crate::Qso {
+        call: "W1AW".into(),
+        qso_date: "20260701".into(),
+        time_on: "140000".into(),
+        band: "20m".into(),
+        mode: "SSB".into(),
+        ..Default::default()
+    };
+    existing.normalize();
+    store.insert(&existing, &station()).unwrap();
+    drop(store);
+
+    let doc = adif_doc(&[
+        &rec("W1AW", "20260701", "140500", "20m", "SSB"), // dupe of the above
+        &rec("K5ZD", "20260702", "150000", "40m", "CW"),  // new
+        &rec("", "20260703", "160000", "20m", "SSB"),     // unusable
+    ]);
+
+    let ex = Exporter::open(dir.db()).unwrap();
+    let plan = ex.plan_import(&doc, DEFAULT_WINDOW_SECS).unwrap();
+
+    assert_eq!(plan.total, 3);
+    assert_eq!(plan.importable.len(), 1);
+    assert_eq!(
+        plan.duplicates, 1,
+        "the dupe check queried the log read-only"
+    );
+    assert_eq!(plan.unusable.len(), 1);
+}
+
+// ------------------------------------------------------------------ commit --
+
+#[test]
+fn commit_writes_the_plan_and_the_journal() {
+    let dir = TmpDir::new();
+    let doc = adif_doc(&[
+        &rec("W1AW", "20260701", "140000", "20m", "SSB"),
+        &rec("K5ZD", "20260702", "150000", "40m", "CW"),
+    ]);
+    let plan = plan_of(&dir, &doc);
+
+    let mut store = LogStore::open(dir.db(), dir.adi()).unwrap();
+    let outcome = store.commit_import(&plan.importable, &station()).unwrap();
+    assert_eq!(outcome.imported, 2);
+    assert!(outcome.journal_appended);
+
+    let rows = store.query_contacts(100).unwrap();
+    assert_eq!(rows.len(), 2);
+
+    // The journal carries both records, under one header.
+    let journal = std::fs::read_to_string(dir.adi()).unwrap();
+    assert_eq!(journal.matches("<EOH>").count(), 1);
+    assert_eq!(journal.matches("<EOR>").count(), 2);
+    assert!(journal.contains("W1AW") && journal.contains("K5ZD"));
+}
+
+#[test]
+fn import_is_idempotent_reimporting_the_same_file_adds_nothing() {
+    // The property that makes import safe to re-run. Without it, a nervous
+    // operator importing twice would silently double their log.
+    let dir = TmpDir::new();
+    let doc = adif_doc(&[
+        &rec("W1AW", "20260701", "140000", "20m", "SSB"),
+        &rec("K5ZD", "20260702", "150000", "40m", "CW"),
+    ]);
+
+    let plan1 = plan_of(&dir, &doc);
+    let mut store = LogStore::open(dir.db(), dir.adi()).unwrap();
+    store.commit_import(&plan1.importable, &station()).unwrap();
+    drop(store);
+
+    let plan2 = plan_of(&dir, &doc);
+    assert_eq!(plan2.total, 2);
+    assert_eq!(plan2.duplicates, 2, "both already logged");
+    assert!(plan2.importable.is_empty());
+
+    let mut store = LogStore::open(dir.db(), dir.adi()).unwrap();
+    let outcome = store.commit_import(&plan2.importable, &station()).unwrap();
+    assert_eq!(outcome.imported, 0);
+    assert_eq!(store.query_contacts(100).unwrap().len(), 2, "still 2");
+}
+
+#[test]
+fn an_imported_records_own_my_fields_survive_the_station_snapshot() {
+    // Importing another log's QSOs must not rewrite where THEY were made from.
+    // The station fills only what the record doesn't already carry.
+    let dir = TmpDir::new();
+    let doc = adif_doc(&[
+        &format!(
+            "{}<MY_GRIDSQUARE:4>FN31 <STATION_CALLSIGN:5>W9XYZ ",
+            rec("W1AW", "20260701", "140000", "20m", "SSB")
+        ),
+        // …and a record with no MY_* at all picks up the current station.
+        &rec("K5ZD", "20260702", "150000", "40m", "CW"),
+    ]);
+    let plan = plan_of(&dir, &doc);
+
+    let mut store = LogStore::open(dir.db(), dir.adi()).unwrap();
+    store.commit_import(&plan.importable, &station()).unwrap();
+
+    let rows = store.query_contacts(100).unwrap();
+    let by_call = |c: &str| {
+        rows.iter()
+            .find(|r| r.qso.call == c)
+            .unwrap()
+            .qso
+            .extra
+            .clone()
+    };
+
+    let imported = by_call("W1AW");
+    assert_eq!(
+        imported.get("MY_GRIDSQUARE").map(String::as_str),
+        Some("FN31"),
+        "the file's own grid is historical truth and must not be overwritten"
+    );
+    assert_eq!(
+        imported.get("STATION_CALLSIGN").map(String::as_str),
+        Some("W9XYZ")
+    );
+
+    let bare = by_call("K5ZD");
+    assert_eq!(
+        bare.get("MY_GRIDSQUARE").map(String::as_str),
+        Some("EM12"),
+        "a record with no MY_* gets the current station"
+    );
+}
+
+#[test]
+fn commit_is_atomic_a_failing_row_imports_nothing() {
+    // Half an import is worse than none: the operator cannot tell which half
+    // landed. Prove the ROLLBACK, not the validation — so force a failure from
+    // inside SQLite, on a row the planner would have happily accepted.
+    let dir = TmpDir::new();
+    let mut store = LogStore::open(dir.db(), dir.adi()).unwrap();
+    store
+        .conn()
+        .execute_batch(
+            "CREATE TRIGGER boom BEFORE INSERT ON qso WHEN NEW.call = 'BOOM' \
+             BEGIN SELECT RAISE(ABORT, 'boom'); END;",
+        )
+        .unwrap();
+
+    let q = |call: &str, time: &str| {
+        let mut q = crate::Qso {
+            call: call.into(),
+            qso_date: "20260701".into(),
+            time_on: time.into(),
+            band: "20m".into(),
+            mode: "SSB".into(),
+            ..Default::default()
+        };
+        q.normalize();
+        q
+    };
+
+    // The bad row sits in the MIDDLE: rows before it have already been inserted
+    // inside the transaction when it blows up.
+    let batch = [
+        q("W1AW", "140000"),
+        q("BOOM", "150000"),
+        q("K5ZD", "160000"),
+    ];
+
+    let result = store.commit_import(&batch, &station());
+    assert!(result.is_err(), "the aborting row must fail the commit");
+
+    let rows = store.query_contacts(100).unwrap();
+    assert!(
+        rows.is_empty(),
+        "the whole batch must roll back — found {} row(s), so a partial import \
+         was committed",
+        rows.len()
+    );
+}
+
+// -------------------------------------------------------------- round-trip --
+
+#[test]
+fn export_then_import_into_a_clean_log_round_trips() {
+    // The two halves must agree: what export writes, import must read back
+    // identically — including split fields, submodes, and extras.
+    let src = TmpDir::new();
+    let mut store = LogStore::open(src.db(), src.adi()).unwrap();
+
+    let mut split = crate::Qso {
+        call: "DX1SPLIT".into(),
+        qso_date: "20260701".into(),
+        time_on: "140000".into(),
+        band: "20m".into(),
+        mode: "CW".into(),
+        freq_hz: Some(14_025_000),
+        freq_rx_hz: Some(14_030_000),
+        rst_sent: Some("599".into()),
+        ..Default::default()
+    };
+    split.normalize();
+
+    let mut ft4 = crate::Qso {
+        call: "EA1AAA".into(),
+        qso_date: "20260702".into(),
+        time_on: "150000".into(),
+        mode: "FT4".into(),
+        freq_hz: Some(14_080_000),
+        ..Default::default()
+    };
+    ft4.normalize();
+
+    let mut intl = crate::Qso {
+        call: "OH2ÄÄ".into(),
+        qso_date: "20260703".into(),
+        time_on: "160000".into(),
+        band: "40m".into(),
+        mode: "SSB".into(),
+        ..Default::default()
+    };
+    intl.extra.insert("NAME_INTL".into(), "Jörg".into());
+    intl.normalize();
+
+    for q in [&split, &ft4, &intl] {
+        store.insert(q, &station()).unwrap();
+    }
+
+    let ex = Exporter::open(src.db()).unwrap();
+    ex.export(
+        &ExportFilter::default(),
+        &ExportOptions {
+            output_path: src.out(),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+    let text = std::fs::read_to_string(src.out()).unwrap();
+
+    // …into a clean log, through the real import path.
+    let dst = TmpDir::new();
+    let plan = plan_of(&dst, &text);
+    assert_eq!(plan.total, 3);
+    assert_eq!(plan.importable.len(), 3);
+    assert!(
+        plan.unusable.is_empty(),
+        "our own export must import cleanly"
+    );
+
+    let mut dst_store = LogStore::open(dst.db(), dst.adi()).unwrap();
+    dst_store
+        .commit_import(&plan.importable, &station())
+        .unwrap();
+
+    let rows = dst_store.query_contacts(100).unwrap();
+    assert_eq!(rows.len(), 3);
+    let by_call = |c: &str| rows.iter().find(|r| r.qso.call == c).unwrap().qso.clone();
+
+    let back = by_call("DX1SPLIT");
+    assert_eq!(back.freq_rx_hz, Some(14_030_000));
+    assert_eq!(back.band_rx.as_deref(), Some("20m"));
+    assert_eq!(back.rst_sent.as_deref(), Some("599"));
+
+    let back = by_call("EA1AAA");
+    assert_eq!(back.mode, "MFSK");
+    assert_eq!(
+        back.submode.as_deref(),
+        Some("FT4"),
+        "FT4 survives the trip"
+    );
+
+    let back = by_call("OH2ÄÄ");
+    assert_eq!(
+        back.extra.get("NAME_INTL").map(String::as_str),
+        Some("Jörg")
+    );
+}
+
+// --------------------------------------------------------------- bulk path --
+
+#[test]
+fn a_large_import_is_one_transaction_not_a_loop_over_insert() {
+    // 20k records. `insert()` fsyncs per contact (right for a live QSO, ~100s for
+    // 20k); commit_import pays that once. If this test ever crawls, someone has
+    // turned the bulk path back into a loop over insert().
+    let dir = TmpDir::new();
+    let mut records = Vec::new();
+    for i in 0..20_000u32 {
+        records.push(rec(
+            &format!("T{i:05}"),
+            "20260701",
+            &format!("{:02}{:02}{:02}", i / 3600 % 24, (i / 60) % 60, i % 60),
+            "20m",
+            "SSB",
+        ));
+    }
+    let doc = adif_doc(&records.iter().map(String::as_str).collect::<Vec<_>>());
+
+    let started = std::time::Instant::now();
+    let plan = plan_of(&dir, &doc);
+    assert_eq!(plan.importable.len(), 20_000);
+
+    let mut store = LogStore::open(dir.db(), dir.adi()).unwrap();
+    let outcome = store.commit_import(&plan.importable, &station()).unwrap();
+    assert_eq!(outcome.imported, 20_000);
+
+    let elapsed = started.elapsed();
+    assert!(
+        elapsed < std::time::Duration::from_secs(30),
+        "20k import took {elapsed:?} — the bulk path has regressed to per-row fsync"
+    );
+
+    // One header, 20k records, one journal write.
+    let journal = std::fs::read_to_string(dir.adi()).unwrap();
+    assert_eq!(journal.matches("<EOR>").count(), 20_000);
+    assert_eq!(journal.matches("<EOH>").count(), 1);
+}

--- a/rigflow-log/src/import/tests.rs
+++ b/rigflow-log/src/import/tests.rs
@@ -306,6 +306,34 @@ fn committing_a_report_marks_the_contact_confirmed_and_is_idempotent() {
 }
 
 #[test]
+fn import_recognizes_per_service_qsl_fields_the_round_trip() {
+    // What our own export writes for a LoTW confirmation is `LOTW_QSL_RCVD:Y`
+    // (+ date), NOT the APP_LoTW form a LoTW report uses. Re-importing that must
+    // recognize it as a lotw confirmation, so an export→import round-trips.
+    let dir = TmpDir::new();
+    let mut store = LogStore::open(dir.db(), dir.adi()).unwrap();
+    insert_worked(&mut store); // W7WRO 40m FT8
+    drop(store);
+
+    let doc = adif_doc(&[&format!(
+        "{}<LOTW_QSL_RCVD:1>Y <LOTW_QSLRDATE:8>20260723 ",
+        rec("W7WRO", "20260712", "235600", "40M", "FT8"),
+    )]);
+    let plan = plan_of(&dir, &doc);
+    assert_eq!(plan.confirmations.len(), 1);
+    assert_eq!(plan.confirmations[0].service, "lotw");
+    assert_eq!(
+        plan.confirmations[0].confirmed_at.as_deref(),
+        Some("20260723")
+    );
+    assert_eq!(
+        plan.importable.len(),
+        0,
+        "a confirmation is not a new contact"
+    );
+}
+
+#[test]
 fn an_unmatched_confirmation_is_surfaced_not_inserted() {
     // A QSL for a QSO we never logged: counted, never turned into a phantom row.
     let dir = TmpDir::new();

--- a/rigflow-log/src/import/tests.rs
+++ b/rigflow-log/src/import/tests.rs
@@ -74,6 +74,32 @@ fn rec(call: &str, date: &str, time: &str, band: &str, mode: &str) -> String {
     )
 }
 
+/// `rec` plus the QSL fields a LoTW confirmation report carries: `QSL_RCVD=Y`,
+/// a `QSLRDATE`, and an `APP_LoTW_*` field that identifies the service.
+fn lotw_rec(call: &str, date: &str, time: &str, band: &str, mode: &str, qslrdate: &str) -> String {
+    format!(
+        "{}<APP_LoTW_OWNCALL:6>KK7TCY <QSL_RCVD:1>Y <QSLRDATE:8>{} ",
+        rec(call, date, time, band, mode),
+        qslrdate,
+    )
+}
+
+/// A W7WRO/40m/FT8 contact already in the log, matching `lotw_rec` above. Its
+/// band is derived from frequency (canonical lowercase "40m").
+fn insert_worked(store: &mut LogStore) {
+    let mut q = crate::Qso {
+        call: "W7WRO".into(),
+        qso_date: "20260712".into(),
+        time_on: "235600".into(),
+        band: String::new(),
+        mode: "FT8".into(),
+        freq_hz: Some(7_076_000),
+        ..Default::default()
+    };
+    q.normalize();
+    store.insert(&q, &station()).unwrap();
+}
+
 fn plan_of(dir: &TmpDir, text: &str) -> ImportPlan {
     let store = LogStore::open(dir.db(), dir.adi()).unwrap();
     let p = plan(store.conn(), text, DEFAULT_WINDOW_SECS).unwrap();
@@ -189,6 +215,110 @@ fn plan_skips_contacts_already_in_the_log() {
 }
 
 #[test]
+fn plan_dedupes_an_uppercase_band_against_a_derived_lowercase_band() {
+    // A contact stored with a frequency-derived band ("40m", lowercase) must
+    // still dedupe against the same QSO re-imported from a program (LoTW,
+    // WSJT-X, N1MM…) that writes BAND uppercase ("40M"). Regression: normalize()
+    // once left a present band's case untouched, so the case-sensitive dedupe
+    // key inserted the confirmation report's QSOs as fresh duplicates.
+    let dir = TmpDir::new();
+    let mut store = LogStore::open(dir.db(), dir.adi()).unwrap();
+    let mut existing = crate::Qso {
+        call: "W7WRO".into(),
+        qso_date: "20260712".into(),
+        time_on: "235600".into(),
+        band: String::new(), // derived from freq → canonical lowercase "40m"
+        mode: "FT8".into(),
+        freq_hz: Some(7_076_000),
+        ..Default::default()
+    };
+    existing.normalize();
+    assert_eq!(existing.band, "40m");
+    store.insert(&existing, &station()).unwrap();
+    drop(store);
+
+    // Same QSO as it comes back in a LoTW report: BAND uppercase.
+    let doc = adif_doc(&[&rec("W7WRO", "20260712", "235600", "40M", "FT8")]);
+    let plan = plan_of(&dir, &doc);
+    assert_eq!(plan.duplicates, 1, "uppercase BAND must match stored 40m");
+    assert_eq!(plan.importable.len(), 0);
+}
+
+#[test]
+fn plan_treats_a_qsl_report_as_confirmations_not_new_contacts() {
+    let dir = TmpDir::new();
+    let mut store = LogStore::open(dir.db(), dir.adi()).unwrap();
+    insert_worked(&mut store);
+    drop(store);
+
+    // The same QSO as it comes back from LoTW: uppercase BAND, QSL_RCVD=Y.
+    let doc = adif_doc(&[&lotw_rec(
+        "W7WRO", "20260712", "235600", "40M", "FT8", "20260723",
+    )]);
+    let plan = plan_of(&dir, &doc);
+    assert_eq!(
+        plan.importable.len(),
+        0,
+        "a confirmation is not a new contact"
+    );
+    assert_eq!(plan.duplicates, 0, "nor a plain duplicate");
+    assert_eq!(plan.confirmations.len(), 1);
+    let c = &plan.confirmations[0];
+    assert_eq!(c.service, "lotw", "service inferred from APP_LoTW_* fields");
+    assert_eq!(c.confirmed_at.as_deref(), Some("20260723"));
+}
+
+#[test]
+fn committing_a_report_marks_the_contact_confirmed_and_is_idempotent() {
+    let dir = TmpDir::new();
+    let mut store = LogStore::open(dir.db(), dir.adi()).unwrap();
+    insert_worked(&mut store);
+
+    let doc = adif_doc(&[&lotw_rec(
+        "W7WRO", "20260712", "235600", "40M", "FT8", "20260723",
+    )]);
+    let plan = plan(store.conn(), &doc, DEFAULT_WINDOW_SECS).unwrap();
+    let outcome = store
+        .commit_import(&plan.importable, &plan.confirmations, &station())
+        .unwrap();
+    assert_eq!(outcome.imported, 0, "no new rows");
+    assert_eq!(outcome.confirmed, 1);
+
+    // The contact view now shows the confirmation.
+    let rows = store.query_contacts(10).unwrap();
+    assert_eq!(rows.len(), 1, "still one contact, not two");
+    assert_eq!(rows[0].confirmed, vec!["lotw".to_string()]);
+
+    // Re-importing the same report records nothing new — idempotent preview.
+    let plan2 = super::plan(store.conn(), &doc, DEFAULT_WINDOW_SECS).unwrap();
+    assert_eq!(plan2.confirmations.len(), 0);
+    assert_eq!(plan2.already_confirmed, 1);
+    drop(store);
+
+    // The client's contact view loads through the read-only Exporter, not the
+    // store — the confirmation column must be populated there too.
+    let ex = Exporter::open(dir.db()).unwrap();
+    let page = ex
+        .page(&ExportFilter::default(), 10, crate::export::Sort::Reverse)
+        .unwrap();
+    assert_eq!(page.rows.len(), 1);
+    assert_eq!(page.rows[0].confirmed, vec!["lotw".to_string()]);
+}
+
+#[test]
+fn an_unmatched_confirmation_is_surfaced_not_inserted() {
+    // A QSL for a QSO we never logged: counted, never turned into a phantom row.
+    let dir = TmpDir::new();
+    let doc = adif_doc(&[&lotw_rec(
+        "W7WRO", "20260712", "235600", "40M", "FT8", "20260723",
+    )]);
+    let plan = plan_of(&dir, &doc);
+    assert_eq!(plan.unmatched_confirmations, 1);
+    assert_eq!(plan.confirmations.len(), 0);
+    assert_eq!(plan.importable.len(), 0);
+}
+
+#[test]
 fn plan_catches_duplicates_within_the_file_itself() {
     // Another program's export can carry its own internal duplicates, and the DB
     // check cannot see rows we are about to add in the same batch.
@@ -271,7 +401,9 @@ fn commit_writes_the_plan_and_the_journal() {
     let plan = plan_of(&dir, &doc);
 
     let mut store = LogStore::open(dir.db(), dir.adi()).unwrap();
-    let outcome = store.commit_import(&plan.importable, &station()).unwrap();
+    let outcome = store
+        .commit_import(&plan.importable, &[], &station())
+        .unwrap();
     assert_eq!(outcome.imported, 2);
     assert!(outcome.journal_appended);
 
@@ -297,7 +429,9 @@ fn import_is_idempotent_reimporting_the_same_file_adds_nothing() {
 
     let plan1 = plan_of(&dir, &doc);
     let mut store = LogStore::open(dir.db(), dir.adi()).unwrap();
-    store.commit_import(&plan1.importable, &station()).unwrap();
+    store
+        .commit_import(&plan1.importable, &[], &station())
+        .unwrap();
     drop(store);
 
     let plan2 = plan_of(&dir, &doc);
@@ -306,7 +440,9 @@ fn import_is_idempotent_reimporting_the_same_file_adds_nothing() {
     assert!(plan2.importable.is_empty());
 
     let mut store = LogStore::open(dir.db(), dir.adi()).unwrap();
-    let outcome = store.commit_import(&plan2.importable, &station()).unwrap();
+    let outcome = store
+        .commit_import(&plan2.importable, &[], &station())
+        .unwrap();
     assert_eq!(outcome.imported, 0);
     assert_eq!(store.query_contacts(100).unwrap().len(), 2, "still 2");
 }
@@ -327,7 +463,9 @@ fn an_imported_records_own_my_fields_survive_the_station_snapshot() {
     let plan = plan_of(&dir, &doc);
 
     let mut store = LogStore::open(dir.db(), dir.adi()).unwrap();
-    store.commit_import(&plan.importable, &station()).unwrap();
+    store
+        .commit_import(&plan.importable, &[], &station())
+        .unwrap();
 
     let rows = store.query_contacts(100).unwrap();
     let by_call = |c: &str| {
@@ -394,7 +532,7 @@ fn commit_is_atomic_a_failing_row_imports_nothing() {
         q("K5ZD", "160000"),
     ];
 
-    let result = store.commit_import(&batch, &station());
+    let result = store.commit_import(&batch, &[], &station());
     assert!(result.is_err(), "the aborting row must fail the commit");
 
     let rows = store.query_contacts(100).unwrap();
@@ -476,7 +614,7 @@ fn export_then_import_into_a_clean_log_round_trips() {
 
     let mut dst_store = LogStore::open(dst.db(), dst.adi()).unwrap();
     dst_store
-        .commit_import(&plan.importable, &station())
+        .commit_import(&plan.importable, &[], &station())
         .unwrap();
 
     let rows = dst_store.query_contacts(100).unwrap();
@@ -528,7 +666,9 @@ fn a_large_import_is_one_transaction_not_a_loop_over_insert() {
     assert_eq!(plan.importable.len(), 20_000);
 
     let mut store = LogStore::open(dir.db(), dir.adi()).unwrap();
-    let outcome = store.commit_import(&plan.importable, &station()).unwrap();
+    let outcome = store
+        .commit_import(&plan.importable, &[], &station())
+        .unwrap();
     assert_eq!(outcome.imported, 20_000);
 
     let elapsed = started.elapsed();

--- a/rigflow-log/src/import/tests.rs
+++ b/rigflow-log/src/import/tests.rs
@@ -421,6 +421,50 @@ fn a_downloaded_eqsl_confirmation_shows_a_badge_and_updates_an_upload_row() {
 }
 
 #[test]
+fn duplicate_confirmed_records_for_one_qso_count_once() {
+    // QRZ can hold near-duplicate confirmed records (e.g. the same QSO uploaded
+    // by both rigflow and WSJT-X, seconds apart) that both match one logged
+    // contact within the window. The operator sees one badge, so the tally must
+    // count the QSO once — not once per fetched record.
+    let dir = TmpDir::new();
+    let mut store = LogStore::open(dir.db(), dir.adi()).unwrap();
+    insert_worked(&mut store); // one W7WRO 40m FT8 at 235600
+    drop(store);
+
+    // Two confirmed QRZ records for that one QSO, 20 seconds apart.
+    let doc = adif_doc(&[
+        &format!(
+            "{}<APP_QRZLOG_STATUS:1>C ",
+            rec("W7WRO", "20260712", "235600", "40M", "FT8")
+        ),
+        &format!(
+            "{}<APP_QRZLOG_STATUS:1>C ",
+            rec("W7WRO", "20260712", "235620", "40M", "FT8")
+        ),
+    ]);
+
+    // First run: one new confirmation, not two.
+    let store = LogStore::open(dir.db(), dir.adi()).unwrap();
+    let dl = super::plan_download(store.conn(), &doc, DEFAULT_WINDOW_SECS).unwrap();
+    assert_eq!(dl.confirmations.len(), 1, "one distinct QSO confirmed");
+    drop(store);
+
+    // Apply it, then re-run: "already confirmed" is 1, not 2.
+    let mut store = LogStore::open(dir.db(), dir.adi()).unwrap();
+    store
+        .commit_import(&dl.importable, &dl.confirmations, &station())
+        .unwrap();
+    let again = super::plan_download(store.conn(), &doc, DEFAULT_WINDOW_SECS).unwrap();
+    assert_eq!(again.confirmations.len(), 0);
+    assert_eq!(
+        again.already_confirmed, 1,
+        "counts the QSO once, not per record"
+    );
+    // And the contact carries a single badge.
+    assert_eq!(store.query_contacts(10).unwrap()[0].confirmed, vec!["qrz"]);
+}
+
+#[test]
 fn a_qrz_download_confirms_c_records_and_ignores_the_rest() {
     // QRZ FETCH returns the whole logbook: confirmed QSOs carry APP_QRZLOG_STATUS=C,
     // the rest =N. A download must confirm the C ones against the log and ignore

--- a/rigflow-log/src/import/tests.rs
+++ b/rigflow-log/src/import/tests.rs
@@ -334,6 +334,93 @@ fn import_recognizes_per_service_qsl_fields_the_round_trip() {
 }
 
 #[test]
+fn import_recognizes_an_eqsl_inbox_confirmation() {
+    // eQSL inbox records mark a confirmation with EQSL_AG (and sometimes
+    // EQSL_QSL_RCVD/EQSL_QSLRDATE), and carry QSL_SENT=Y (not QSL_RCVD). All must
+    // be recognized as an eqsl confirmation, and confirmed_at must be non-null so
+    // the badge shows — falling back to the QSO date when eQSL gives no QSL date.
+    let dir = TmpDir::new();
+    let mut store = LogStore::open(dir.db(), dir.adi()).unwrap();
+    insert_worked(&mut store); // W7WRO 40m FT8, 20260712
+    drop(store);
+
+    // No EQSL_QSL_RCVD / no date — only EQSL_AG + APP_EQSL_AG, plus QSL_SENT=Y.
+    let doc = adif_doc(&[&format!(
+        "{}<QSL_SENT:1>Y <EQSL_AG:1>Y <APP_EQSL_AG:1>Y ",
+        rec("W7WRO", "20260712", "235600", "40M", "FT8"),
+    )]);
+    let plan = plan_of(&dir, &doc);
+    assert_eq!(plan.confirmations.len(), 1);
+    assert_eq!(plan.confirmations[0].service, "eqsl");
+    assert_eq!(
+        plan.confirmations[0].confirmed_at.as_deref(),
+        Some("20260712"),
+        "falls back to the QSO date when eQSL supplies none"
+    );
+    assert_eq!(plan.importable.len(), 0);
+}
+
+#[test]
+fn eqsl_confirmation_uses_its_date_when_present() {
+    let dir = TmpDir::new();
+    let mut store = LogStore::open(dir.db(), dir.adi()).unwrap();
+    insert_worked(&mut store);
+    drop(store);
+
+    let doc = adif_doc(&[&format!(
+        "{}<QSL_SENT:1>Y <EQSL_AG:1>Y <EQSL_QSL_RCVD:1>Y <EQSL_QSLRDATE:8>20260720 ",
+        rec("W7WRO", "20260712", "235600", "40M", "FT8"),
+    )]);
+    let plan = plan_of(&dir, &doc);
+    assert_eq!(plan.confirmations.len(), 1);
+    assert_eq!(plan.confirmations[0].service, "eqsl");
+    assert_eq!(
+        plan.confirmations[0].confirmed_at.as_deref(),
+        Some("20260720")
+    );
+}
+
+#[test]
+fn a_downloaded_eqsl_confirmation_shows_a_badge_and_updates_an_upload_row() {
+    // The end-to-end shape of the on-air bug: an eQSL confirmation must reach the
+    // contact view's badge, even for a QSO already marked *uploaded* to eqsl.
+    let dir = TmpDir::new();
+    let mut store = LogStore::open(dir.db(), dir.adi()).unwrap();
+    let mut q = crate::Qso {
+        call: "W7WRO".into(),
+        qso_date: "20260712".into(),
+        time_on: "235600".into(),
+        band: String::new(),
+        mode: "FT8".into(),
+        freq_hz: Some(7_076_000),
+        ..Default::default()
+    };
+    q.normalize(); // the live path normalizes before insert (derives band "40m")
+    let a = store.insert(&q, &station()).unwrap();
+    // We already uploaded this QSO to eqsl (row exists, confirmed_at NULL).
+    store.mark_uploaded(&[a.id], "eqsl").unwrap();
+
+    let doc = adif_doc(&[&format!(
+        "{}<QSL_SENT:1>Y <EQSL_AG:1>Y ",
+        rec("W7WRO", "20260712", "235600", "40M", "FT8"),
+    )]);
+    let plan = super::plan(store.conn(), &doc, DEFAULT_WINDOW_SECS).unwrap();
+    // Not "already confirmed" — the existing row is upload-only.
+    assert_eq!(plan.confirmations.len(), 1);
+    assert_eq!(plan.already_confirmed, 0);
+
+    store
+        .commit_import(&plan.importable, &plan.confirmations, &station())
+        .unwrap();
+    let rows = store.query_contacts(10).unwrap();
+    assert_eq!(
+        rows[0].confirmed,
+        vec!["eqsl".to_string()],
+        "badge now shows eqsl"
+    );
+}
+
+#[test]
 fn an_unmatched_confirmation_is_surfaced_not_inserted() {
     // A QSL for a QSO we never logged: counted, never turned into a phantom row.
     let dir = TmpDir::new();

--- a/rigflow-log/src/import/tests.rs
+++ b/rigflow-log/src/import/tests.rs
@@ -421,6 +421,42 @@ fn a_downloaded_eqsl_confirmation_shows_a_badge_and_updates_an_upload_row() {
 }
 
 #[test]
+fn a_qrz_download_confirms_c_records_and_ignores_the_rest() {
+    // QRZ FETCH returns the whole logbook: confirmed QSOs carry APP_QRZLOG_STATUS=C,
+    // the rest =N. A download must confirm the C ones against the log and ignore
+    // the N ones entirely — never add them as new contacts.
+    let dir = TmpDir::new();
+    let mut store = LogStore::open(dir.db(), dir.adi()).unwrap();
+    insert_worked(&mut store); // W7WRO 40m FT8, 20260712
+    drop(store);
+
+    let doc = adif_doc(&[
+        // Confirmed on QRZ, matches the logged QSO → a qrz confirmation.
+        &format!(
+            "{}<APP_QRZLOG_STATUS:1>C <APP_QRZLOG_QSLDATE:8>20260720 <QSL_RCVD:1>N ",
+            rec("W7WRO", "20260712", "235600", "40M", "FT8"),
+        ),
+        // Not confirmed, and not even in our log → must be ignored, not imported.
+        &format!(
+            "{}<APP_QRZLOG_STATUS:1>N ",
+            rec("N7XS", "20240520", "023000", "2m", "FM"),
+        ),
+    ]);
+
+    let store = LogStore::open(dir.db(), dir.adi()).unwrap();
+    let dl = super::plan_download(store.conn(), &doc, DEFAULT_WINDOW_SECS).unwrap();
+    assert_eq!(dl.confirmations.len(), 1);
+    assert_eq!(dl.confirmations[0].service, "qrz");
+    assert_eq!(
+        dl.confirmations[0].confirmed_at.as_deref(),
+        Some("20260720")
+    );
+    // The unconfirmed stranger is ignored: no import, no duplicate count.
+    assert_eq!(dl.importable.len(), 0);
+    assert_eq!(dl.duplicates, 0);
+}
+
+#[test]
 fn an_unmatched_confirmation_is_surfaced_not_inserted() {
     // A QSL for a QSO we never logged: counted, never turned into a phantom row.
     let dir = TmpDir::new();

--- a/rigflow-log/src/lib.rs
+++ b/rigflow-log/src/lib.rs
@@ -16,6 +16,7 @@ pub mod dedupe;
 pub mod display;
 pub mod error;
 pub mod export;
+pub mod import;
 pub mod migrations;
 pub mod model;
 pub mod normalize;
@@ -26,6 +27,7 @@ pub mod wsjtx;
 pub use capture::{CapturedRadioState, Receiver};
 pub use error::LogError;
 pub use export::{ExportFilter, ExportOptions, ExportSummary, Exporter, FieldProfile};
+pub use import::{ImportPlan, ImportProblem};
 pub use model::{Qso, Station};
 pub use store::LogStore;
 

--- a/rigflow-log/src/lib.rs
+++ b/rigflow-log/src/lib.rs
@@ -13,6 +13,7 @@
 pub mod adif;
 pub mod capture;
 pub mod dedupe;
+pub mod display;
 pub mod error;
 pub mod export;
 pub mod migrations;

--- a/rigflow-log/src/lib.rs
+++ b/rigflow-log/src/lib.rs
@@ -1,0 +1,37 @@
+//! rigflow contact (QSO) logging — phase 1: local capture and storage.
+//!
+//! This crate is a **leaf**: it depends on no other rigflow crate and pulls in
+//! neither egui nor ALSA, so it compiles and its tests run in environments that
+//! cannot build `rigflow-client`. All pure/testable logging logic lives here —
+//! the SQLite store, the ADIF parser/writer, mode/band normalization, dedupe,
+//! the WSJT-X UDP decoder, and the split-frequency (`FREQ_RX`) derivation.
+//!
+//! The `rigflow-client` crate owns only the thin wiring: building
+//! [`capture::CapturedRadioState`] from its live UI state, the egui windows and
+//! panels, the hotkeys, and the UDP-2237 listener thread.
+
+pub mod adif;
+pub mod capture;
+pub mod dedupe;
+pub mod error;
+pub mod migrations;
+pub mod model;
+pub mod normalize;
+pub mod schema;
+pub mod store;
+pub mod wsjtx;
+
+pub use capture::{CapturedRadioState, Receiver};
+pub use error::LogError;
+pub use model::{Qso, Station};
+pub use store::LogStore;
+
+/// Current UTC as ADIF-native `(qso_date "YYYYMMDD", time_on "HHMMSS")`. Used to
+/// freeze the log time at the instant a manual entry opens.
+pub fn now_utc_adif() -> (String, String) {
+    let now = chrono::Utc::now();
+    (
+        now.format("%Y%m%d").to_string(),
+        now.format("%H%M%S").to_string(),
+    )
+}

--- a/rigflow-log/src/lib.rs
+++ b/rigflow-log/src/lib.rs
@@ -14,6 +14,7 @@ pub mod adif;
 pub mod capture;
 pub mod dedupe;
 pub mod error;
+pub mod export;
 pub mod migrations;
 pub mod model;
 pub mod normalize;
@@ -23,6 +24,7 @@ pub mod wsjtx;
 
 pub use capture::{CapturedRadioState, Receiver};
 pub use error::LogError;
+pub use export::{ExportFilter, ExportOptions, ExportSummary, Exporter, FieldProfile};
 pub use model::{Qso, Station};
 pub use store::LogStore;
 

--- a/rigflow-log/src/migrations.rs
+++ b/rigflow-log/src/migrations.rs
@@ -1,0 +1,35 @@
+//! Minimal migration mechanism keyed on `PRAGMA user_version`.
+//!
+//! A schema this small doesn't need a migration framework: each step bumps
+//! `user_version` by one inside a transaction. Adding a future column means
+//! appending a step and incrementing [`schema::SCHEMA_VERSION`].
+
+use rusqlite::Connection;
+
+use crate::error::LogError;
+use crate::schema;
+
+/// Bring `conn` up to [`schema::SCHEMA_VERSION`], applying only the steps its
+/// current `user_version` is missing. Idempotent: a fully-migrated database is
+/// a no-op; reopening never re-runs a step.
+pub fn migrate(conn: &Connection) -> Result<(), LogError> {
+    let mut version: i64 = conn.query_row("PRAGMA user_version", [], |r| r.get(0))?;
+
+    while version < schema::SCHEMA_VERSION {
+        let tx = conn.unchecked_transaction()?;
+        match version {
+            0 => {
+                tx.execute_batch(schema::V1_DDL)?;
+            }
+            other => {
+                return Err(LogError::UnknownSchemaVersion(other));
+            }
+        }
+        version += 1;
+        // user_version can't be bound as a parameter; it's an integer we
+        // control, so format it directly.
+        tx.execute_batch(&format!("PRAGMA user_version = {version}"))?;
+        tx.commit()?;
+    }
+    Ok(())
+}

--- a/rigflow-log/src/migrations.rs
+++ b/rigflow-log/src/migrations.rs
@@ -21,6 +21,9 @@ pub fn migrate(conn: &Connection) -> Result<(), LogError> {
             0 => {
                 tx.execute_batch(schema::V1_DDL)?;
             }
+            1 => {
+                tx.execute_batch(schema::V2_DDL)?;
+            }
             other => {
                 return Err(LogError::UnknownSchemaVersion(other));
             }

--- a/rigflow-log/src/model.rs
+++ b/rigflow-log/src/model.rs
@@ -1,0 +1,117 @@
+//! Core logging data model: a normalized [`Qso`] and the [`Station`] profile.
+//!
+//! A `Qso` is the single normalized-contact shape that every capture path
+//! (manual entry, ADIF file import, WSJT-X ingest) converges on before it hits
+//! the store. Columns mirror the SQLite schema; every ADIF field we don't model
+//! as a column round-trips through [`Qso::extra`] so nothing is dropped.
+
+use std::collections::BTreeMap;
+
+use crate::normalize;
+
+/// The logging station's identity. In rigflow the **callsign is per-operator**
+/// (`station_call` = the operator id) and the **location is global** (grid,
+/// state, county, zones, name apply to the whole physical station). These
+/// values are snapshotted onto each QSO at log time so later edits never
+/// rewrite history.
+#[derive(Debug, Clone, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct Station {
+    pub station_call: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub gridsquare: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub my_state: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub my_county: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cq_zone: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub itu_zone: Option<String>,
+}
+
+impl Station {
+    /// The `MY_*` ADIF fields this station contributes to a logged QSO's
+    /// `extra` map. `MY_GRIDSQUARE` etc. are historical truth once copied.
+    pub fn my_adif_fields(&self) -> BTreeMap<String, String> {
+        let mut m = BTreeMap::new();
+        // STATION_CALLSIGN is the QSO-level "who transmitted"; also emit
+        // OPERATOR so single-op logs are unambiguous.
+        if !self.station_call.trim().is_empty() {
+            m.insert(
+                "STATION_CALLSIGN".into(),
+                self.station_call.trim().to_string(),
+            );
+            m.insert("OPERATOR".into(), self.station_call.trim().to_string());
+        }
+        for (k, v) in [
+            ("MY_GRIDSQUARE", &self.gridsquare),
+            ("MY_NAME", &self.name),
+            ("MY_STATE", &self.my_state),
+            ("MY_CNTY", &self.my_county),
+            ("MY_CQ_ZONE", &self.cq_zone),
+            ("MY_ITU_ZONE", &self.itu_zone),
+        ] {
+            if let Some(v) = v.as_ref().filter(|s| !s.trim().is_empty()) {
+                m.insert(k.to_string(), v.trim().to_string());
+            }
+        }
+        m
+    }
+}
+
+/// A normalized contact. Times are UTC, ADIF-native (`YYYYMMDD` / `HHMMSS`).
+///
+/// Split semantics (ADIF): `freq_hz`/`band` are the **transmit** frequency/band
+/// (where *you* called); `freq_rx_hz`/`band_rx` are the **receive**
+/// frequency/band (the DX station's transmit frequency) and are `None` on a
+/// simplex QSO. `band` is derived from `freq_hz` and `band_rx` from
+/// `freq_rx_hz`, independently.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct Qso {
+    pub call: String,
+    pub qso_date: String,
+    pub time_on: String,
+    pub band: String,
+    pub mode: String,
+    pub submode: Option<String>,
+    pub freq_hz: Option<u64>,
+    pub freq_rx_hz: Option<u64>,
+    pub band_rx: Option<String>,
+    pub rst_sent: Option<String>,
+    pub rst_rcvd: Option<String>,
+    pub gridsquare: Option<String>,
+    pub dxcc: Option<i64>,
+    /// Every ADIF field not held in a column above, keyed by upper-case ADIF
+    /// field name (includes `APP_*` extensions, `*_INTL` fields, and the
+    /// snapshotted `MY_*` station fields). Ordered for deterministic output.
+    pub extra: BTreeMap<String, String>,
+}
+
+impl Qso {
+    /// Fill in derived/canonical fields:
+    /// - normalize `mode`/`submode`,
+    /// - derive `band` from `freq_hz` when band is blank,
+    /// - derive `band_rx` from `freq_rx_hz` when a split RX freq is present.
+    ///
+    /// Idempotent — safe to call on already-normalized input.
+    pub fn normalize(&mut self) {
+        let (mode, submode) = normalize::normalize_mode(&self.mode, self.submode.as_deref());
+        self.mode = mode;
+        self.submode = submode;
+
+        if self.band.trim().is_empty()
+            && let Some(b) = self.freq_hz.and_then(normalize::band_for_freq_hz)
+        {
+            self.band = b.to_string();
+        }
+        // band_rx is derived from freq_rx independently; only meaningful when a
+        // split RX frequency exists.
+        if self.band_rx.is_none()
+            && let Some(b) = self.freq_rx_hz.and_then(normalize::band_for_freq_hz)
+        {
+            self.band_rx = Some(b.to_string());
+        }
+    }
+}

--- a/rigflow-log/src/model.rs
+++ b/rigflow-log/src/model.rs
@@ -101,17 +101,30 @@ impl Qso {
         self.mode = mode;
         self.submode = submode;
 
-        if self.band.trim().is_empty()
-            && let Some(b) = self.freq_hz.and_then(normalize::band_for_freq_hz)
-        {
+        // Band: derive from freq when blank; otherwise canonicalize the case of
+        // a band that's already present. An imported "40M" must become "40m" —
+        // the form we store when deriving from freq — or the case-sensitive
+        // dedupe key treats the same contact as new (see dedupe / import).
+        if self.band.trim().is_empty() {
+            if let Some(b) = self.freq_hz.and_then(normalize::band_for_freq_hz) {
+                self.band = b.to_string();
+            }
+        } else if let Some(b) = normalize::canonical_band(&self.band) {
             self.band = b.to_string();
         }
         // band_rx is derived from freq_rx independently; only meaningful when a
-        // split RX frequency exists.
-        if self.band_rx.is_none()
-            && let Some(b) = self.freq_rx_hz.and_then(normalize::band_for_freq_hz)
-        {
-            self.band_rx = Some(b.to_string());
+        // split RX frequency exists. Same canonicalization when already present.
+        match self.band_rx.as_deref() {
+            None => {
+                if let Some(b) = self.freq_rx_hz.and_then(normalize::band_for_freq_hz) {
+                    self.band_rx = Some(b.to_string());
+                }
+            }
+            Some(b) => {
+                if let Some(c) = normalize::canonical_band(b) {
+                    self.band_rx = Some(c.to_string());
+                }
+            }
         }
     }
 }

--- a/rigflow-log/src/normalize.rs
+++ b/rigflow-log/src/normalize.rs
@@ -47,6 +47,19 @@ pub fn band_for_freq_hz(freq_hz: u64) -> Option<&'static str> {
         .map(|(_, _, band)| *band)
 }
 
+/// Every ADIF `BAND` string we recognize, low→high. The band enumeration is
+/// closed, so export can reject an unknown band outright rather than silently
+/// matching nothing.
+pub fn known_bands() -> impl Iterator<Item = &'static str> {
+    BANDS.iter().map(|(_, _, b)| *b)
+}
+
+/// Whether `band` is a recognized ADIF `BAND` (case-insensitive).
+pub fn is_known_band(band: &str) -> bool {
+    let b = band.trim().to_ascii_lowercase();
+    known_bands().any(|k| k.eq_ignore_ascii_case(&b))
+}
+
 /// Known submode → canonical parent `MODE`. When a submode value shows up in
 /// the `MODE` field (a common non-compliance), we split it back into
 /// `(parent_mode, Some(submode))`.
@@ -61,7 +74,6 @@ const SUBMODE_PARENT: &[(&str, &str)] = &[
     ("JT65A", "JT65"),
     ("JT65B", "JT65"),
     ("JT65C", "JT65"),
-    ("OLIVIA", "OLIVIA"),
 ];
 
 /// Aliases for the `MODE` field itself (not submodes): things operators or
@@ -109,6 +121,107 @@ pub fn normalize_mode(mode: &str, submode: Option<&str>) -> (String, Option<Stri
     }
 
     (alias_mode(&mode_uc), None)
+}
+
+/// A coarse mode family, for filters that mean "all the digital contacts" rather
+/// than an exact mode list.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum ModeClass {
+    Phone,
+    Cw,
+    Digital,
+    Image,
+}
+
+impl ModeClass {
+    /// Every class, for UI enumeration.
+    pub const ALL: &'static [ModeClass] = &[
+        ModeClass::Phone,
+        ModeClass::Cw,
+        ModeClass::Digital,
+        ModeClass::Image,
+    ];
+
+    /// Stable lower-case wire/UI name.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            ModeClass::Phone => "phone",
+            ModeClass::Cw => "cw",
+            ModeClass::Digital => "digital",
+            ModeClass::Image => "image",
+        }
+    }
+
+    /// Parse a class name (case-insensitive). `None` if unknown.
+    pub fn parse(s: &str) -> Option<ModeClass> {
+        let s = s.trim().to_ascii_lowercase();
+        ModeClass::ALL.iter().copied().find(|c| c.as_str() == s)
+    }
+}
+
+/// Canonical `MODE` → class. Keyed on the **canonical parent mode** (what the
+/// `mode` column actually stores after [`normalize_mode`]), never on a submode:
+/// FT4 is stored as `MFSK`/`FT4`, so classifying `MFSK` classifies FT4 with it.
+///
+/// This table is the single source of truth for the mode→class mapping. Export's
+/// `mode_classes` filter expands through [`modes_in_class`] rather than
+/// hardcoding a list at the call site, so a mode added to [`MODE_ALIAS`] or
+/// [`SUBMODE_PARENT`] only has to be classified once, here.
+const MODE_CLASS: &[(&str, ModeClass)] = &[
+    // Phone
+    ("SSB", ModeClass::Phone),
+    ("AM", ModeClass::Phone),
+    ("FM", ModeClass::Phone),
+    ("DIGITALVOICE", ModeClass::Phone),
+    // CW
+    ("CW", ModeClass::Cw),
+    // Digital
+    ("FT8", ModeClass::Digital),
+    ("MFSK", ModeClass::Digital), // FT4, JS8
+    ("JT65", ModeClass::Digital),
+    ("JT9", ModeClass::Digital),
+    ("JT4", ModeClass::Digital),
+    ("Q65", ModeClass::Digital),
+    ("FSK441", ModeClass::Digital),
+    ("ISCAT", ModeClass::Digital),
+    ("MSK144", ModeClass::Digital),
+    ("PSK", ModeClass::Digital),
+    ("RTTY", ModeClass::Digital),
+    ("OLIVIA", ModeClass::Digital),
+    ("CONTESTIA", ModeClass::Digital),
+    ("DOMINO", ModeClass::Digital),
+    ("THOR", ModeClass::Digital),
+    ("THRB", ModeClass::Digital),
+    ("MT63", ModeClass::Digital),
+    ("HELL", ModeClass::Digital),
+    ("ARDOP", ModeClass::Digital),
+    ("PACKET", ModeClass::Digital),
+    ("PACTOR", ModeClass::Digital),
+    ("VARA", ModeClass::Digital),
+    ("WINMOR", ModeClass::Digital),
+    // Image
+    ("SSTV", ModeClass::Image),
+    ("ATV", ModeClass::Image),
+    ("FAX", ModeClass::Image),
+];
+
+/// The class of a canonical `MODE`, or `None` for a mode we don't classify (an
+/// unknown mode passed through by [`normalize_mode`]). `None` is "unclassified",
+/// never a guess — an unclassified mode simply doesn't match any class filter.
+pub fn mode_class(mode: &str) -> Option<ModeClass> {
+    let m = mode.trim().to_ascii_uppercase();
+    MODE_CLASS.iter().find(|(k, _)| *k == m).map(|(_, c)| *c)
+}
+
+/// Every canonical `MODE` in a class. Export expands a `mode_classes` filter
+/// into an `IN (...)` over these, so the SQL only ever compares the indexed
+/// `mode` column against exact values.
+pub fn modes_in_class(class: ModeClass) -> Vec<&'static str> {
+    MODE_CLASS
+        .iter()
+        .filter(|(_, c)| *c == class)
+        .map(|(m, _)| *m)
+        .collect()
 }
 
 fn parent_of_submode(sm: &str) -> Option<&'static str> {
@@ -222,5 +335,81 @@ mod tests {
             normalize_mode("contestia", None),
             ("CONTESTIA".into(), None)
         );
+    }
+
+    #[test]
+    fn mode_class_basics() {
+        assert_eq!(mode_class("SSB"), Some(ModeClass::Phone));
+        assert_eq!(mode_class("cw"), Some(ModeClass::Cw));
+        assert_eq!(mode_class("FT8"), Some(ModeClass::Digital));
+        assert_eq!(mode_class("SSTV"), Some(ModeClass::Image));
+    }
+
+    #[test]
+    fn mode_class_follows_normalization() {
+        // The class table is keyed on the CANONICAL mode, so classifying has to
+        // go through normalize_mode first — USB is not in the table, SSB is.
+        let (mode, _) = normalize_mode("USB", None);
+        assert_eq!(mode_class(&mode), Some(ModeClass::Phone));
+
+        // FT4 normalizes to MFSK/FT4; classifying the stored parent gets digital.
+        let (mode, submode) = normalize_mode("FT4", None);
+        assert_eq!(submode.as_deref(), Some("FT4"));
+        assert_eq!(mode_class(&mode), Some(ModeClass::Digital));
+    }
+
+    #[test]
+    fn mode_class_unknown_is_none() {
+        assert_eq!(mode_class("CONTESTIA"), Some(ModeClass::Digital));
+        assert_eq!(mode_class("NOTAMODE"), None);
+    }
+
+    #[test]
+    fn olivia_is_a_mode_not_its_own_submode() {
+        // Regression: OLIVIA used to self-parent in SUBMODE_PARENT, stamping a
+        // bogus <SUBMODE:6>OLIVIA on every Olivia QSO. MODE=OLIVIA is canonical;
+        // real Olivia submodes look like "OLIVIA 8/250".
+        assert_eq!(normalize_mode("OLIVIA", None), ("OLIVIA".into(), None));
+    }
+
+    #[test]
+    fn modes_in_class_expands() {
+        let phone = modes_in_class(ModeClass::Phone);
+        assert!(phone.contains(&"SSB"));
+        assert!(phone.contains(&"AM"));
+        assert!(phone.contains(&"FM"));
+        assert!(!phone.contains(&"CW"));
+
+        // Digital must include MFSK, or FT4/JS8 QSOs silently fall out of a
+        // "digital" export.
+        let digital = modes_in_class(ModeClass::Digital);
+        assert!(digital.contains(&"FT8"));
+        assert!(digital.contains(&"MFSK"));
+        assert!(digital.contains(&"RTTY"));
+
+        assert_eq!(modes_in_class(ModeClass::Cw), vec!["CW"]);
+    }
+
+    #[test]
+    fn mode_class_roundtrips_by_name() {
+        for c in ModeClass::ALL {
+            assert_eq!(ModeClass::parse(c.as_str()), Some(*c));
+        }
+        assert_eq!(ModeClass::parse("PHONE"), Some(ModeClass::Phone));
+        assert_eq!(ModeClass::parse("nope"), None);
+    }
+
+    #[test]
+    fn every_classified_mode_is_canonical() {
+        // A class-table key that isn't its own canonical mode would never match
+        // the stored `mode` column. Guards against adding e.g. "USB" or "FT4".
+        for (m, _) in MODE_CLASS {
+            let (canonical, submode) = normalize_mode(m, None);
+            assert_eq!(
+                (&canonical[..], submode.as_deref()),
+                (*m, None),
+                "MODE_CLASS key {m} is not a canonical MODE"
+            );
+        }
     }
 }

--- a/rigflow-log/src/normalize.rs
+++ b/rigflow-log/src/normalize.rs
@@ -60,6 +60,16 @@ pub fn is_known_band(band: &str) -> bool {
     known_bands().any(|k| k.eq_ignore_ascii_case(&b))
 }
 
+/// The canonical ADIF `BAND` string for `band`, matched case-insensitively
+/// (e.g. `"40M"` → `"40m"`). `None` if `band` is not a recognized ham band, so
+/// callers leave an unrecognized value untouched rather than mangling it. This
+/// is what lets an imported uppercase `BAND` dedupe against a contact we stored
+/// with a lowercase band derived from frequency.
+pub fn canonical_band(band: &str) -> Option<&'static str> {
+    let b = band.trim();
+    known_bands().find(|k| k.eq_ignore_ascii_case(b))
+}
+
 /// Known submode → canonical parent `MODE`. When a submode value shows up in
 /// the `MODE` field (a common non-compliance), we split it back into
 /// `(parent_mode, Some(submode))`.

--- a/rigflow-log/src/normalize.rs
+++ b/rigflow-log/src/normalize.rs
@@ -1,0 +1,226 @@
+//! Centralized mode/band normalization.
+//!
+//! Two independent jobs:
+//! - [`band_for_freq_hz`] maps a frequency to its ADIF `BAND` string. TX and RX
+//!   frequencies are mapped **independently** (a split QSO can straddle two
+//!   bands, and 60m is a channelized edge case), so the caller derives `band`
+//!   from `freq_hz` and `band_rx` from `freq_rx_hz` with two separate calls.
+//! - [`normalize_mode`] maps a (possibly non-compliant) mode/submode pair to a
+//!   canonical ADIF `MODE` plus an optional `SUBMODE`, so downstream matching
+//!   (confirmation sync in a later phase) has a stable vocabulary.
+
+/// ADIF band table: `(low_hz, high_hz_inclusive, adif_band)`, ordered low→high.
+/// Ranges are the ADIF `BAND` enumeration bounds. Endpoints are inclusive so a
+/// dial sitting exactly on a band edge still resolves.
+const BANDS: &[(u64, u64, &str)] = &[
+    (135_700, 137_800, "2190m"),
+    (472_000, 479_000, "630m"),
+    (1_800_000, 2_000_000, "160m"),
+    (3_500_000, 4_000_000, "80m"),
+    // 60m: ADIF treats the whole 5 MHz allocation as "60m"; US is channelized
+    // (5330.5–5405 kHz) but other regions have a contiguous band. Use the wider
+    // region-2/1 bounds so channelized US dials still resolve.
+    (5_060_000, 5_450_000, "60m"),
+    (7_000_000, 7_300_000, "40m"),
+    (10_100_000, 10_150_000, "30m"),
+    (14_000_000, 14_350_000, "20m"),
+    (18_068_000, 18_168_000, "17m"),
+    (21_000_000, 21_450_000, "15m"),
+    (24_890_000, 24_990_000, "12m"),
+    (28_000_000, 29_700_000, "10m"),
+    (50_000_000, 54_000_000, "6m"),
+    (70_000_000, 71_000_000, "4m"),
+    (144_000_000, 148_000_000, "2m"),
+    (222_000_000, 225_000_000, "1.25m"),
+    (420_000_000, 450_000_000, "70cm"),
+    (902_000_000, 928_000_000, "33cm"),
+    (1_240_000_000, 1_300_000_000, "23cm"),
+];
+
+/// Returns the ADIF `BAND` string a frequency falls in, or `None` if the
+/// frequency is outside every ham band (e.g. a WAV recording tuned to a
+/// broadcast station). `None` means "leave BAND unset", never a guess.
+pub fn band_for_freq_hz(freq_hz: u64) -> Option<&'static str> {
+    BANDS
+        .iter()
+        .find(|(lo, hi, _)| freq_hz >= *lo && freq_hz <= *hi)
+        .map(|(_, _, band)| *band)
+}
+
+/// Known submode → canonical parent `MODE`. When a submode value shows up in
+/// the `MODE` field (a common non-compliance), we split it back into
+/// `(parent_mode, Some(submode))`.
+const SUBMODE_PARENT: &[(&str, &str)] = &[
+    ("PSK31", "PSK"),
+    ("PSK63", "PSK"),
+    ("PSK125", "PSK"),
+    ("QPSK31", "PSK"),
+    ("QPSK63", "PSK"),
+    ("FT4", "MFSK"),
+    ("JS8", "MFSK"),
+    ("JT65A", "JT65"),
+    ("JT65B", "JT65"),
+    ("JT65C", "JT65"),
+    ("OLIVIA", "OLIVIA"),
+];
+
+/// Aliases for the `MODE` field itself (not submodes): things operators or
+/// other software write that aren't the ADIF-canonical mode. USB/LSB are CAT
+/// sidebands, not ADIF modes — both normalize to `SSB`.
+const MODE_ALIAS: &[(&str, &str)] = &[
+    ("USB", "SSB"),
+    ("LSB", "SSB"),
+    ("CWU", "CW"),
+    ("CWL", "CW"),
+    ("PKTUSB", "MFSK"),
+    ("DIG", "MFSK"),
+    ("DATA", "MFSK"),
+];
+
+/// Normalize a raw `(mode, submode)` pair to canonical ADIF `(MODE, SUBMODE)`.
+///
+/// Rules, in order:
+/// 1. Upper-case and trim both.
+/// 2. If a submode is supplied, keep it and, if we know its parent, prefer that
+///    parent as the mode.
+/// 3. Else if the mode value is itself a known submode, split it into
+///    `(parent, Some(submode))`.
+/// 4. Else map any mode alias (USB/LSB→SSB, …).
+///
+/// An unknown mode is passed through upper-cased rather than dropped.
+pub fn normalize_mode(mode: &str, submode: Option<&str>) -> (String, Option<String>) {
+    let mode_uc = mode.trim().to_ascii_uppercase();
+    let submode_uc = submode
+        .map(|s| s.trim().to_ascii_uppercase())
+        .filter(|s| !s.is_empty());
+
+    if let Some(sm) = submode_uc {
+        // An explicit submode wins; resolve its canonical parent if known,
+        // otherwise trust the supplied mode.
+        let parent = parent_of_submode(&sm)
+            .map(str::to_string)
+            .unwrap_or_else(|| alias_mode(&mode_uc));
+        return (parent, Some(sm));
+    }
+
+    // No submode: the mode field itself might actually be a submode value.
+    if let Some(parent) = parent_of_submode(&mode_uc) {
+        return (parent.to_string(), Some(mode_uc));
+    }
+
+    (alias_mode(&mode_uc), None)
+}
+
+fn parent_of_submode(sm: &str) -> Option<&'static str> {
+    SUBMODE_PARENT
+        .iter()
+        .find(|(k, _)| *k == sm)
+        .map(|(_, v)| *v)
+}
+
+fn alias_mode(mode_uc: &str) -> String {
+    MODE_ALIAS
+        .iter()
+        .find(|(k, _)| *k == mode_uc)
+        .map(|(_, v)| v.to_string())
+        .unwrap_or_else(|| mode_uc.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn band_from_freq_spread() {
+        assert_eq!(band_for_freq_hz(1_840_000), Some("160m"));
+        assert_eq!(band_for_freq_hz(3_573_000), Some("80m"));
+        assert_eq!(band_for_freq_hz(7_074_000), Some("40m"));
+        assert_eq!(band_for_freq_hz(10_136_000), Some("30m"));
+        assert_eq!(band_for_freq_hz(14_074_000), Some("20m"));
+        assert_eq!(band_for_freq_hz(14_200_000), Some("20m"));
+        assert_eq!(band_for_freq_hz(18_100_000), Some("17m"));
+        assert_eq!(band_for_freq_hz(21_074_000), Some("15m"));
+        assert_eq!(band_for_freq_hz(28_074_000), Some("10m"));
+        assert_eq!(band_for_freq_hz(50_313_000), Some("6m"));
+        assert_eq!(band_for_freq_hz(144_174_000), Some("2m"));
+        assert_eq!(band_for_freq_hz(432_100_000), Some("70cm"));
+    }
+
+    #[test]
+    fn band_edges_inclusive() {
+        assert_eq!(band_for_freq_hz(14_000_000), Some("20m"));
+        assert_eq!(band_for_freq_hz(14_350_000), Some("20m"));
+    }
+
+    #[test]
+    fn band_60m_channelized_us() {
+        // US 60m channel 1 center — must still resolve to 60m.
+        assert_eq!(band_for_freq_hz(5_332_000), Some("60m"));
+    }
+
+    #[test]
+    fn band_out_of_range_is_none() {
+        assert_eq!(band_for_freq_hz(9_000_000), None); // between 40m and 30m
+        assert_eq!(band_for_freq_hz(1_000_000), None); // MW broadcast
+    }
+
+    #[test]
+    fn band_tx_and_rx_independent() {
+        // A split QSO can straddle a band edge; each side maps on its own.
+        assert_eq!(band_for_freq_hz(7_200_000), Some("40m"));
+        assert_eq!(band_for_freq_hz(7_290_000), Some("40m"));
+    }
+
+    #[test]
+    fn mode_ssb_from_sideband() {
+        assert_eq!(normalize_mode("USB", None), ("SSB".into(), None));
+        assert_eq!(normalize_mode("lsb", None), ("SSB".into(), None));
+        assert_eq!(normalize_mode("SSB", None), ("SSB".into(), None));
+    }
+
+    #[test]
+    fn mode_cw() {
+        assert_eq!(normalize_mode("CW", None), ("CW".into(), None));
+        assert_eq!(normalize_mode("CWU", None), ("CW".into(), None));
+    }
+
+    #[test]
+    fn mode_ft8_is_toplevel() {
+        assert_eq!(normalize_mode("FT8", None), ("FT8".into(), None));
+    }
+
+    #[test]
+    fn mode_submode_in_mode_field_is_split() {
+        // "PSK31" logged as the MODE → (PSK, PSK31).
+        assert_eq!(
+            normalize_mode("PSK31", None),
+            ("PSK".into(), Some("PSK31".into()))
+        );
+        // FT4 is MFSK/FT4 in ADIF.
+        assert_eq!(
+            normalize_mode("FT4", None),
+            ("MFSK".into(), Some("FT4".into()))
+        );
+    }
+
+    #[test]
+    fn mode_explicit_submode_resolves_parent() {
+        assert_eq!(
+            normalize_mode("PSK", Some("PSK63")),
+            ("PSK".into(), Some("PSK63".into()))
+        );
+        // Unknown submode: trust the supplied (aliased) mode.
+        assert_eq!(
+            normalize_mode("USB", Some("SOMETHING")),
+            ("SSB".into(), Some("SOMETHING".into()))
+        );
+    }
+
+    #[test]
+    fn mode_unknown_passes_through_uppercased() {
+        assert_eq!(
+            normalize_mode("contestia", None),
+            ("CONTESTIA".into(), None)
+        );
+    }
+}

--- a/rigflow-log/src/schema.rs
+++ b/rigflow-log/src/schema.rs
@@ -1,13 +1,15 @@
-//! SQLite schema (v1) and PRAGMA setup.
+//! SQLite schema and PRAGMA setup.
 //!
 //! The schema is deliberately forward-looking: `qso_service` and `sync_state`
 //! are created now but stay empty until a later phase adds online-service
 //! confirmation sync. The `extra` JSON column round-trips arbitrary ADIF
 //! fields, and `idx_qso_match` is the join key future confirmation matching
 //! will use, so it is created correctly now.
+//!
+//! v2 adds `export_state`: the incremental-export bookmarks.
 
 /// Current schema version stamped into `PRAGMA user_version`.
-pub const SCHEMA_VERSION: i64 = 1;
+pub const SCHEMA_VERSION: i64 = 2;
 
 /// DDL that brings a fresh database to v1.
 pub const V1_DDL: &str = r#"
@@ -59,6 +61,29 @@ CREATE TABLE sync_state (
     service      TEXT PRIMARY KEY,
     last_marker  TEXT,
     last_run_at  TEXT
+);
+"#;
+
+/// DDL that brings a v1 database to v2.
+///
+/// `export_state` holds one **incremental-export bookmark** per named profile,
+/// so independent incremental streams (a Wavelog feed, a per-service feed) never
+/// collide. `last_qso_id` is the `qso.id` (= rowid) of the newest QSO the last
+/// incremental run exported: incremental export is about *export progress*, not
+/// contact time, so it filters on insertion order, never on `qso_date`.
+///
+/// This is deliberately separate from `sync_state`, which belongs to
+/// online-service confirmation sync — a different clock with different owners.
+///
+/// **Only the `since_last_export` path writes this table**, and only after a
+/// successful non-dry-run write. An ad-hoc filtered export must never move an
+/// operator's incremental position.
+pub const V2_DDL: &str = r#"
+CREATE TABLE export_state (
+    profile         TEXT PRIMARY KEY,
+    last_qso_id     INTEGER NOT NULL,
+    last_created_at TEXT,
+    last_run_at     TEXT NOT NULL
 );
 "#;
 

--- a/rigflow-log/src/schema.rs
+++ b/rigflow-log/src/schema.rs
@@ -1,0 +1,72 @@
+//! SQLite schema (v1) and PRAGMA setup.
+//!
+//! The schema is deliberately forward-looking: `qso_service` and `sync_state`
+//! are created now but stay empty until a later phase adds online-service
+//! confirmation sync. The `extra` JSON column round-trips arbitrary ADIF
+//! fields, and `idx_qso_match` is the join key future confirmation matching
+//! will use, so it is created correctly now.
+
+/// Current schema version stamped into `PRAGMA user_version`.
+pub const SCHEMA_VERSION: i64 = 1;
+
+/// DDL that brings a fresh database to v1.
+pub const V1_DDL: &str = r#"
+CREATE TABLE station (
+    id            INTEGER PRIMARY KEY,
+    station_call  TEXT NOT NULL,
+    gridsquare    TEXT,
+    my_state      TEXT,
+    my_county     TEXT,
+    cq_zone       TEXT,
+    itu_zone      TEXT,
+    name          TEXT
+);
+
+CREATE TABLE qso (
+    id            INTEGER PRIMARY KEY,
+    call          TEXT NOT NULL,
+    qso_date      TEXT NOT NULL,
+    time_on       TEXT NOT NULL,
+    band          TEXT NOT NULL,
+    mode          TEXT NOT NULL,
+    submode       TEXT,
+    freq_hz       INTEGER,
+    freq_rx_hz    INTEGER,
+    band_rx       TEXT,
+    rst_sent      TEXT,
+    rst_rcvd      TEXT,
+    gridsquare    TEXT,
+    dxcc          INTEGER,
+    station_id    INTEGER NOT NULL REFERENCES station(id),
+    extra         TEXT NOT NULL DEFAULT '{}',
+    created_at    TEXT NOT NULL,
+    updated_at    TEXT NOT NULL
+);
+
+CREATE INDEX idx_qso_match ON qso(call, band, mode, qso_date);
+CREATE INDEX idx_qso_call  ON qso(call);
+
+CREATE TABLE qso_service (
+    qso_id       INTEGER NOT NULL REFERENCES qso(id) ON DELETE CASCADE,
+    service      TEXT NOT NULL,
+    uploaded_at  TEXT,
+    confirmed_at TEXT,
+    detail       TEXT,
+    PRIMARY KEY (qso_id, service)
+);
+
+CREATE TABLE sync_state (
+    service      TEXT PRIMARY KEY,
+    last_marker  TEXT,
+    last_run_at  TEXT
+);
+"#;
+
+/// Connection PRAGMAs applied at open. WAL + `synchronous=FULL` prioritizes
+/// durability over throughput — a QSO cannot be re-made, so a committed contact
+/// must survive a crash. `foreign_keys` enforces the `station_id` reference.
+pub const PRAGMAS: &str = r#"
+PRAGMA journal_mode = WAL;
+PRAGMA synchronous = FULL;
+PRAGMA foreign_keys = ON;
+"#;

--- a/rigflow-log/src/store.rs
+++ b/rigflow-log/src/store.rs
@@ -33,6 +33,18 @@ pub struct InsertOutcome {
     pub journal_appended: bool,
 }
 
+/// Result of a committed import.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ImportCommit {
+    /// Rows written. Duplicates and unusable records were dropped at plan time,
+    /// so this is the length of what was handed in.
+    pub imported: usize,
+    /// Whether the batched ADIF journal append succeeded. `false` means the
+    /// contacts are in the DB but missing from the journal (a warning: the
+    /// journal is only ever a subset of the DB).
+    pub journal_appended: bool,
+}
+
 /// A stored contact plus its row id, for the contact view.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct LoggedQso {
@@ -128,45 +140,16 @@ impl LogStore {
     /// snapshot fills only `extra` keys not already present, so an imported
     /// record's own `MY_*` (from WSJT-X or another log) is preserved.
     pub fn insert(&mut self, qso: &Qso, station: &Station) -> Result<InsertOutcome, LogError> {
-        let mut q = qso.clone();
-        for (k, v) in station.my_adif_fields() {
-            q.extra.entry(k).or_insert(v);
-        }
-        let now = Utc::now().to_rfc3339();
-        let extra_json = serde_json::to_string(&q.extra)?;
+        let q = with_station_snapshot(qso, station);
 
         let tx = self.conn.transaction()?;
         let station_id = upsert_station(&tx, station)?;
-        tx.execute(
-            "INSERT INTO qso (call,qso_date,time_on,band,mode,submode,freq_hz,freq_rx_hz,\
-             band_rx,rst_sent,rst_rcvd,gridsquare,dxcc,station_id,extra,created_at,updated_at) \
-             VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12,?13,?14,?15,?16,?17)",
-            params![
-                q.call,
-                q.qso_date,
-                q.time_on,
-                q.band,
-                q.mode,
-                q.submode,
-                q.freq_hz.map(|v| v as i64),
-                q.freq_rx_hz.map(|v| v as i64),
-                q.band_rx,
-                q.rst_sent,
-                q.rst_rcvd,
-                q.gridsquare,
-                q.dxcc,
-                station_id,
-                extra_json,
-                now,
-                now,
-            ],
-        )?;
-        let id = tx.last_insert_rowid();
+        let id = insert_qso_row(&tx, &q, station_id)?;
         tx.commit()?;
 
         // Journal append happens AFTER the DB commit. A failure here is a
         // warning, not an error: the DB is authoritative.
-        let journal_appended = match self.append_journal(&q) {
+        let journal_appended = match self.append_journal(std::slice::from_ref(&q)) {
             Ok(()) => true,
             Err(e) => {
                 eprintln!("rigflow-log: ADIF journal append failed (DB commit kept): {e}");
@@ -175,6 +158,59 @@ impl LogStore {
         };
         Ok(InsertOutcome {
             id,
+            journal_appended,
+        })
+    }
+
+    /// Commit a planned ADIF import: **one transaction, one journal write, one
+    /// fsync** for the whole batch.
+    ///
+    /// This is not a loop over [`LogStore::insert`], and it must not become one.
+    /// `insert` is tuned for a single live contact — `synchronous=FULL` plus a
+    /// journal `fsync` per record, because a QSO cannot be re-made and must
+    /// survive a crash. Paying that per row over an imported log is quadratically
+    /// miserable: 20k records take ~100s that way, and under a second like this.
+    ///
+    /// Atomic: if any row fails, the transaction rolls back and **nothing** is
+    /// imported. A half-imported log is worse than none, because the operator
+    /// cannot tell which half.
+    ///
+    /// `qsos` is expected to be [`crate::import::ImportPlan::importable`] — already
+    /// normalized, validated, and deduped. Callers get the `MY_*` snapshot
+    /// semantics of `insert`: the station fills only fields the imported record
+    /// doesn't already carry, so another log's `MY_*` survives.
+    pub fn commit_import(
+        &mut self,
+        qsos: &[Qso],
+        station: &Station,
+    ) -> Result<ImportCommit, LogError> {
+        if qsos.is_empty() {
+            return Ok(ImportCommit {
+                imported: 0,
+                journal_appended: true,
+            });
+        }
+        let staged: Vec<Qso> = qsos
+            .iter()
+            .map(|q| with_station_snapshot(q, station))
+            .collect();
+
+        let tx = self.conn.transaction()?;
+        let station_id = upsert_station(&tx, station)?;
+        for q in &staged {
+            insert_qso_row(&tx, q, station_id)?;
+        }
+        tx.commit()?;
+
+        let journal_appended = match self.append_journal(&staged) {
+            Ok(()) => true,
+            Err(e) => {
+                eprintln!("rigflow-log: ADIF journal append failed (DB commit kept): {e}");
+                false
+            }
+        };
+        Ok(ImportCommit {
+            imported: staged.len(),
             journal_appended,
         })
     }
@@ -308,21 +344,77 @@ impl LogStore {
         Ok(())
     }
 
-    /// Append one ADIF record to the journal, creating it (with header) on first
-    /// write. `O_APPEND` + `fsync`; safe because this store is single-owner.
-    fn append_journal(&self, q: &Qso) -> Result<(), LogError> {
+    /// Append records to the journal, creating it (with header) on first write.
+    /// `O_APPEND` + a single `fsync` for the whole batch; safe because this store
+    /// is single-owner.
+    ///
+    /// Batched deliberately: a live contact passes one record (one fsync, which is
+    /// the durability we want for a QSO that cannot be re-made), while an import
+    /// passes thousands and pays that cost **once**.
+    fn append_journal(&self, qsos: &[Qso]) -> Result<(), LogError> {
+        if qsos.is_empty() {
+            return Ok(());
+        }
         let fresh = !self.journal_path.exists();
         let mut f = std::fs::OpenOptions::new()
             .create(true)
             .append(true)
             .open(&self.journal_path)?;
+
+        let mut buf = String::new();
         if fresh {
-            f.write_all(adif::adif_header().as_bytes())?;
+            buf.push_str(&adif::adif_header());
         }
-        f.write_all(adif::write_record(&adif::qso_to_record(q)).as_bytes())?;
+        for q in qsos {
+            buf.push_str(&adif::write_record(&adif::qso_to_record(q)));
+        }
+        f.write_all(buf.as_bytes())?;
         f.sync_all()?;
         Ok(())
     }
+}
+
+/// Apply the station's `MY_*` snapshot to a QSO, filling only fields the record
+/// does not already carry — so an imported record's own `MY_*` (from WSJT-X, or
+/// from another logging program) is preserved as the historical truth it is.
+fn with_station_snapshot(qso: &Qso, station: &Station) -> Qso {
+    let mut q = qso.clone();
+    for (k, v) in station.my_adif_fields() {
+        q.extra.entry(k).or_insert(v);
+    }
+    q
+}
+
+/// Insert one `qso` row inside an open transaction. Shared by the single-contact
+/// and bulk-import paths so the column list can only ever drift in one place.
+fn insert_qso_row(tx: &Transaction<'_>, q: &Qso, station_id: i64) -> Result<i64, LogError> {
+    let now = Utc::now().to_rfc3339();
+    let extra_json = serde_json::to_string(&q.extra)?;
+    tx.execute(
+        "INSERT INTO qso (call,qso_date,time_on,band,mode,submode,freq_hz,freq_rx_hz,\
+         band_rx,rst_sent,rst_rcvd,gridsquare,dxcc,station_id,extra,created_at,updated_at) \
+         VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12,?13,?14,?15,?16,?17)",
+        params![
+            q.call,
+            q.qso_date,
+            q.time_on,
+            q.band,
+            q.mode,
+            q.submode,
+            q.freq_hz.map(|v| v as i64),
+            q.freq_rx_hz.map(|v| v as i64),
+            q.band_rx,
+            q.rst_sent,
+            q.rst_rcvd,
+            q.gridsquare,
+            q.dxcc,
+            station_id,
+            extra_json,
+            now,
+            now,
+        ],
+    )?;
+    Ok(tx.last_insert_rowid())
 }
 
 /// Upsert the station row keyed by callsign, refreshing its location fields to

--- a/rigflow-log/src/store.rs
+++ b/rigflow-log/src/store.rs
@@ -240,6 +240,57 @@ impl LogStore {
         Ok(wb)
     }
 
+    /// Count the QSOs an export filter would match, without writing a file.
+    ///
+    /// Convenience for a caller that already holds the store (and for tests).
+    /// The client's dialog counts through [`crate::export::Exporter`] on a
+    /// worker thread instead, so a full scan can't stutter the UI.
+    pub fn count_matching(&self, filter: &crate::export::ExportFilter) -> Result<usize, LogError> {
+        crate::export::writer::count_with(&self.conn, filter)
+    }
+
+    /// The current position of a named incremental-export bookmark.
+    pub fn export_bookmark(&self, profile: &str) -> Result<Option<i64>, LogError> {
+        crate::export::writer::read_bookmark(&self.conn, profile)
+    }
+
+    /// Advance a named incremental-export bookmark to `last_qso_id`.
+    ///
+    /// **This is the only way the bookmark moves, and it is not reachable from
+    /// the export writer** — that runs on a read-only connection. Call it only
+    /// after an incremental (`since_last_export`), non-dry-run export has
+    /// actually written its file. An ad-hoc filtered export must never land
+    /// here: moving the bookmark on a one-off "export my 20m QSOs" would skip
+    /// every unexported QSO outside that filter on the next incremental run.
+    ///
+    /// Monotonic by construction: a bookmark never moves backwards, so a
+    /// re-export of an older slice can't rewind the operator's position.
+    pub fn advance_export_bookmark(
+        &mut self,
+        profile: &str,
+        last_qso_id: i64,
+    ) -> Result<(), LogError> {
+        let now = Utc::now().to_rfc3339();
+        let created_at: Option<String> = self
+            .conn
+            .query_row(
+                "SELECT created_at FROM qso WHERE id = ?1",
+                [last_qso_id],
+                |r| r.get(0),
+            )
+            .optional()?;
+        self.conn.execute(
+            "INSERT INTO export_state (profile, last_qso_id, last_created_at, last_run_at) \
+             VALUES (?1, ?2, ?3, ?4) \
+             ON CONFLICT(profile) DO UPDATE SET \
+               last_qso_id     = max(last_qso_id, excluded.last_qso_id), \
+               last_created_at = excluded.last_created_at, \
+               last_run_at     = excluded.last_run_at",
+            params![profile, last_qso_id, created_at, now],
+        )?;
+        Ok(())
+    }
+
     /// Append one ADIF record to the journal, creating it (with header) on first
     /// write. `O_APPEND` + `fsync`; safe because this store is single-owner.
     fn append_journal(&self, q: &Qso) -> Result<(), LogError> {
@@ -300,7 +351,16 @@ fn upsert_station(tx: &Transaction<'_>, s: &Station) -> Result<i64, LogError> {
     }
 }
 
-fn row_to_logged_qso(r: &rusqlite::Row<'_>) -> rusqlite::Result<Result<LoggedQso, LogError>> {
+/// The `SELECT` list [`row_to_logged_qso`] expects, in order. Shared by every
+/// query that hydrates a [`LoggedQso`] (contact view, dedupe, export) so a
+/// column added here can't silently shift an index in one caller and not
+/// another.
+pub(crate) const QSO_COLUMNS: &str = "id,call,qso_date,time_on,band,mode,submode,freq_hz,\
+     freq_rx_hz,band_rx,rst_sent,rst_rcvd,gridsquare,dxcc,extra";
+
+pub(crate) fn row_to_logged_qso(
+    r: &rusqlite::Row<'_>,
+) -> rusqlite::Result<Result<LoggedQso, LogError>> {
     let extra_json: String = r.get(14)?;
     let extra: BTreeMap<String, String> = match serde_json::from_str(&extra_json) {
         Ok(m) => m,

--- a/rigflow-log/src/store.rs
+++ b/rigflow-log/src/store.rs
@@ -234,6 +234,60 @@ impl LogStore {
         })
     }
 
+    /// Delete the contact with row id `id`. Returns whether a row was removed.
+    ///
+    /// **DB-only.** The DB is the mutable source of truth; `qso_service` rows
+    /// cascade (`ON DELETE CASCADE`). The `.adi` journal is **append-only and is
+    /// deliberately left untouched** — it is a historical capture log of what was
+    /// logged, not a mirror of current state, and rewriting it would destroy both
+    /// that property and its crash-safety. Nothing reads the journal back
+    /// (`LogStore::open` loads from SQLite), so the divergence is by design: a
+    /// deleted contact stays in the journal as history. Recover current state via
+    /// an export of the DB, not the journal.
+    pub fn delete_qso(&mut self, id: i64) -> Result<bool, LogError> {
+        let n = self.conn.execute("DELETE FROM qso WHERE id = ?1", [id])?;
+        Ok(n > 0)
+    }
+
+    /// Overwrite the contact with row id `id` with the fields of `qso`.
+    ///
+    /// **DB-only**, for the same reason as [`LogStore::delete_qso`]: the
+    /// append-only journal keeps the originally-logged record; the edit lives in
+    /// the DB. Edits the modeled columns and `extra`; `station_id` and
+    /// `created_at` are left as they were (an edit does not re-provenance or
+    /// re-date the contact). The passed QSO is normalized first, so an edited
+    /// band/mode is canonical.
+    pub fn update_qso(&mut self, id: i64, qso: &Qso) -> Result<(), LogError> {
+        let mut q = qso.clone();
+        q.normalize();
+        let now = Utc::now().to_rfc3339();
+        let extra_json = serde_json::to_string(&q.extra)?;
+        self.conn.execute(
+            "UPDATE qso SET call=?1,qso_date=?2,time_on=?3,band=?4,mode=?5,submode=?6,\
+             freq_hz=?7,freq_rx_hz=?8,band_rx=?9,rst_sent=?10,rst_rcvd=?11,gridsquare=?12,\
+             dxcc=?13,extra=?14,updated_at=?15 WHERE id=?16",
+            params![
+                q.call,
+                q.qso_date,
+                q.time_on,
+                q.band,
+                q.mode,
+                q.submode,
+                q.freq_hz.map(|v| v as i64),
+                q.freq_rx_hz.map(|v| v as i64),
+                q.band_rx,
+                q.rst_sent,
+                q.rst_rcvd,
+                q.gridsquare,
+                q.dxcc,
+                extra_json,
+                now,
+                id,
+            ],
+        )?;
+        Ok(())
+    }
+
     /// Most-recent contacts first (by UTC date/time, then id). `limit` caps the
     /// result. Structured so a later phase can add a filter clause without
     /// touching callers.
@@ -723,6 +777,105 @@ mod tests {
         assert_eq!(text.matches("<EOH>").count(), 1, "exactly one header");
         assert_eq!(text.matches("<EOR>").count(), 2, "one EOR per QSO");
         assert!(text.contains("W1AW") && text.contains("K5ZD"));
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn delete_removes_the_row_but_leaves_the_append_only_journal() {
+        let dir = std::env::temp_dir().join(format!("rigflow-del-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let db = dir.join("rigflow_log.db");
+        let adi = dir.join("rigflow_log.adi");
+        std::fs::remove_file(&db).ok();
+        std::fs::remove_file(&adi).ok();
+
+        let mut s = LogStore::open(&db, &adi).unwrap();
+        let a = s.insert(&qso("W1AW", "20m", "142300"), &station()).unwrap();
+        s.insert(&qso("K5ZD", "20m", "143000"), &station()).unwrap();
+
+        assert!(s.delete_qso(a.id).unwrap(), "existing row is deleted");
+        assert!(!s.delete_qso(a.id).unwrap(), "already gone → false");
+
+        // The DB — the source of truth — reflects the deletion.
+        let rows = s.query_contacts(10).unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].qso.call, "K5ZD");
+
+        // The journal is append-only and untouched: it still holds BOTH records,
+        // the deleted one included. It is history, not a mirror of current state.
+        let text = std::fs::read_to_string(&adi).unwrap();
+        assert_eq!(text.matches("<EOH>").count(), 1);
+        assert_eq!(
+            text.matches("<EOR>").count(),
+            2,
+            "both records still logged"
+        );
+        assert!(text.contains("W1AW") && text.contains("K5ZD"));
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn delete_cascades_its_confirmations() {
+        // Deleting a QSO must drop its qso_service rows (ON DELETE CASCADE), so a
+        // confirmation can't outlive the contact it confirmed.
+        let mut s = LogStore::open_in_memory("/nonexistent/ignored.adi").unwrap();
+        let out = s.insert(&qso("W1AW", "20m", "142300"), &station()).unwrap();
+        s.commit_import(
+            &[],
+            &[crate::import::Confirmation {
+                qso_id: out.id,
+                service: "lotw".into(),
+                confirmed_at: Some("20260723".into()),
+            }],
+            &station(),
+        )
+        .unwrap();
+        let count = |s: &LogStore| -> i64 {
+            s.conn()
+                .query_row("SELECT COUNT(*) FROM qso_service", [], |r| r.get(0))
+                .unwrap()
+        };
+        assert_eq!(count(&s), 1);
+        s.delete_qso(out.id).unwrap(); // DB-only; journal is not touched
+        assert_eq!(count(&s), 0, "confirmation cascaded away with the QSO");
+    }
+
+    #[test]
+    fn update_changes_the_db_but_not_the_append_only_journal() {
+        let dir = std::env::temp_dir().join(format!("rigflow-upd-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let db = dir.join("rigflow_log.db");
+        let adi = dir.join("rigflow_log.adi");
+        std::fs::remove_file(&db).ok();
+        std::fs::remove_file(&adi).ok();
+
+        let mut s = LogStore::open(&db, &adi).unwrap();
+        let out = s.insert(&qso("W1AW", "20m", "142300"), &station()).unwrap();
+
+        let mut edited = s.query_contacts(1).unwrap().remove(0).qso;
+        edited.call = "W1AX".into();
+        edited.rst_rcvd = Some("57".into());
+        s.update_qso(out.id, &edited).unwrap();
+
+        // The DB reflects the edit in place, not as a new row.
+        let rows = s.query_contacts(10).unwrap();
+        assert_eq!(rows.len(), 1, "an edit is in place, not an insert");
+        assert_eq!(rows[0].qso.call, "W1AX");
+        assert_eq!(rows[0].qso.rst_rcvd.as_deref(), Some("57"));
+        // The snapshotted MY_* fields the edit didn't touch survive.
+        assert_eq!(
+            rows[0].qso.extra.get("MY_GRIDSQUARE"),
+            Some(&"EM12".to_string())
+        );
+
+        // The append-only journal still holds the ORIGINAL record, untouched.
+        let text = std::fs::read_to_string(&adi).unwrap();
+        assert_eq!(text.matches("<EOR>").count(), 1);
+        assert!(text.contains("W1AW"), "journal keeps what was logged");
+        assert!(
+            !text.contains("W1AX"),
+            "the edit is not written to the journal"
+        );
         std::fs::remove_dir_all(&dir).ok();
     }
 

--- a/rigflow-log/src/store.rs
+++ b/rigflow-log/src/store.rs
@@ -5,7 +5,7 @@
 //! `Connection` is `!Sync`, and `synchronous=FULL` makes every commit fsync, so
 //! exactly one thread (the UI thread in the client) drives it.
 
-use std::collections::{BTreeMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::io::Write;
 use std::path::{Path, PathBuf};
 
@@ -39,6 +39,9 @@ pub struct ImportCommit {
     /// Rows written. Duplicates and unusable records were dropped at plan time,
     /// so this is the length of what was handed in.
     pub imported: usize,
+    /// QSL confirmations recorded against existing QSOs (from a LoTW/eQSL
+    /// report). These marked contacts confirmed; they added no rows.
+    pub confirmed: usize,
     /// Whether the batched ADIF journal append succeeded. `false` means the
     /// contacts are in the DB but missing from the journal (a warning: the
     /// journal is only ever a subset of the DB).
@@ -50,6 +53,10 @@ pub struct ImportCommit {
 pub struct LoggedQso {
     pub id: i64,
     pub qso: Qso,
+    /// Services that have confirmed this QSO (lower-case: `lotw`, `eqsl`, …),
+    /// from the `qso_service` table. Empty unless a query enriched it — only the
+    /// contact-view queries do, since only they show the confirmation column.
+    pub confirmed: Vec<String>,
 }
 
 /// In-memory "worked before?" index, loaded once at open and updated on each
@@ -175,18 +182,26 @@ impl LogStore {
     /// imported. A half-imported log is worse than none, because the operator
     /// cannot tell which half.
     ///
-    /// `qsos` is expected to be [`crate::import::ImportPlan::importable`] — already
-    /// normalized, validated, and deduped. Callers get the `MY_*` snapshot
-    /// semantics of `insert`: the station fills only fields the imported record
-    /// doesn't already carry, so another log's `MY_*` survives.
+    /// `qsos` is expected to be [`crate::import::ImportPlan::importable`] and
+    /// `confirmations` to be [`crate::import::ImportPlan::confirmations`] — both
+    /// already matched, normalized, and deduped at plan time. New contacts and
+    /// QSL confirmations land in the **same transaction**, so a report that both
+    /// adds and confirms is still all-or-nothing.
+    ///
+    /// Callers get the `MY_*` snapshot semantics of `insert`: the station fills
+    /// only fields the imported record doesn't already carry, so another log's
+    /// `MY_*` survives. Confirmations touch only `qso_service`, not the journal —
+    /// they add no QSO the journal doesn't already have.
     pub fn commit_import(
         &mut self,
         qsos: &[Qso],
+        confirmations: &[crate::import::Confirmation],
         station: &Station,
     ) -> Result<ImportCommit, LogError> {
-        if qsos.is_empty() {
+        if qsos.is_empty() && confirmations.is_empty() {
             return Ok(ImportCommit {
                 imported: 0,
+                confirmed: 0,
                 journal_appended: true,
             });
         }
@@ -200,6 +215,9 @@ impl LogStore {
         for q in &staged {
             insert_qso_row(&tx, q, station_id)?;
         }
+        for c in confirmations {
+            record_confirmation(&tx, c)?;
+        }
         tx.commit()?;
 
         let journal_appended = match self.append_journal(&staged) {
@@ -211,6 +229,7 @@ impl LogStore {
         };
         Ok(ImportCommit {
             imported: staged.len(),
+            confirmed: confirmations.len(),
             journal_appended,
         })
     }
@@ -229,6 +248,7 @@ impl LogStore {
         for r in rows {
             out.push(r??);
         }
+        attach_confirmations(&self.conn, &mut out)?;
         Ok(out)
     }
 
@@ -294,12 +314,14 @@ impl LogStore {
         filter: &crate::export::ExportFilter,
         limit: usize,
     ) -> Result<Vec<LoggedQso>, LogError> {
-        crate::export::writer::query_with(
+        let mut rows = crate::export::writer::query_with(
             &self.conn,
             filter,
             limit,
             crate::export::Sort::Reverse, // the view is always newest-first
-        )
+        )?;
+        attach_confirmations(&self.conn, &mut rows)?;
+        Ok(rows)
     }
 
     /// The current position of a named incremental-export bookmark.
@@ -385,6 +407,24 @@ fn with_station_snapshot(qso: &Qso, station: &Station) -> Qso {
     q
 }
 
+/// Record one QSL confirmation inside an open transaction. Upsert keyed on
+/// `(qso_id, service)`, so re-recording the same confirmation just refreshes its
+/// date rather than erroring on the primary key — the same idempotency the plan
+/// preview promises. `uploaded_at` stays null: importing a report tells us the
+/// service confirmed, not that (or when) we uploaded.
+fn record_confirmation(
+    tx: &Transaction<'_>,
+    c: &crate::import::Confirmation,
+) -> Result<(), LogError> {
+    tx.execute(
+        "INSERT INTO qso_service (qso_id, service, confirmed_at, detail) \
+         VALUES (?1, ?2, ?3, NULL) \
+         ON CONFLICT(qso_id, service) DO UPDATE SET confirmed_at = excluded.confirmed_at",
+        params![c.qso_id, c.service, c.confirmed_at],
+    )?;
+    Ok(())
+}
+
 /// Insert one `qso` row inside an open transaction. Shared by the single-contact
 /// and bulk-import paths so the column list can only ever drift in one place.
 fn insert_qso_row(tx: &Transaction<'_>, q: &Qso, station_id: i64) -> Result<i64, LogError> {
@@ -467,6 +507,42 @@ fn upsert_station(tx: &Transaction<'_>, s: &Station) -> Result<i64, LogError> {
 pub(crate) const QSO_COLUMNS: &str = "id,call,qso_date,time_on,band,mode,submode,freq_hz,\
      freq_rx_hz,band_rx,rst_sent,rst_rcvd,gridsquare,dxcc,extra";
 
+/// Fill each row's `confirmed` list from `qso_service`, in one query for the
+/// whole page. The ids are our own row ids, so inlining them in the `IN (…)`
+/// clause is safe (no user text). Shared by the read-write contact queries here
+/// and the read-only [`crate::export::Exporter::page`] the client's view runs
+/// on, so the confirmation column is populated whichever path loads the page.
+pub(crate) fn attach_confirmations(
+    conn: &Connection,
+    rows: &mut [LoggedQso],
+) -> Result<(), LogError> {
+    if rows.is_empty() {
+        return Ok(());
+    }
+    let ids = rows
+        .iter()
+        .map(|r| r.id.to_string())
+        .collect::<Vec<_>>()
+        .join(",");
+    let sql = format!(
+        "SELECT qso_id, service FROM qso_service WHERE qso_id IN ({ids}) AND confirmed_at IS NOT NULL"
+    );
+    let mut by_id: HashMap<i64, Vec<String>> = HashMap::new();
+    let mut stmt = conn.prepare(&sql)?;
+    let mapped = stmt.query_map([], |r| Ok((r.get::<_, i64>(0)?, r.get::<_, String>(1)?)))?;
+    for row in mapped {
+        let (id, service) = row?;
+        by_id.entry(id).or_default().push(service);
+    }
+    for r in rows.iter_mut() {
+        if let Some(mut services) = by_id.remove(&r.id) {
+            services.sort();
+            r.confirmed = services;
+        }
+    }
+    Ok(())
+}
+
 pub(crate) fn row_to_logged_qso(
     r: &rusqlite::Row<'_>,
 ) -> rusqlite::Result<Result<LoggedQso, LogError>> {
@@ -477,6 +553,7 @@ pub(crate) fn row_to_logged_qso(
     };
     Ok(Ok(LoggedQso {
         id: r.get(0)?,
+        confirmed: Vec::new(),
         qso: Qso {
             call: r.get(1)?,
             qso_date: r.get(2)?,

--- a/rigflow-log/src/store.rs
+++ b/rigflow-log/src/store.rs
@@ -249,6 +249,23 @@ impl LogStore {
         crate::export::writer::count_with(&self.conn, filter)
     }
 
+    /// Contacts matching an export filter, newest first, capped at `limit`.
+    ///
+    /// Shares [`crate::export::query::build`] with the export writer, so the
+    /// contact view lists exactly the QSOs an export of the same filter writes.
+    pub fn query_contacts_filtered(
+        &self,
+        filter: &crate::export::ExportFilter,
+        limit: usize,
+    ) -> Result<Vec<LoggedQso>, LogError> {
+        crate::export::writer::query_with(
+            &self.conn,
+            filter,
+            limit,
+            crate::export::Sort::Reverse, // the view is always newest-first
+        )
+    }
+
     /// The current position of a named incremental-export bookmark.
     pub fn export_bookmark(&self, profile: &str) -> Result<Option<i64>, LogError> {
         crate::export::writer::read_bookmark(&self.conn, profile)

--- a/rigflow-log/src/store.rs
+++ b/rigflow-log/src/store.rs
@@ -1,0 +1,541 @@
+//! The SQLite-backed contact store — the source of truth.
+//!
+//! `LogStore` owns one `rusqlite::Connection` and the path to the append-only
+//! ADIF journal. It is single-owner by design (see the crate docs): the
+//! `Connection` is `!Sync`, and `synchronous=FULL` makes every commit fsync, so
+//! exactly one thread (the UI thread in the client) drives it.
+
+use std::collections::{BTreeMap, HashSet};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+use chrono::Utc;
+use rusqlite::{Connection, Transaction};
+use rusqlite::{OptionalExtension, params};
+
+use crate::error::LogError;
+use crate::model::{Qso, Station};
+use crate::{adif, dedupe, migrations, schema};
+
+pub struct LogStore {
+    conn: Connection,
+    journal_path: PathBuf,
+}
+
+/// Result of a successful insert.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InsertOutcome {
+    /// The new `qso.id`.
+    pub id: i64,
+    /// Whether the post-commit ADIF journal append succeeded. `false` means the
+    /// contact is safely in the DB but the journal is missing this record (the
+    /// journal is only ever a subset of the DB — a warning, not a failure).
+    pub journal_appended: bool,
+}
+
+/// A stored contact plus its row id, for the contact view.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LoggedQso {
+    pub id: i64,
+    pub qso: Qso,
+}
+
+/// In-memory "worked before?" index, loaded once at open and updated on each
+/// insert. Kept small: sets of what's been worked, not the full log.
+#[derive(Debug, Clone, Default)]
+pub struct WorkedBefore {
+    calls: HashSet<String>,
+    call_bands: HashSet<(String, String)>,
+    dxccs: HashSet<i64>,
+}
+
+impl WorkedBefore {
+    /// Never worked this callsign before.
+    pub fn is_new_call(&self, call: &str) -> bool {
+        !self.calls.contains(&call.trim().to_ascii_uppercase())
+    }
+    /// Worked this call, but never on this band.
+    pub fn is_new_band(&self, call: &str, band: &str) -> bool {
+        !self
+            .call_bands
+            .contains(&(call.trim().to_ascii_uppercase(), band.trim().to_string()))
+    }
+    /// Never worked this DXCC entity.
+    pub fn is_new_dxcc(&self, dxcc: i64) -> bool {
+        !self.dxccs.contains(&dxcc)
+    }
+    /// Fold a just-logged QSO into the index.
+    pub fn record(&mut self, q: &Qso) {
+        let call = q.call.trim().to_ascii_uppercase();
+        self.calls.insert(call.clone());
+        self.call_bands.insert((call, q.band.trim().to_string()));
+        if let Some(d) = q.dxcc {
+            self.dxccs.insert(d);
+        }
+    }
+}
+
+impl LogStore {
+    /// Open (creating if absent) the database at `db_path` and bind the ADIF
+    /// journal at `journal_path`. Applies PRAGMAs and migrates to the current
+    /// schema version. The journal file itself is created lazily on first
+    /// insert.
+    pub fn open(
+        db_path: impl AsRef<Path>,
+        journal_path: impl AsRef<Path>,
+    ) -> Result<Self, LogError> {
+        let conn = Connection::open(db_path.as_ref())?;
+        conn.execute_batch(schema::PRAGMAS)?;
+        migrations::migrate(&conn)?;
+        Ok(LogStore {
+            conn,
+            journal_path: journal_path.as_ref().to_path_buf(),
+        })
+    }
+
+    /// Open an in-memory database (tests, ephemeral use). The journal path is
+    /// still required but nothing is written to it unless an insert runs.
+    #[cfg(test)]
+    pub fn open_in_memory(journal_path: impl AsRef<Path>) -> Result<Self, LogError> {
+        let conn = Connection::open_in_memory()?;
+        // WAL is meaningless in-memory; still set foreign_keys + synchronous.
+        conn.execute_batch("PRAGMA foreign_keys = ON;")?;
+        migrations::migrate(&conn)?;
+        Ok(LogStore {
+            conn,
+            journal_path: journal_path.as_ref().to_path_buf(),
+        })
+    }
+
+    #[cfg(test)]
+    pub(crate) fn conn(&self) -> &Connection {
+        &self.conn
+    }
+
+    /// The schema version currently stamped on the database.
+    pub fn schema_version(&self) -> Result<i64, LogError> {
+        Ok(self
+            .conn
+            .query_row("PRAGMA user_version", [], |r| r.get(0))?)
+    }
+
+    /// Log a contact. Ordering is load-bearing:
+    /// `BEGIN → upsert station → INSERT qso → COMMIT → append one ADIF record`.
+    /// If the journal append fails we warn and keep the commit, preserving the
+    /// invariant that the journal is a subset of the DB (never the reverse).
+    ///
+    /// `station` provides `station_id` provenance and the `MY_*` snapshot; the
+    /// snapshot fills only `extra` keys not already present, so an imported
+    /// record's own `MY_*` (from WSJT-X or another log) is preserved.
+    pub fn insert(&mut self, qso: &Qso, station: &Station) -> Result<InsertOutcome, LogError> {
+        let mut q = qso.clone();
+        for (k, v) in station.my_adif_fields() {
+            q.extra.entry(k).or_insert(v);
+        }
+        let now = Utc::now().to_rfc3339();
+        let extra_json = serde_json::to_string(&q.extra)?;
+
+        let tx = self.conn.transaction()?;
+        let station_id = upsert_station(&tx, station)?;
+        tx.execute(
+            "INSERT INTO qso (call,qso_date,time_on,band,mode,submode,freq_hz,freq_rx_hz,\
+             band_rx,rst_sent,rst_rcvd,gridsquare,dxcc,station_id,extra,created_at,updated_at) \
+             VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12,?13,?14,?15,?16,?17)",
+            params![
+                q.call,
+                q.qso_date,
+                q.time_on,
+                q.band,
+                q.mode,
+                q.submode,
+                q.freq_hz.map(|v| v as i64),
+                q.freq_rx_hz.map(|v| v as i64),
+                q.band_rx,
+                q.rst_sent,
+                q.rst_rcvd,
+                q.gridsquare,
+                q.dxcc,
+                station_id,
+                extra_json,
+                now,
+                now,
+            ],
+        )?;
+        let id = tx.last_insert_rowid();
+        tx.commit()?;
+
+        // Journal append happens AFTER the DB commit. A failure here is a
+        // warning, not an error: the DB is authoritative.
+        let journal_appended = match self.append_journal(&q) {
+            Ok(()) => true,
+            Err(e) => {
+                eprintln!("rigflow-log: ADIF journal append failed (DB commit kept): {e}");
+                false
+            }
+        };
+        Ok(InsertOutcome {
+            id,
+            journal_appended,
+        })
+    }
+
+    /// Most-recent contacts first (by UTC date/time, then id). `limit` caps the
+    /// result. Structured so a later phase can add a filter clause without
+    /// touching callers.
+    pub fn query_contacts(&self, limit: usize) -> Result<Vec<LoggedQso>, LogError> {
+        let mut stmt = self.conn.prepare(
+            "SELECT id,call,qso_date,time_on,band,mode,submode,freq_hz,freq_rx_hz,band_rx,\
+             rst_sent,rst_rcvd,gridsquare,dxcc,extra \
+             FROM qso ORDER BY qso_date DESC, time_on DESC, id DESC LIMIT ?1",
+        )?;
+        let rows = stmt.query_map([limit as i64], row_to_logged_qso)?;
+        let mut out = Vec::new();
+        for r in rows {
+            out.push(r??);
+        }
+        Ok(out)
+    }
+
+    /// Find existing contacts that duplicate `q` under the natural key
+    /// (call+mode+band) within `window_secs`. Returned for the caller to
+    /// **warn** on — this never rejects an insert. Pass
+    /// [`dedupe::DEFAULT_WINDOW_SECS`] for the standard ±30-minute window.
+    pub fn find_duplicates(&self, q: &Qso, window_secs: i64) -> Result<Vec<LoggedQso>, LogError> {
+        let mut stmt = self.conn.prepare(
+            "SELECT id,call,qso_date,time_on,band,mode,submode,freq_hz,freq_rx_hz,band_rx,\
+             rst_sent,rst_rcvd,gridsquare,dxcc,extra \
+             FROM qso WHERE call = ?1 COLLATE NOCASE AND mode = ?2 AND band = ?3",
+        )?;
+        let rows = stmt.query_map(params![q.call, q.mode, q.band], row_to_logged_qso)?;
+        let mut out = Vec::new();
+        for r in rows {
+            let lq = r??;
+            if dedupe::within_window(q, &lq.qso, window_secs) {
+                out.push(lq);
+            }
+        }
+        Ok(out)
+    }
+
+    /// Build the "worked before?" index from the whole log.
+    pub fn load_worked_before(&self) -> Result<WorkedBefore, LogError> {
+        let mut wb = WorkedBefore::default();
+        let mut stmt = self.conn.prepare("SELECT call, band, dxcc FROM qso")?;
+        let rows = stmt.query_map([], |r| {
+            Ok((
+                r.get::<_, String>(0)?,
+                r.get::<_, String>(1)?,
+                r.get::<_, Option<i64>>(2)?,
+            ))
+        })?;
+        for r in rows {
+            let (call, band, dxcc) = r?;
+            let call = call.trim().to_ascii_uppercase();
+            wb.calls.insert(call.clone());
+            wb.call_bands.insert((call, band.trim().to_string()));
+            if let Some(d) = dxcc {
+                wb.dxccs.insert(d);
+            }
+        }
+        Ok(wb)
+    }
+
+    /// Append one ADIF record to the journal, creating it (with header) on first
+    /// write. `O_APPEND` + `fsync`; safe because this store is single-owner.
+    fn append_journal(&self, q: &Qso) -> Result<(), LogError> {
+        let fresh = !self.journal_path.exists();
+        let mut f = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&self.journal_path)?;
+        if fresh {
+            f.write_all(adif::adif_header().as_bytes())?;
+        }
+        f.write_all(adif::write_record(&adif::qso_to_record(q)).as_bytes())?;
+        f.sync_all()?;
+        Ok(())
+    }
+}
+
+/// Upsert the station row keyed by callsign, refreshing its location fields to
+/// the current profile, and return its id (provenance for `qso.station_id`).
+fn upsert_station(tx: &Transaction<'_>, s: &Station) -> Result<i64, LogError> {
+    let existing: Option<i64> = tx
+        .query_row(
+            "SELECT id FROM station WHERE station_call = ?1",
+            [&s.station_call],
+            |r| r.get(0),
+        )
+        .optional()?;
+    if let Some(id) = existing {
+        tx.execute(
+            "UPDATE station SET gridsquare=?2, my_state=?3, my_county=?4, cq_zone=?5, \
+             itu_zone=?6, name=?7 WHERE id=?1",
+            params![
+                id,
+                s.gridsquare,
+                s.my_state,
+                s.my_county,
+                s.cq_zone,
+                s.itu_zone,
+                s.name
+            ],
+        )?;
+        Ok(id)
+    } else {
+        tx.execute(
+            "INSERT INTO station (station_call,gridsquare,my_state,my_county,cq_zone,itu_zone,name) \
+             VALUES (?1,?2,?3,?4,?5,?6,?7)",
+            params![
+                s.station_call,
+                s.gridsquare,
+                s.my_state,
+                s.my_county,
+                s.cq_zone,
+                s.itu_zone,
+                s.name
+            ],
+        )?;
+        Ok(tx.last_insert_rowid())
+    }
+}
+
+fn row_to_logged_qso(r: &rusqlite::Row<'_>) -> rusqlite::Result<Result<LoggedQso, LogError>> {
+    let extra_json: String = r.get(14)?;
+    let extra: BTreeMap<String, String> = match serde_json::from_str(&extra_json) {
+        Ok(m) => m,
+        Err(e) => return Ok(Err(LogError::Json(e))),
+    };
+    Ok(Ok(LoggedQso {
+        id: r.get(0)?,
+        qso: Qso {
+            call: r.get(1)?,
+            qso_date: r.get(2)?,
+            time_on: r.get(3)?,
+            band: r.get(4)?,
+            mode: r.get(5)?,
+            submode: r.get(6)?,
+            freq_hz: r.get::<_, Option<i64>>(7)?.map(|v| v as u64),
+            freq_rx_hz: r.get::<_, Option<i64>>(8)?.map(|v| v as u64),
+            band_rx: r.get(9)?,
+            rst_sent: r.get(10)?,
+            rst_rcvd: r.get(11)?,
+            gridsquare: r.get(12)?,
+            dxcc: r.get(13)?,
+            extra,
+        },
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn station() -> Station {
+        Station {
+            station_call: "N0CALL".into(),
+            gridsquare: Some("EM12".into()),
+            name: Some("Dave".into()),
+            ..Default::default()
+        }
+    }
+
+    fn qso(call: &str, band: &str, time_on: &str) -> Qso {
+        Qso {
+            call: call.into(),
+            qso_date: "20260711".into(),
+            time_on: time_on.into(),
+            band: band.into(),
+            mode: "SSB".into(),
+            freq_hz: Some(14_207_000),
+            rst_sent: Some("59".into()),
+            rst_rcvd: Some("59".into()),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn insert_and_query_roundtrip() {
+        let mut s = LogStore::open_in_memory("/nonexistent-dir-abc/ignored.adi").unwrap();
+        // Journal path is a bogus dir so append fails; the DB commit must stand.
+        let out = s.insert(&qso("W1AW", "20m", "142300"), &station()).unwrap();
+        assert!(out.id > 0);
+        assert!(!out.journal_appended, "append to bogus path should fail");
+
+        let rows = s.query_contacts(10).unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].qso.call, "W1AW");
+        assert_eq!(rows[0].qso.band, "20m");
+        // MY_* snapshot landed in extra.
+        assert_eq!(
+            rows[0].qso.extra.get("MY_GRIDSQUARE"),
+            Some(&"EM12".to_string())
+        );
+        assert_eq!(
+            rows[0].qso.extra.get("STATION_CALLSIGN"),
+            Some(&"N0CALL".to_string())
+        );
+    }
+
+    #[test]
+    fn imported_my_fields_not_clobbered() {
+        let mut s = LogStore::open_in_memory("/nonexistent/ignored.adi").unwrap();
+        let mut q = qso("K5ZD", "20m", "142300");
+        q.extra.insert("MY_GRIDSQUARE".into(), "FN31".into()); // imported value
+        s.insert(&q, &station()).unwrap();
+        let rows = s.query_contacts(1).unwrap();
+        // Station grid is EM12, but the imported FN31 must be preserved.
+        assert_eq!(
+            rows[0].qso.extra.get("MY_GRIDSQUARE"),
+            Some(&"FN31".to_string())
+        );
+    }
+
+    #[test]
+    fn query_orders_recent_first() {
+        let mut s = LogStore::open_in_memory("/nonexistent/ignored.adi").unwrap();
+        s.insert(&qso("W1AW", "20m", "142300"), &station()).unwrap();
+        s.insert(&qso("K5ZD", "20m", "143000"), &station()).unwrap();
+        let rows = s.query_contacts(10).unwrap();
+        assert_eq!(rows[0].qso.call, "K5ZD"); // later time_on first
+        assert_eq!(rows[1].qso.call, "W1AW");
+    }
+
+    #[test]
+    fn worked_before_index() {
+        let mut s = LogStore::open_in_memory("/nonexistent/ignored.adi").unwrap();
+        let mut q = qso("W1AW", "20m", "142300");
+        q.dxcc = Some(291);
+        s.insert(&q, &station()).unwrap();
+
+        let wb = s.load_worked_before().unwrap();
+        assert!(!wb.is_new_call("w1aw")); // case-insensitive
+        assert!(wb.is_new_call("K5ZD"));
+        assert!(!wb.is_new_band("W1AW", "20m"));
+        assert!(wb.is_new_band("W1AW", "40m"));
+        assert!(!wb.is_new_dxcc(291));
+        assert!(wb.is_new_dxcc(1));
+    }
+
+    #[test]
+    fn find_duplicates_flags_near_repeat_only() {
+        let mut s = LogStore::open_in_memory("/nonexistent/ignored.adi").unwrap();
+        s.insert(&qso("W1AW", "20m", "142300"), &station()).unwrap();
+
+        // 5 minutes later, same call/mode/band → flagged.
+        let near = qso("w1aw", "20m", "142800");
+        assert_eq!(
+            s.find_duplicates(&near, crate::dedupe::DEFAULT_WINDOW_SECS)
+                .unwrap()
+                .len(),
+            1
+        );
+
+        // Hours later (contest re-work) → not flagged.
+        let later = qso("W1AW", "20m", "182300");
+        assert!(
+            s.find_duplicates(&later, crate::dedupe::DEFAULT_WINDOW_SECS)
+                .unwrap()
+                .is_empty()
+        );
+
+        // Different band → not flagged.
+        let other_band = qso("W1AW", "40m", "142400");
+        assert!(
+            s.find_duplicates(&other_band, crate::dedupe::DEFAULT_WINDOW_SECS)
+                .unwrap()
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn append_failure_keeps_commit() {
+        // A committed QSO with a failed journal append must still be a complete
+        // log on the next read — the crash-safety / subset invariant.
+        let mut s = LogStore::open_in_memory("/definitely/not/writable/x.adi").unwrap();
+        let out = s.insert(&qso("W1AW", "20m", "142300"), &station()).unwrap();
+        assert!(!out.journal_appended);
+        assert_eq!(s.query_contacts(10).unwrap().len(), 1);
+    }
+
+    #[test]
+    fn journal_written_with_header_then_records() {
+        let dir = std::env::temp_dir().join(format!("rigflow-jrnl-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let db = dir.join("rigflow_log.db");
+        let adi = dir.join("rigflow_log.adi");
+        std::fs::remove_file(&adi).ok();
+
+        {
+            let mut s = LogStore::open(&db, &adi).unwrap();
+            let out = s.insert(&qso("W1AW", "20m", "142300"), &station()).unwrap();
+            assert!(out.journal_appended);
+            s.insert(&qso("K5ZD", "20m", "143000"), &station()).unwrap();
+        }
+        let text = std::fs::read_to_string(&adi).unwrap();
+        assert!(text.starts_with("<ADIF_VER:5>"), "header must be first");
+        assert_eq!(text.matches("<EOH>").count(), 1, "exactly one header");
+        assert_eq!(text.matches("<EOR>").count(), 2, "one EOR per QSO");
+        assert!(text.contains("W1AW") && text.contains("K5ZD"));
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn open_migrates_to_current_version() {
+        let store = LogStore::open_in_memory("/tmp/ignored.adi").unwrap();
+        assert_eq!(store.schema_version().unwrap(), schema::SCHEMA_VERSION);
+    }
+
+    #[test]
+    fn reopen_on_disk_is_idempotent() {
+        let dir = std::env::temp_dir().join(format!("rigflow-log-test-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let db = dir.join("rigflow_log.db");
+        let adi = dir.join("rigflow_log.adi");
+
+        {
+            let s = LogStore::open(&db, &adi).unwrap();
+            assert_eq!(s.schema_version().unwrap(), schema::SCHEMA_VERSION);
+        }
+        // Reopen: migrate() must be a no-op and tables must still be there.
+        {
+            let s = LogStore::open(&db, &adi).unwrap();
+            assert_eq!(s.schema_version().unwrap(), schema::SCHEMA_VERSION);
+            let n: i64 = s
+                .conn()
+                .query_row(
+                    "SELECT count(*) FROM sqlite_master WHERE type='table' AND name='qso'",
+                    [],
+                    |r| r.get(0),
+                )
+                .unwrap();
+            assert_eq!(n, 1);
+        }
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn tables_and_indexes_exist() {
+        let s = LogStore::open_in_memory("/tmp/ignored.adi").unwrap();
+        for tbl in ["station", "qso", "qso_service", "sync_state"] {
+            let n: i64 = s
+                .conn()
+                .query_row(
+                    "SELECT count(*) FROM sqlite_master WHERE type='table' AND name=?1",
+                    [tbl],
+                    |r| r.get(0),
+                )
+                .unwrap();
+            assert_eq!(n, 1, "table {tbl} missing");
+        }
+        let idx: i64 = s
+            .conn()
+            .query_row(
+                "SELECT count(*) FROM sqlite_master WHERE type='index' AND name='idx_qso_match'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(idx, 1);
+    }
+}

--- a/rigflow-log/src/store.rs
+++ b/rigflow-log/src/store.rs
@@ -454,6 +454,28 @@ impl LogStore {
         Ok(())
     }
 
+    /// Mark each QSO in `qso_ids` as uploaded to `service` now. Upserts the
+    /// `qso_service` row (setting `uploaded_at`), so it composes with a
+    /// confirmation already recorded for the same `(qso_id, service)`. One
+    /// transaction for the whole batch. After this, the `not_uploaded_to` export
+    /// filter excludes these QSOs for that service.
+    pub fn mark_uploaded(&mut self, qso_ids: &[i64], service: &str) -> Result<(), LogError> {
+        if qso_ids.is_empty() {
+            return Ok(());
+        }
+        let now = Utc::now().to_rfc3339();
+        let tx = self.conn.transaction()?;
+        for &id in qso_ids {
+            tx.execute(
+                "INSERT INTO qso_service (qso_id, service, uploaded_at) VALUES (?1, ?2, ?3) \
+                 ON CONFLICT(qso_id, service) DO UPDATE SET uploaded_at = excluded.uploaded_at",
+                params![id, service, now],
+            )?;
+        }
+        tx.commit()?;
+        Ok(())
+    }
+
     /// When `service` last ran a download sync (RFC3339), or `None` if never.
     pub fn sync_last_run(&self, service: &str) -> Result<Option<String>, LogError> {
         Ok(self
@@ -950,6 +972,45 @@ mod tests {
         );
         // Services are independent.
         assert_eq!(s.sync_marker("eqsl").unwrap(), None);
+    }
+
+    #[test]
+    fn mark_uploaded_records_and_composes_with_a_confirmation() {
+        let mut s = LogStore::open_in_memory("/nonexistent/ignored.adi").unwrap();
+        let a = s.insert(&qso("W1AW", "20m", "142300"), &station()).unwrap();
+        let b = s.insert(&qso("K5ZD", "20m", "143000"), &station()).unwrap();
+
+        // A confirmation already exists for A on eqsl.
+        s.commit_import(
+            &[],
+            &[crate::import::Confirmation {
+                qso_id: a.id,
+                service: "eqsl".into(),
+                confirmed_at: Some("20260723".into()),
+            }],
+            &station(),
+        )
+        .unwrap();
+
+        s.mark_uploaded(&[a.id, b.id], "eqsl").unwrap();
+
+        // A's row now carries BOTH confirmed_at and uploaded_at; B's just uploaded.
+        let row = |id: i64, col: &str| -> Option<String> {
+            s.conn()
+                .query_row(
+                    &format!("SELECT {col} FROM qso_service WHERE qso_id=?1 AND service='eqsl'"),
+                    [id],
+                    |r| r.get(0),
+                )
+                .unwrap()
+        };
+        assert_eq!(row(a.id, "confirmed_at").as_deref(), Some("20260723"));
+        assert!(row(a.id, "uploaded_at").is_some());
+        assert!(row(b.id, "uploaded_at").is_some());
+        assert!(row(b.id, "confirmed_at").is_none());
+
+        // Empty id list is a no-op, not an error.
+        s.mark_uploaded(&[], "eqsl").unwrap();
     }
 
     #[test]

--- a/rigflow-log/src/store.rs
+++ b/rigflow-log/src/store.rs
@@ -420,6 +420,53 @@ impl LogStore {
         Ok(())
     }
 
+    /// The last download marker recorded for an online `service` (e.g. `lotw`),
+    /// or `None` if it has never synced. For LoTW this is the `APP_LoTW_LASTQSL`
+    /// timestamp of the newest confirmation seen last run; the next download
+    /// passes it as `qso_qslsince` so only newer confirmations come back.
+    pub fn sync_marker(&self, service: &str) -> Result<Option<String>, LogError> {
+        Ok(self
+            .conn
+            .query_row(
+                "SELECT last_marker FROM sync_state WHERE service = ?1",
+                [service],
+                |r| r.get(0),
+            )
+            .optional()?
+            .flatten())
+    }
+
+    /// Record a download marker for `service`, stamping the run time. Upsert on
+    /// the service key. Unlike the export bookmark this is not forced monotonic:
+    /// the server (LoTW) is authoritative for its own "last QSL" timestamp, and a
+    /// re-sync that returns an equal or slightly older marker is harmless because
+    /// applying the report is idempotent (already-recorded confirmations skip).
+    pub fn set_sync_marker(&mut self, service: &str, marker: Option<&str>) -> Result<(), LogError> {
+        let now = Utc::now().to_rfc3339();
+        self.conn.execute(
+            "INSERT INTO sync_state (service, last_marker, last_run_at) \
+             VALUES (?1, ?2, ?3) \
+             ON CONFLICT(service) DO UPDATE SET \
+               last_marker = excluded.last_marker, \
+               last_run_at = excluded.last_run_at",
+            params![service, marker, now],
+        )?;
+        Ok(())
+    }
+
+    /// When `service` last ran a download sync (RFC3339), or `None` if never.
+    pub fn sync_last_run(&self, service: &str) -> Result<Option<String>, LogError> {
+        Ok(self
+            .conn
+            .query_row(
+                "SELECT last_run_at FROM sync_state WHERE service = ?1",
+                [service],
+                |r| r.get(0),
+            )
+            .optional()?
+            .flatten())
+    }
+
     /// Append records to the journal, creating it (with header) on first write.
     /// `O_APPEND` + a single `fsync` for the whole batch; safe because this store
     /// is single-owner.
@@ -877,6 +924,32 @@ mod tests {
             "the edit is not written to the journal"
         );
         std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn sync_marker_round_trips_and_upserts() {
+        let mut s = LogStore::open_in_memory("/nonexistent/ignored.adi").unwrap();
+        // Never synced.
+        assert_eq!(s.sync_marker("lotw").unwrap(), None);
+        assert_eq!(s.sync_last_run("lotw").unwrap(), None);
+
+        s.set_sync_marker("lotw", Some("2026-07-23 20:45:06"))
+            .unwrap();
+        assert_eq!(
+            s.sync_marker("lotw").unwrap().as_deref(),
+            Some("2026-07-23 20:45:06")
+        );
+        assert!(s.sync_last_run("lotw").unwrap().is_some());
+
+        // Upsert on the service key: a second run replaces the marker.
+        s.set_sync_marker("lotw", Some("2026-07-24 09:00:00"))
+            .unwrap();
+        assert_eq!(
+            s.sync_marker("lotw").unwrap().as_deref(),
+            Some("2026-07-24 09:00:00")
+        );
+        // Services are independent.
+        assert_eq!(s.sync_marker("eqsl").unwrap(), None);
     }
 
     #[test]

--- a/rigflow-log/src/wsjtx.rs
+++ b/rigflow-log/src/wsjtx.rs
@@ -1,0 +1,205 @@
+//! Decoder for the WSJT-X UDP telemetry protocol (the datagrams it sends to
+//! UDP port 2237).
+//!
+//! The wire format is a Qt `QDataStream` `NetworkMessage`: big-endian, framed
+//! as `quint32 magic (0xADBCCBDA)`, `quint32 schema`, `quint32 message_type`,
+//! then a UTF-8 client id, then message-specific fields. Strings are QByteArrays
+//! (a `quint32` byte length then the bytes; length `0xFFFFFFFF` = null).
+//! Verified against WSJT-X `NetworkMessage.hpp`.
+//!
+//! We decode the **`LoggedADIF`** message (type 12), which carries the contact
+//! as an ADIF string we feed straight into [`crate::adif`]. WSJT-X emits this
+//! alongside the typed `QSOLogged` (type 5) for every logged QSO; we
+//! deliberately ingest only `LoggedADIF` so a contact is never logged twice.
+//! Every other message type is reported as [`WsjtxMessage::Other`] for the
+//! caller to ignore.
+
+/// WSJT-X datagram magic number.
+pub const MAGIC: u32 = 0xADBC_CBDA;
+
+// Message type discriminants (NetworkMessage.hpp).
+const MSG_QSO_LOGGED: u32 = 5;
+const MSG_LOGGED_ADIF: u32 = 12;
+
+/// A decoded WSJT-X message.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum WsjtxMessage {
+    /// `LoggedADIF` (type 12): the logged contact as an ADIF document.
+    LoggedAdif { client_id: String, adif: String },
+    /// `QSOLogged` (type 5): recognized but intentionally not ingested (the
+    /// `LoggedADIF` for the same QSO is used instead).
+    QsoLoggedIgnored,
+    /// Any other message type (Heartbeat, Status, Decode, …).
+    Other { message_type: u32 },
+}
+
+/// Decode a single datagram. Returns `None` if it isn't a WSJT-X message (bad
+/// magic) or is truncated/malformed.
+pub fn decode(buf: &[u8]) -> Option<WsjtxMessage> {
+    let mut r = Reader::new(buf);
+    if r.u32()? != MAGIC {
+        return None;
+    }
+    let _schema = r.u32()?;
+    let msg_type = r.u32()?;
+    let client_id = r.qstr()?; // present on every message
+
+    match msg_type {
+        MSG_LOGGED_ADIF => {
+            let adif = r.qstr()?;
+            Some(WsjtxMessage::LoggedAdif { client_id, adif })
+        }
+        MSG_QSO_LOGGED => Some(WsjtxMessage::QsoLoggedIgnored),
+        other => Some(WsjtxMessage::Other {
+            message_type: other,
+        }),
+    }
+}
+
+/// Minimal big-endian QDataStream reader. Every method returns `None` on
+/// underflow so a truncated packet decodes to `None` rather than panicking.
+struct Reader<'a> {
+    buf: &'a [u8],
+    pos: usize,
+}
+
+impl<'a> Reader<'a> {
+    fn new(buf: &'a [u8]) -> Self {
+        Reader { buf, pos: 0 }
+    }
+
+    fn take(&mut self, n: usize) -> Option<&'a [u8]> {
+        let end = self.pos.checked_add(n)?;
+        let slice = self.buf.get(self.pos..end)?;
+        self.pos = end;
+        Some(slice)
+    }
+
+    fn u32(&mut self) -> Option<u32> {
+        let b = self.take(4)?;
+        Some(u32::from_be_bytes([b[0], b[1], b[2], b[3]]))
+    }
+
+    /// A QByteArray/utf8 string: `quint32` length then bytes. Length
+    /// `0xFFFFFFFF` denotes a null string, decoded as empty. Invalid UTF-8 is
+    /// decoded lossily rather than rejected.
+    fn qstr(&mut self) -> Option<String> {
+        let len = self.u32()?;
+        if len == 0xFFFF_FFFF {
+            return Some(String::new());
+        }
+        let bytes = self.take(len as usize)?;
+        Some(String::from_utf8_lossy(bytes).into_owned())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Test datagram builder mirroring WSJT-X's big-endian QDataStream framing.
+    struct Builder {
+        buf: Vec<u8>,
+    }
+    impl Builder {
+        fn new(msg_type: u32) -> Self {
+            let mut buf = Vec::new();
+            buf.extend_from_slice(&MAGIC.to_be_bytes());
+            buf.extend_from_slice(&3u32.to_be_bytes()); // schema 3
+            buf.extend_from_slice(&msg_type.to_be_bytes());
+            Builder { buf }
+        }
+        fn qstr(mut self, s: &str) -> Self {
+            self.buf.extend_from_slice(&(s.len() as u32).to_be_bytes());
+            self.buf.extend_from_slice(s.as_bytes());
+            self
+        }
+        fn null_qstr(mut self) -> Self {
+            self.buf.extend_from_slice(&0xFFFF_FFFFu32.to_be_bytes());
+            self
+        }
+        fn build(self) -> Vec<u8> {
+            self.buf
+        }
+    }
+
+    const SAMPLE_ADIF: &str = "<ADIF_VER:5>3.1.6<EOH><CALL:4>W1AW<QSO_DATE:8>20260711<TIME_ON:6>142300\
+         <BAND:3>20m<MODE:3>FT8<FREQ:9>14.074000<EOR>";
+
+    #[test]
+    fn decode_logged_adif() {
+        let dg = Builder::new(MSG_LOGGED_ADIF)
+            .qstr("WSJT-X")
+            .qstr(SAMPLE_ADIF)
+            .build();
+        match decode(&dg) {
+            Some(WsjtxMessage::LoggedAdif { client_id, adif }) => {
+                assert_eq!(client_id, "WSJT-X");
+                assert_eq!(adif, SAMPLE_ADIF);
+            }
+            other => panic!("expected LoggedAdif, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn logged_adif_feeds_the_parser() {
+        let dg = Builder::new(MSG_LOGGED_ADIF)
+            .qstr("WSJT-X")
+            .qstr(SAMPLE_ADIF)
+            .build();
+        let WsjtxMessage::LoggedAdif { adif, .. } = decode(&dg).unwrap() else {
+            panic!("expected LoggedAdif");
+        };
+        let qsos = crate::adif::parse_adif_to_qsos(&adif).unwrap();
+        assert_eq!(qsos.len(), 1);
+        assert_eq!(qsos[0].call, "W1AW");
+        assert_eq!(qsos[0].band, "20m");
+        assert_eq!(qsos[0].mode, "FT8");
+        assert_eq!(qsos[0].freq_hz, Some(14_074_000));
+    }
+
+    #[test]
+    fn null_client_id_is_handled() {
+        let dg = Builder::new(MSG_LOGGED_ADIF)
+            .null_qstr()
+            .qstr(SAMPLE_ADIF)
+            .build();
+        assert!(matches!(decode(&dg), Some(WsjtxMessage::LoggedAdif { .. })));
+    }
+
+    #[test]
+    fn qso_logged_is_recognized_but_ignored() {
+        let dg = Builder::new(MSG_QSO_LOGGED).qstr("WSJT-X").build();
+        assert_eq!(decode(&dg), Some(WsjtxMessage::QsoLoggedIgnored));
+    }
+
+    #[test]
+    fn status_message_is_other() {
+        let dg = Builder::new(1).qstr("WSJT-X").build();
+        assert_eq!(decode(&dg), Some(WsjtxMessage::Other { message_type: 1 }));
+    }
+
+    #[test]
+    fn wrong_magic_is_none() {
+        let mut dg = Builder::new(MSG_LOGGED_ADIF).qstr("WSJT-X").build();
+        dg[0] = 0x00; // corrupt the magic
+        assert_eq!(decode(&dg), None);
+    }
+
+    #[test]
+    fn truncated_is_none() {
+        let dg = Builder::new(MSG_LOGGED_ADIF)
+            .qstr("WSJT-X")
+            .qstr(SAMPLE_ADIF)
+            .build();
+        // Cut the ADIF string's declared length short.
+        assert_eq!(decode(&dg[..dg.len() - 10]), None);
+        // Just the header, no id/payload.
+        assert_eq!(decode(&dg[..12]), None);
+    }
+
+    #[test]
+    fn empty_buffer_is_none() {
+        assert_eq!(decode(&[]), None);
+    }
+}


### PR DESCRIPTION
Contact logging: local log, ADIF, and online QSL sync (LoTW / eQSL / QRZ)                                                                                             
                                                                                                                                                                        
  Summary                                                                                                                                                               
                                                                                                                                                                        
  Adds a complete contact-logging subsystem to rigflow: a per-operator SQLite log, ADIF import/export, WSJT-X and manual capture, and two-way online QSL sync with      
  LoTW, eQSL, and QRZ Logbook — with confirmations shown as badges in the contact view. This is self-contained, additive, and does not touch the RF/DSP/media paths.    
                                                                                                                                                                        
  What's included                                                                                                                                                       
                                                                                                                                                                        
  New crate rigflow-log — a leaf crate (rusqlite / chrono / serde; no core / egui / ALSA / network), so the whole model is unit-testable off-hardware:                  
  - SQLite store (schema v2, with v1→v2 migration that runs silently on first open) + an append-only ADIF journal.                                                      
  - model / normalize (mode + band canonicalization, band-from-freq) / adif (hand-rolled parser + writer) / display / dedupe / capture / wsjtx / export / import.       
                                                                                                                                                                        
  Capture                                                                                                                                                               
  - Manual entry (L) freezing the radio snapshot (freq/mode/split/time) at open.                                                                                        
  - WSJT-X LoggedADIF ingest via the existing UDP listener.                                                                                                             
  - Dedupe on a ±30-minute call+band+mode key, shared across all capture paths.                                                                                         
                                                                                                                                                                        
  ADIF import / export                                                                                                                                                  
  - Import is plan → preview → commit: a read-only plan reports "N records · M to import · K duplicates · U unusable" before anything is written; commit is one         
  transaction + one journal fsync, all-or-nothing.                                                                                                                      
  - Export with filters, streaming writer, field profiles (Full/Core/Custom), and incremental bookmarks.                                                                
  - One filter shared between the contact view and the export — you see exactly what you'll export.                                                                     
                                                                                                                                                                        
  Online QSL sync (new)                                                                                                                                                 
  - LoTW — incremental confirmation download (qso_qslsince, cursored on APP_LoTW_LASTQSL).                                                                              
  - eQSL — upload (ADIF batch) + inbox confirmation download.                                                                                                           
  - QRZ Logbook — upload (one INSERT per record) + confirmed-only paged download (STATUS:CONFIRMED + AFTERLOGID).                                                       
  - Downloads auto-commit confirmations into a qso_service table (never insert new contacts); confirmations are shown as green LoTW / eQSL / QRZ badges in the contact  
  view and round-trip through export.                                                                                                                                   
  - Credentials in the OS keyring (macOS Keychain / Linux Secret Service) with a per-operator 0600-file fallback.                                                       
                                                                                                                                                                        
  Contact management & UI                                                                                                                                               
  - Contact view (V) with call-worked-before lookup, edit, delete, and multi-select (export selection / bulk delete).                                                   
  - Filter, export, import, and sync windows; human-readable dates/times.                                                                                               
  - Edit/delete are DB-only — the .adi journal stays strictly append-only (DB is the source of truth).                                                                  
                                                                                                                                                                        
  Design notes (load-bearing)                                                                                                                                           
                                                                                                                                                                        
  - DB is authoritative; the journal is append-only history. Edit/delete mutate SQLite only; the journal is never rewritten. Export always derives from the DB.         
  - Confirmations are per (QSO, service). Detection is per-record (LOTW_QSL_RCVD, EQSL_AG/APP_EQSL_*, APP_QRZLOG_STATUS=C, generic QSL_RCVD); a service download        
  applies confirmations only and ignores non-confirmation records; tallies count distinct QSOs, not raw fetch records.                                                  
  - Sync runs off the UI thread on the existing export-worker seam; the read-only plan/HTTP happen there, the UI thread commits.                                        
  - Passwords/keys never appear in logs, status lines, or error strings.                                                                                                
                                                                                                                                                                        
  New dependencies                                                                                                                                                      
                                                                                                                                                                        
  rusqlite, chrono, serde (rigflow-log); ureq and keyring (client, for online sync).  

Testing                                                                                                                                                               
                                                                                                                                                                        
  - 145 rigflow-log unit/integration tests, clippy-clean, covering parse/normalize/dedupe/store/import/export/confirmation detection.                                   
  - The three services were exercised against live LoTW / eQSL / QRZ accounts during development and iterated (auth field names, eQSL's relocated download path +       
  HTML-escaped/QRZ-encoded ADIF, QRZ per-record INSERT, fetch strategy, distinct-QSO counting).                                                                         
  - The client is type-checked but not run/linked here (CI/sandbox has no ALSA/libdbus). Its lotw/eqsl/qrz/credentials unit tests and the full UI need a run on a real  
  machine — the author is doing on-air verification before merge.                                                                                                       
                                                                                                                                                                        
  Compatibility / migration                                                                                                                                             
                                                                                                                                                                        
  - First open of an existing operator migrates the log schema v1→v2 automatically. Recommend backing up ~/.config/rigflow/operators before first run.                  
  - Additive only: RF/DSP/media, digital, and rig-control paths are untouched.                                                                                          
                                                                                                                                                                        
  Out of scope / follow-ups                                                                                                                                             
                                                                                                                                                                        
  Roadmap captured in docs/release-review/feature-gap-proposal.md (callbook lookup and DX-cluster spots are the proposed next increment). LoTW upload is intentionally  
  not included (needs TQSL + certificate).                            