### PR TITLE
Release 1.0.0 — contact logging, callbook lookup, and DX cluster 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,11 +21,12 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      # rigflow-client links ALSA (cpal); rigflow-server links libusb (RTL-SDR driver).
+      # rigflow-client links ALSA (cpal) and D-Bus (keyring credential storage);
+      # rigflow-server links libusb (RTL-SDR driver).
       - name: Install system libraries
         run: |
           sudo apt-get update
-          sudo apt-get install -y libasound2-dev libusb-1.0-0-dev
+          sudo apt-get install -y libasound2-dev libusb-1.0-0-dev libdbus-1-dev
 
       - name: Install Rust (stable)
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,13 +55,14 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      # Linux: client links ALSA, server links libusb. macOS uses CoreAudio
-      # (built in) and the client needs no extra libraries.
+      # Linux: client links ALSA + D-Bus (keyring credential storage), server
+      # links libusb. macOS uses CoreAudio + the Keychain (both built in) and the
+      # client needs no extra libraries.
       - name: Install system libraries (Linux)
         if: matrix.os == 'linux'
         run: |
           sudo apt-get update
-          sudo apt-get install -y libasound2-dev libusb-1.0-0-dev
+          sudo apt-get install -y libasound2-dev libusb-1.0-0-dev libdbus-1-dev
 
       - name: Install Rust (stable)
         uses: dtolnay/rust-toolchain@stable

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3707,7 +3707,7 @@ dependencies = [
 
 [[package]]
 name = "rigflow-client"
-version = "0.1.5"
+version = "1.0.0"
 dependencies = [
  "cpal",
  "eframe",
@@ -3732,7 +3732,7 @@ dependencies = [
 
 [[package]]
 name = "rigflow-core"
-version = "0.1.5"
+version = "1.0.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -3740,7 +3740,7 @@ dependencies = [
 
 [[package]]
 name = "rigflow-log"
-version = "0.1.5"
+version = "1.0.0"
 dependencies = [
  "chrono",
  "rusqlite",
@@ -3750,7 +3750,7 @@ dependencies = [
 
 [[package]]
 name = "rigflow-probe"
-version = "0.1.5"
+version = "1.0.0"
 dependencies = [
  "clap",
  "env_logger",
@@ -3768,7 +3768,7 @@ dependencies = [
 
 [[package]]
 name = "rigflow-protocol"
-version = "0.1.5"
+version = "1.0.0"
 dependencies = [
  "rigflow-core",
  "serde",
@@ -3777,7 +3777,7 @@ dependencies = [
 
 [[package]]
 name = "rigflow-server"
-version = "0.1.5"
+version = "1.0.0"
 dependencies = [
  "axum",
  "env_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.1.5"
+version = "1.0.0"
 license = "MIT"
 authors = ["David Bourgoyne"]
 repository = "https://github.com/dbourgoyne/rigflow"

--- a/README.md
+++ b/README.md
@@ -19,15 +19,24 @@ operate from your laptop.
 **Receive**
 - Modes: WFM, NFM, AM, USB, LSB, CW (CWU/CWL), and **Data** (USB for FT8/digital)
 - Real-time spectrum + waterfall, click/scroll/keyboard tuning, bookmarks
-- Noise reduction (NR2), AGC, squelch; per-operator settings and presets
+- **Dual-watch** (two receivers at once), **split**, and **RIT/XIT** (Hermes Lite 2)
+- Noise reduction (NR2), AGC, squelch, auto-notch, noise blanker; per-operator settings and presets
 - RX IQ recording and playback
 
 **Transmit** (Hermes Lite 2)
-- **SSB** from your microphone (USB/LSB), with a soft limiter + speech compressor
+- **SSB** from your microphone (USB/LSB), with a soft limiter + speech compressor, plus a **voice keyer**
 - **CW** via straight-key (Space bar), or Text-to-CW with F1–F4 memory macros and sidetone
 - **Digital (FT8 / WSJT-X)** — on **Linux** via virtual audio (PipeWire/Pulse) **or** TCI; on
   **macOS** via TCI only (experimental). An in-app setup window shows the exact settings
 - Built-in two-tone and tune/SWR test aids
+
+**Log & operate**
+- Built-in **contact log** with worked-before hints, a filterable Contacts view, edit/delete, and
+  automatic logging of WSJT-X/FT8 QSOs
+- **ADIF import/export**, plus direct **LoTW / eQSL / QRZ** upload and confirmation sync
+- **Callbook lookup** (QRZ / HamQTH / Callook + an offline prefix baseline) auto-fills name, QTH,
+  grid, and DXCC as you log
+- **DX cluster** — live spots on the waterfall and a click-to-tune band map
 
 **Station**
 - Remote operation over the network; multiple radios, one client

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -2,6 +2,54 @@
 
 ---
 
+## v1.0.0 — Contact logging, callbook lookup, and DX cluster
+
+The 1.0 release turns Rigflow into a complete operating position: alongside receive, transmit, and
+digital, you can now log contacts, look callsigns up, and see cluster spots on the waterfall.
+
+> These headline features live in the **client** (a local log, callbook lookups, and the cluster
+> connection), so they work against an existing v0.1.5 server — but installing the matching **1.0**
+> client + server pair is recommended.
+
+**Contact logging**
+
+- **Built-in logbook.** Press **`L`** to log a contact — frequency and mode are captured
+  automatically, and the time is stamped **when you press Log** (so you can open the window early in a
+  pileup). **Worked-before hints** flag new calls, new bands, and dupes as you type.
+- **WSJT-X / FT8 auto-logging.** QSOs logged in WSJT-X are ingested into the active operator's log
+  automatically, duplicates skipped.
+- **Contacts view.** Filter, edit any field (including date/time), delete, and multi-select; the view
+  filter is **shared with export**, so what you see is what you send.
+- **ADIF import/export.** Plan → preview → commit import (skips dupes, imports confirmations);
+  streaming export with an incremental "since last export" mode. A local SQLite log plus an
+  append-only ADIF journal.
+- **Online sync.** Upload to and download confirmations from **LoTW**, **eQSL**, and **QRZ Logbook**;
+  confirmation badges in the Contacts view. Credentials are kept in the OS **secure keyring** (with an
+  encrypted-file fallback) and never written to logs or ADIF.
+- **Station profile.** A Station panel for your callsign, grid, and state/county/zones — written as
+  the `MY_*` fields on every contact.
+
+**Callbook lookup**
+
+- As you type a callsign, auto-fills **name, QTH, grid, state/county, country, and DXCC/zones**.
+- Providers, tried in priority order: **QRZ XML** (qrz.com login + XML subscription), **HamQTH**
+  (free), and **Callook** (US, no account), over an always-on **offline prefix baseline** (DXCC +
+  zones, no network). Your typed values always win.
+
+**DX cluster**
+
+- Connect to a DX-cluster node and see live spots **on the spectrum/waterfall** and in a scrollable,
+  click-to-tune **band map**. Built-in node list (VE7CC / NC7J / W3LPL / HRD) or a custom host.
+- Filter by current band and mode; spots age out; auto-reconnect on drop.
+
+**Quality of life**
+
+- Callbook location shown in plain language (`via QRZ · Chicago, IL · United States`) instead of just
+  a grid square.
+- Full user documentation for logging, callbook, and DX cluster in the Operator guide.
+
+---
+
 ## v0.1.5 — Dual-watch, split / RIT-XIT, band memory, and safety locks
 
 > **⚠ Upgrade the client and server together.** This release extends the client↔server protocol

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -28,13 +28,15 @@ sudo apt install libusb-1.0-0
 ```
 *(Fedora: `libusb1` · Arch: `libusb`)*
 
-**Client (Linux):** the UI plays audio through ALSA.
+**Client (Linux):** the UI plays audio through ALSA, and stores callbook/logging-service credentials
+in the desktop **secret service** over D-Bus (with an encrypted-file fallback if none is running).
 
 ```bash
-sudo apt install libasound2
+sudo apt install libasound2 libdbus-1-3
 ```
+*(Fedora: `alsa-lib dbus-libs` · Arch: `alsa-lib dbus`)*
 
-**Client (macOS):** audio uses CoreAudio — nothing to install.
+**Client (macOS):** audio uses CoreAudio and credentials go to the login Keychain — nothing to install.
 
 **Digital modes (WSJT-X/FT8):** On **Linux** you can use either the **virtual-audio** method —
 which needs **PipeWire** (or PulseAudio), standard on modern Linux desktops — **or** the **TCI**
@@ -61,11 +63,12 @@ sudo apt install build-essential pkg-config libusb-1.0-0-dev
 ```
 *(Fedora: `gcc pkgconf-pkg-config libusb1-devel` · Arch: `base-devel libusb`)*
 
-**Client (Linux)** — the ALSA **dev** headers:
+**Client (Linux)** — the ALSA and D-Bus **dev** headers:
 
 ```bash
-sudo apt install build-essential pkg-config libasound2-dev
+sudo apt install build-essential pkg-config libasound2-dev libdbus-1-dev
 ```
+*(Fedora: `alsa-lib-devel dbus-devel` · Arch: `alsa-lib dbus`)*
 
 **Client (macOS)** — the Xcode Command Line Tools: `xcode-select --install`.
 

--- a/docs/operator-guide.md
+++ b/docs/operator-guide.md
@@ -20,10 +20,13 @@ display for that radio and operator.
 
 ## Screen layout
 
-- **Left panel** — all controls, grouped into collapsible sections (Radio Operator, Server, Radios,
-  **Radio Control**, **Source Control**, Waterfall, Bookmarks).
+- **Left panel** — all controls, grouped into collapsible sections (Radio Operator, Station, Server,
+  Radios, **Radio Control**, **Source Control**, Waterfall, Bookmarks, **DX Cluster**).
 - **Center** — a status bar (frequency, mode, S-meter, dBm, TX/RX, SWR) above the **spectrum** and
   **waterfall**.
+- **Logbook windows** open on demand rather than living in the left panel: **`L`** opens the
+  log-entry window and **`V`** toggles the **Contacts** view, whose toolbar holds import, export,
+  online sync, and the callbook settings.
 
 Advanced and diagnostic controls are hidden by default. Tick **"Show advanced & diagnostics
 controls"** at the bottom of Radio Control (and Source Control) to reveal them.
@@ -85,6 +88,30 @@ adaptive or manual normalization (top/range in dB).
 
 ---
 
+## Dual-watch, split & RIT/XIT (Hermes Lite 2)
+
+On hardware that supports it, Rigflow can run **two receivers at once** and transmit **split**. These
+controls appear in the **VFO** section (and inline on the status bar); they're hidden on receive-only
+sources.
+
+- **Dual-watch — two receivers.** Enable a second receiver (**VFO B**) alongside VFO A. The center
+  pane splits into stacked spectrum + waterfall panes, and you hear **A in the left ear, B in the
+  right**. Each VFO has its own frequency, mode, and full receive processing (filter, pitch, squelch,
+  NR2, noise blanker, auto-notch, AGC, deemphasis). An **Active VFO: A | B** selector points the
+  Receive controls at the receiver you're adjusting; both volumes stay visible so you can mix the two
+  live.
+- **Split.** Transmit on the selected TX VFO while listening on the other — the classic DX-split
+  setup. The transmitting VFO is marked **▶TX** on the status bar.
+- **RIT / XIT.** A per-VFO **RIT** offset nudges your *receive* frequency without moving your transmit
+  frequency (chasing a drifting station); **XIT** offsets your *transmit* frequency the same way.
+- **Hotkeys:** **`X`** swaps TX focus between A and B, **`=`** copies the active VFO to the other
+  (A=B), and **`B`** bookmarks the current frequency.
+
+Each VFO keeps its own tuning **Snap** step (see above), and the per-band memory restores frequency +
+mode as you move around.
+
+---
+
 ## Transmitting — SSB (voice)
 
 1. Set the mode to **USB** or **LSB**.
@@ -94,6 +121,14 @@ adaptive or manual normalization (top/range in dB).
 
 Optional **TX processing** (under **Advanced**): a soft **limiter** (peak protection) and a **speech
 compressor** (more average talk power). Leave the limiter on; add compression to taste.
+
+### Voice keyer
+
+To save your voice on a long CQ or a pileup, record a clip once and let Rigflow send it. In the
+**Transmit** section you can **record** a short message from your microphone, **preview** it (played
+locally, off-air), **delete** it, and **transmit** it — Rigflow keys the radio and plays the clip
+through the normal SSB transmit path. Clips are stored **per operator**, so each operator keeps their
+own CQ. It's ordinary voice transmit under the hood, so the same focus/PTT safety rules below apply.
 
 > The Space bar (SSB and CW) only keys when no text field has focus (so it doesn't fight typing), and
 > transmit **stops if the client window loses focus** — switching to another window always drops you
@@ -182,6 +217,130 @@ tuning. This applies to both the virtual-audio (rigctld) and TCI paths.
 
 ---
 
+## Logging contacts
+
+Rigflow has a built-in contact log (an electronic logbook). Contacts are stored per operator in a
+local database, and everything exports to standard **ADIF** for LoTW, eQSL, QRZ, or any other logger.
+
+### Set your station first
+
+Before logging, fill in the **Station** panel: your **callsign**, **grid**, and (for US awards)
+**state / county / CQ & ITU zones**. These become the `MY_*` fields written into every contact you
+log, so awards and confirmations match correctly. The callsign and operator name are per operator;
+the physical location (grid/state/county/zones) is shared across operators on the same rig.
+
+> The station snapshot is copied into each contact **at the moment you log it** — so if you correct
+> your station details later, only *future* contacts pick up the change. See
+> **[Troubleshooting](troubleshooting.md)** to fix already-logged contacts.
+
+### Logging a contact
+
+1. Press **`L`** to open the log-entry window. It captures the current **frequency and mode**; the
+   **time is stamped when you press Log**, not when the window opens — so you can pop it open early in
+   a pileup, prep the call, and the logged time still reflects when you actually made the contact.
+2. Type the **callsign** and fill the exchange (**RST sent/received**, **name**, **grid**, comment).
+   With a callbook configured (below), **name and grid auto-fill** as you type the call.
+3. **Worked-before hints** tell you at a glance whether the callsign is new, new on this band, or a
+   dupe.
+4. Press **Log** (Enter) to save.
+
+**WSJT-X / FT8 contacts log themselves** — when WSJT-X logs a QSO, Rigflow ingests it automatically
+into the active operator's log (skipping duplicates), so digital contacts need no manual entry.
+
+### The Contacts view
+
+Press **`V`** to open the **Contacts** view and browse your log. You can **filter** (by band, mode, date, callsign,
+and more), see **confirmation badges** (which contacts LoTW / eQSL / QRZ have confirmed), **edit** any
+field of a contact (including date/time — the place to correct a late or mis-stamped entry),
+**delete** contacts, and **select multiple** rows for a bulk action. The filter you set here is
+**shared with export** — what you see is exactly what gets written.
+
+### Import & export (ADIF)
+
+From the **Contacts** view's toolbar (**Import… / Export…**):
+
+- **Export** writes ADIF for the current filter. It's a *plan → write* flow, streams large logs to
+  disk without stalling the UI, and can do an **incremental** "since last export" so you only send new
+  contacts to an external logger. (The file picker needs a desktop **file-chooser portal**; see
+  Troubleshooting if **Browse…** does nothing.)
+- **Import** reads an ADIF file with a **plan → preview → commit** flow: it shows what will be added
+  before changing anything, skips near-duplicates, and imports **confirmations** — e.g. a LoTW
+  `lotwreport.adi` marks your matching contacts confirmed rather than creating duplicates.
+
+The log is kept in a local SQLite database (the source of truth) plus an **append-only ADIF journal**
+that captures every contact as it's made. Export from the database for a current-state ADIF; the
+journal is a historical capture record and is never rewritten.
+
+### Online sync (LoTW / eQSL / QRZ)
+
+From the **Contacts** view's toolbar (**Sync…**) you can sync directly with the online services:
+
+- **LoTW** — download confirmations (marks matching contacts confirmed).
+- **eQSL** — upload contacts and download confirmations.
+- **QRZ Logbook** — upload contacts and download confirmations.
+
+Enter each service's credentials once; they're stored in your operating system's **secure keyring**
+(with an encrypted-file fallback if no keyring is available) and never written to logs or the ADIF.
+Confirmed contacts show a coloured badge in the Contacts view.
+
+> **US county format:** LoTW/tqsl expects `MY_CNTY` as `STATE,County` (e.g. `MD,Carroll`), not a bare
+> county name. Set your county that way in the Station panel.
+
+---
+
+## Callbook lookup
+
+As you type a callsign in the log-entry window, Rigflow can look it up online and **auto-fill the
+name, grid, QTH (city), state/county, country, and DXCC/zones**. The "via …" note under the fields
+shows where the data came from and a human-readable location, e.g. `via QRZ · Chicago, IL · United
+States · DXCC 291`.
+
+**Providers**, tried in your priority order (first match wins):
+
+| Provider | Account | Notes |
+|---|---|---|
+| **QRZ XML** | qrz.com login + **XML Logbook Data** subscription | Full data. This is your qrz.com login, **not** the QRZ Logbook API key used for QSO sync. |
+| **HamQTH** | free account | Username + password. |
+| **Callook** | none | US callsigns only, no login. |
+
+Underneath all of them is an always-on **offline prefix baseline** that fills the **DXCC entity and
+CQ/ITU zones** from the callsign prefix with no network — so even without an account (or offline), a
+contact still gets its country and zones, and WSJT-X captures get a DXCC.
+
+**Configure** in the **Callbook** window (Contacts view → **Callbook…**): enable each provider, set the
+priority order, and enter credentials — stored in the same secure keyring as the sync services.
+**Anything you type always wins** over the callbook, and an online result overrides the offline
+baseline field-by-field, so a lookup never clobbers your own edits.
+
+---
+
+## DX Cluster
+
+Connect to a **DX-cluster** node to see where stations are being spotted — overlaid live on your
+spectrum/waterfall and in a scrollable spot list — and click a spot to tune straight to it.
+
+**Set it up** in the **DX Cluster** panel → **Configure…**: tick **Enabled**, pick a node from the
+built-in list (**VE7CC** by default, plus NC7J / W3LPL / HRD) or enter a **custom host/port**, and
+confirm your **callsign** (public nodes log in with just your call — no password). **Save & apply** to
+connect; the panel shows the connection status.
+
+**Working spots:**
+
+- The **spot list (band map)** is the main view — every spot that passes your filter, sorted by
+  frequency, each row **click-to-tune** (it recenters on the spot). This shows band-wide activity that
+  the narrow waterfall span can't.
+- **Markers** appear on the spectrum and waterfall for spots inside the currently displayed span —
+  callsign + a fade-with-age tick, click to tune.
+- A **"N received · M shown"** line tells you how many spots have arrived versus how many pass your
+  filter.
+
+**Filter** (in Configure) by **current band only** (default) and by **mode**, to cut the firehose down
+to what you're working. Spots age out automatically, and the connection reconnects itself if the node
+drops. Cluster settings are locked while you're connected to a rigflow **server**, like other operator
+settings.
+
+---
+
 ## Bookmarks
 
 Save the current frequency/mode as a **bookmark** (Bookmarks section) and recall it later; you can
@@ -198,6 +357,8 @@ Recordings appear back in the **Radios** list as playable "radios," so you can r
   operators sharing one rig each keep their own setup, and each radio resumes where its operator left
   it (frequency, mode, filters, volume, NR2/AGC, TX processing, waterfall).
 - Library/hardware items (CW macros, mic device, bookmarks, license, server IP) are operator-wide.
+- The **contact log**, **callbook** setup, **DX-cluster** setup, and **voice-keyer** clips are all
+  per operator too; service/callbook **credentials** live in the OS secure keyring (file fallback).
 - Operator settings are **locked while connected** to a server (to avoid surprise changes mid-session).
 
 ## Understanding the control sections

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -119,6 +119,43 @@ platform, with a live status for each piece.
 
 ---
 
+## Logging, callbook & DX cluster
+
+**A contact has the wrong `MY_CNTY` / `MY_ITU_ZONE` / grid (or tqsl rejects it).**
+- Your station details are **snapshotted into each contact when you log it**, so fixing the Station
+  panel only affects *future* contacts. Correct an already-logged contact in the **Contacts view**
+  (edit the fields), or bulk-fix in the database.
+- **tqsl** wants US counties as `STATE,County` (e.g. `MD,Carroll`), not a bare county name — set it
+  that way in the Station panel.
+
+**Callbook isn't filling name / grid.**
+- Open the **Callbook** window and confirm the provider is **enabled** and its credentials are
+  entered. **QRZ** needs an **XML Logbook Data** subscription and uses your **qrz.com login** — not
+  the QRZ Logbook API key used for QSO sync. **Callook** only knows **US** callsigns.
+- With no provider (or offline), only the **offline prefix baseline** fills in — that's country +
+  DXCC/zones, not name/city. The "via …" note tells you which source answered.
+
+**Import made duplicates instead of marking contacts confirmed.**
+- Use **Import** (plan → preview → commit); it matches on call/band/mode/date and applies
+  confirmations rather than adding rows. A LoTW `lotwreport.adi` marks matching contacts confirmed.
+
+**Export "Browse…" does nothing.**
+- The file picker needs a desktop **file-chooser portal** (`xdg-desktop-portal` with a backend). If
+  your session has none, type the output path into the field by hand instead.
+
+**Service/callbook credentials aren't remembered.**
+- On Linux they're stored in the desktop **secret service** (GNOME Keyring / KWallet). With none
+  running, Rigflow falls back to an **encrypted file** — that's expected, not an error.
+
+**DX cluster says "connected" but I see no spots.**
+- Check the **"N received · M shown"** line. **0 received** on a busy band → wrong host/port, or your
+  callsign was rejected at login; try another node. **Received but 0 shown** → the display filter is
+  hiding them: turn off **current band only** or clear the **mode** filter in Configure.
+- Markers only draw for spots **inside the visible span**; use the **spot list** to see the whole band
+  and click a row to tune.
+
+---
+
 ## Settings & display
 
 **My settings won't change / fields are greyed out.**

--- a/rigflow-client/src/cluster/client.rs
+++ b/rigflow-client/src/cluster/client.rs
@@ -1,0 +1,369 @@
+//! DX-cluster telnet client thread (Phase 2).
+//!
+//! A dedicated background thread (like `wsjtx_listener`) owns the TCP socket. It
+//! is driven by [`DxClusterCommand`]s from the UI (connect / disconnect) and
+//! writes parsed, deduped, bounded spots into a shared [`SpotBook`] that the
+//! waterfall/spectrum renderer reads. Connection state is mirrored into
+//! `UiState.dx_cluster_status` for the status line.
+//!
+//! Robustness:
+//! - **blocking `TcpStream` with a read timeout** so the read loop also polls the
+//!   command channel and runs the expiry sweep without a second thread;
+//! - a **byte accumulator** for line framing — telnet lines (and the login
+//!   prompt, which has no trailing newline) can arrive split across reads;
+//! - **reconnect with capped backoff**, staying responsive to commands via
+//!   `recv_timeout`. Cluster nodes drop connections routinely; that is normal.
+//!
+//! Login is just the operator callsign — public nodes have no password.
+
+use std::io::{ErrorKind, Read, Write};
+use std::net::{TcpStream, ToSocketAddrs};
+use std::sync::mpsc::{Receiver, RecvTimeoutError, Sender, TryRecvError};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use super::{DEFAULT_TTL, DxSpot, expire, insert_spot, parse_spot_line};
+use crate::ui::state::UiState;
+
+/// Shared, deduped, bounded spot list — written by the cluster thread, read by
+/// the renderer. Kept OUT of `UiState` (deep-cloned every frame) so a few
+/// thousand spots never clone per frame.
+pub type SpotBook = Arc<Mutex<Vec<DxSpot>>>;
+
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(15);
+const READ_TIMEOUT: Duration = Duration::from_millis(500);
+const EXPIRE_INTERVAL: Duration = Duration::from_secs(30);
+const LOGIN_WINDOW: Duration = Duration::from_secs(6);
+const INITIAL_BACKOFF: Duration = Duration::from_secs(2);
+const MAX_BACKOFF: Duration = Duration::from_secs(60);
+/// Spots to backfill on connect so the display populates immediately.
+const BACKFILL: u32 = 50;
+
+/// Connection state, mirrored into `UiState` for the status line.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub enum DxClusterStatus {
+    #[default]
+    Disconnected,
+    Connecting,
+    Connected,
+    /// Last error; the thread keeps retrying with backoff.
+    Error(String),
+}
+
+/// A lifecycle command from the UI to the cluster thread.
+#[derive(Debug, Clone)]
+pub enum DxClusterCommand {
+    Connect {
+        host: String,
+        port: u16,
+        call: String,
+    },
+    Disconnect,
+}
+
+/// What the UI holds: a command sender plus the shared spot book.
+pub struct DxClusterHandle {
+    tx: Sender<DxClusterCommand>,
+    pub spots: SpotBook,
+}
+
+impl DxClusterHandle {
+    pub fn connect(&self, host: impl Into<String>, port: u16, call: impl Into<String>) {
+        let _ = self.tx.send(DxClusterCommand::Connect {
+            host: host.into(),
+            port,
+            call: call.into(),
+        });
+    }
+
+    pub fn disconnect(&self) {
+        let _ = self.tx.send(DxClusterCommand::Disconnect);
+    }
+}
+
+/// Spawn the cluster thread. It idles until it receives a `Connect` command.
+pub fn spawn_dx_cluster(state: Arc<Mutex<UiState>>) -> DxClusterHandle {
+    let (tx, rx) = std::sync::mpsc::channel();
+    let spots: SpotBook = Arc::new(Mutex::new(Vec::new()));
+    let spots_thread = Arc::clone(&spots);
+    let _ = std::thread::Builder::new()
+        .name("dx-cluster".to_string())
+        .spawn(move || run(state, rx, spots_thread));
+    DxClusterHandle { tx, spots }
+}
+
+#[derive(Clone)]
+struct Target {
+    host: String,
+    port: u16,
+    call: String,
+}
+
+/// The effect a command has on the desired-connection target.
+enum Effect {
+    SetTarget(Target),
+    Clear,
+}
+
+fn effect_of(cmd: DxClusterCommand) -> Effect {
+    match cmd {
+        DxClusterCommand::Connect { host, port, call } => {
+            Effect::SetTarget(Target { host, port, call })
+        }
+        DxClusterCommand::Disconnect => Effect::Clear,
+    }
+}
+
+/// Apply a command effect: a new target resets backoff, a disconnect clears it.
+fn apply(effect: Effect, target: &mut Option<Target>, backoff: &mut Duration) {
+    match effect {
+        Effect::SetTarget(t) => {
+            *target = Some(t);
+            *backoff = INITIAL_BACKOFF;
+        }
+        Effect::Clear => *target = None,
+    }
+}
+
+/// Why a live connection ended.
+enum ServeEnd {
+    /// UI asked to disconnect — go idle.
+    Disconnect,
+    /// UI asked to connect elsewhere — switch target immediately.
+    NewTarget(Target),
+    /// Socket dropped/errored — reconnect after backoff.
+    Reconnect(String),
+    /// Command channel closed (app shutting down) — exit the thread.
+    Closed,
+}
+
+fn set_status(state: &Arc<Mutex<UiState>>, status: DxClusterStatus) {
+    if let Ok(mut s) = state.lock() {
+        s.dx_cluster_status = status;
+    }
+}
+
+fn grow(backoff: Duration) -> Duration {
+    (backoff * 2).min(MAX_BACKOFF)
+}
+
+fn run(state: Arc<Mutex<UiState>>, rx: Receiver<DxClusterCommand>, spots: SpotBook) {
+    let mut target: Option<Target> = None;
+    let mut backoff = INITIAL_BACKOFF;
+
+    loop {
+        // No target: go idle and block until the UI asks to connect.
+        let Some(t) = target.clone() else {
+            set_status(&state, DxClusterStatus::Disconnected);
+            match rx.recv() {
+                Ok(cmd) => apply(effect_of(cmd), &mut target, &mut backoff),
+                Err(_) => return, // sender dropped → app closing
+            }
+            continue;
+        };
+
+        set_status(&state, DxClusterStatus::Connecting);
+        match tcp_connect(&t.host, t.port) {
+            Ok(stream) => {
+                backoff = INITIAL_BACKOFF;
+                match serve(stream, &t, &rx, &state, &spots) {
+                    ServeEnd::Disconnect => target = None,
+                    ServeEnd::NewTarget(nt) => {
+                        apply(Effect::SetTarget(nt), &mut target, &mut backoff)
+                    }
+                    ServeEnd::Closed => return,
+                    ServeEnd::Reconnect(reason) => {
+                        set_status(&state, DxClusterStatus::Error(reason));
+                        if backoff_wait(&rx, &mut backoff, &mut target).is_closed() {
+                            return;
+                        }
+                    }
+                }
+            }
+            Err(e) => {
+                set_status(
+                    &state,
+                    DxClusterStatus::Error(format!("connect failed: {e}")),
+                );
+                if backoff_wait(&rx, &mut backoff, &mut target).is_closed() {
+                    return;
+                }
+            }
+        }
+    }
+}
+
+enum WaitOutcome {
+    Continue,
+    Closed,
+}
+
+impl WaitOutcome {
+    fn is_closed(&self) -> bool {
+        matches!(self, WaitOutcome::Closed)
+    }
+}
+
+/// Wait out the backoff, staying responsive: a command applies immediately (and
+/// resets backoff), a real timeout grows it, a closed channel ends the thread.
+fn backoff_wait(
+    rx: &Receiver<DxClusterCommand>,
+    backoff: &mut Duration,
+    target: &mut Option<Target>,
+) -> WaitOutcome {
+    match rx.recv_timeout(*backoff) {
+        Ok(cmd) => {
+            apply(effect_of(cmd), target, backoff);
+            WaitOutcome::Continue
+        }
+        Err(RecvTimeoutError::Timeout) => {
+            *backoff = grow(*backoff);
+            WaitOutcome::Continue
+        }
+        Err(RecvTimeoutError::Disconnected) => WaitOutcome::Closed,
+    }
+}
+
+fn tcp_connect(host: &str, port: u16) -> std::io::Result<TcpStream> {
+    let addrs = (host, port).to_socket_addrs()?;
+    let mut last_err = None;
+    for addr in addrs {
+        match TcpStream::connect_timeout(&addr, CONNECT_TIMEOUT) {
+            Ok(s) => return Ok(s),
+            Err(e) => last_err = Some(e),
+        }
+    }
+    Err(last_err.unwrap_or_else(|| std::io::Error::other("no address resolved")))
+}
+
+/// Drive a live connection: log in, request a backfill, then stream spots until
+/// the socket drops or a command interrupts.
+fn serve(
+    mut stream: TcpStream,
+    target: &Target,
+    rx: &Receiver<DxClusterCommand>,
+    state: &Arc<Mutex<UiState>>,
+    spots: &SpotBook,
+) -> ServeEnd {
+    if let Err(e) = stream.set_read_timeout(Some(READ_TIMEOUT)) {
+        return ServeEnd::Reconnect(format!("set_read_timeout: {e}"));
+    }
+
+    // Login + backfill.
+    match login(&mut stream, &target.call, rx) {
+        Ok(()) => {}
+        Err(end) => return end,
+    }
+    let _ = send_line(&mut stream, &format!("sh/dx {BACKFILL}"));
+    set_status(state, DxClusterStatus::Connected);
+
+    let mut acc = String::new();
+    let mut buf = [0u8; 4096];
+    let mut last_expire = Instant::now();
+
+    loop {
+        match poll_command(rx) {
+            CmdPoll::Disconnect => return ServeEnd::Disconnect,
+            CmdPoll::NewTarget(t) => return ServeEnd::NewTarget(t),
+            CmdPoll::Closed => return ServeEnd::Closed,
+            CmdPoll::None => {}
+        }
+
+        match stream.read(&mut buf) {
+            Ok(0) => return ServeEnd::Reconnect("connection closed by node".to_string()),
+            Ok(n) => {
+                acc.push_str(&String::from_utf8_lossy(&buf[..n]));
+                drain_lines(&mut acc, spots);
+            }
+            Err(e) if is_timeout(&e) => {} // no data this tick — fall through to housekeeping
+            Err(e) => return ServeEnd::Reconnect(format!("read error: {e}")),
+        }
+
+        if last_expire.elapsed() >= EXPIRE_INTERVAL {
+            if let Ok(mut s) = spots.lock() {
+                expire(&mut s, Instant::now(), DEFAULT_TTL);
+            }
+            last_expire = Instant::now();
+        }
+    }
+}
+
+/// Read until a recognisable login prompt (or a short timeout), then send the
+/// callsign. Public nodes accept the call unprompted, so a timeout is harmless.
+fn login(
+    stream: &mut TcpStream,
+    call: &str,
+    rx: &Receiver<DxClusterCommand>,
+) -> Result<(), ServeEnd> {
+    let start = Instant::now();
+    let mut acc = String::new();
+    let mut buf = [0u8; 1024];
+
+    while start.elapsed() < LOGIN_WINDOW {
+        match poll_command(rx) {
+            CmdPoll::Disconnect => return Err(ServeEnd::Disconnect),
+            CmdPoll::NewTarget(t) => return Err(ServeEnd::NewTarget(t)),
+            CmdPoll::Closed => return Err(ServeEnd::Closed),
+            CmdPoll::None => {}
+        }
+        match stream.read(&mut buf) {
+            Ok(0) => return Err(ServeEnd::Reconnect("closed during login".to_string())),
+            Ok(n) => {
+                acc.push_str(&String::from_utf8_lossy(&buf[..n]).to_ascii_lowercase());
+                if acc.contains("login")
+                    || acc.contains("your call")
+                    || acc.contains("call:")
+                    || acc.contains("callsign")
+                {
+                    break;
+                }
+            }
+            Err(e) if is_timeout(&e) => {}
+            Err(e) => return Err(ServeEnd::Reconnect(format!("login read: {e}"))),
+        }
+    }
+
+    send_line(stream, call).map_err(|e| ServeEnd::Reconnect(format!("login write: {e}")))
+}
+
+/// Pull complete `\n`-terminated lines out of the accumulator, parse each, and
+/// insert any spots. A trailing partial line stays buffered for the next read.
+fn drain_lines(acc: &mut String, spots: &SpotBook) {
+    while let Some(pos) = acc.find('\n') {
+        let line: String = acc.drain(..=pos).collect();
+        let line = line.trim_end_matches(['\r', '\n']);
+        if let Some(spot) = parse_spot_line(line, Instant::now())
+            && let Ok(mut s) = spots.lock()
+        {
+            insert_spot(&mut s, spot);
+        }
+    }
+}
+
+enum CmdPoll {
+    None,
+    Disconnect,
+    NewTarget(Target),
+    Closed,
+}
+
+fn poll_command(rx: &Receiver<DxClusterCommand>) -> CmdPoll {
+    match rx.try_recv() {
+        Ok(DxClusterCommand::Disconnect) => CmdPoll::Disconnect,
+        Ok(DxClusterCommand::Connect { host, port, call }) => {
+            CmdPoll::NewTarget(Target { host, port, call })
+        }
+        Err(TryRecvError::Empty) => CmdPoll::None,
+        Err(TryRecvError::Disconnected) => CmdPoll::Closed,
+    }
+}
+
+fn send_line(stream: &mut TcpStream, line: &str) -> std::io::Result<()> {
+    stream.write_all(line.as_bytes())?;
+    stream.write_all(b"\r\n")?;
+    stream.flush()
+}
+
+fn is_timeout(e: &std::io::Error) -> bool {
+    matches!(e.kind(), ErrorKind::WouldBlock | ErrorKind::TimedOut)
+}

--- a/rigflow-client/src/cluster/config.rs
+++ b/rigflow-client/src/cluster/config.rs
@@ -1,0 +1,215 @@
+//! DX-cluster configuration (Phase 3): which node, login callsign, and the
+//! client-side display filter. Operator-scoped, persisted as `cluster.json` in
+//! the operator directory (mirrors `callbook.json`). Editing is locked while
+//! connected to a rigflow server (`UiState.config_locked`), like other operator
+//! settings — enforced by the UI (Phase 5).
+//!
+//! The filter is **client-side only** for v1: `current_band_only` + a mode
+//! whitelist, both driven by data already on [`DxSpot`]. Spotter-continent
+//! filtering and a configurable TTL are deferred (see the design doc §7/§12).
+
+use rigflow_core::radio::ham_band::HamBand;
+
+use super::DxSpot;
+
+/// A built-in cluster node offered in the picker. All are free, callsign-only
+/// login; they carry the same peered global feed, so the choice is about
+/// reliability/filtering, not content.
+pub struct ClusterNode {
+    pub name: &'static str,
+    pub host: &'static str,
+    pub port: u16,
+}
+
+/// The shortlist. VE7CC is the default (cleanest `set/filter` command set).
+pub const NODES: &[ClusterNode] = &[
+    ClusterNode {
+        name: "VE7CC",
+        host: "ve7cc.net",
+        port: 23,
+    },
+    ClusterNode {
+        name: "NC7J",
+        host: "dxc.nc7j.com",
+        port: 23,
+    },
+    ClusterNode {
+        name: "W3LPL",
+        host: "w3lpl.net",
+        port: 7373,
+    },
+    ClusterNode {
+        name: "HRD",
+        host: "hrd.wa9pie.net",
+        port: 8000,
+    },
+];
+
+/// Per-operator DX-cluster configuration.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct DxClusterConfig {
+    /// Master on/off. When off, the thread stays disconnected.
+    #[serde(default)]
+    pub enabled: bool,
+    #[serde(default = "default_host")]
+    pub host: String,
+    #[serde(default = "default_port")]
+    pub port: u16,
+    /// Login callsign; empty = use the operator's callsign.
+    #[serde(default)]
+    pub call: String,
+    /// Show only spots on the currently tuned band (the default, most-relevant
+    /// view). When false, spots from all bands show.
+    #[serde(default = "default_true")]
+    pub current_band_only: bool,
+    /// Mode whitelist (uppercase, matched against `DxSpot.mode_hint`); empty =
+    /// all modes.
+    #[serde(default)]
+    pub modes: Vec<String>,
+}
+
+fn default_host() -> String {
+    NODES[0].host.to_string()
+}
+fn default_port() -> u16 {
+    NODES[0].port
+}
+fn default_true() -> bool {
+    true
+}
+
+impl Default for DxClusterConfig {
+    fn default() -> Self {
+        DxClusterConfig {
+            enabled: false,
+            host: default_host(),
+            port: default_port(),
+            call: String::new(),
+            current_band_only: true,
+            modes: Vec::new(),
+        }
+    }
+}
+
+impl DxClusterConfig {
+    /// The callsign to log in with: the explicit `call` if set, else the
+    /// operator's callsign. Uppercased/trimmed; empty if neither is available.
+    pub fn login_call(&self, operator_call: &str) -> String {
+        let c = if self.call.trim().is_empty() {
+            operator_call
+        } else {
+            &self.call
+        };
+        c.trim().to_ascii_uppercase()
+    }
+
+    /// The built-in node name matching the current host/port, or `None` for a
+    /// custom entry (for showing the picker's current selection).
+    pub fn matching_node(&self) -> Option<&'static str> {
+        NODES
+            .iter()
+            .find(|n| n.host == self.host && n.port == self.port)
+            .map(|n| n.name)
+    }
+
+    /// Whether a spot passes the display filter given the currently tuned band.
+    pub fn show(&self, spot: &DxSpot, current_band: Option<HamBand>) -> bool {
+        if self.current_band_only && spot.band != current_band {
+            return false;
+        }
+        if !self.modes.is_empty() {
+            match &spot.mode_hint {
+                Some(m) if self.modes.iter().any(|x| x.eq_ignore_ascii_case(m)) => {}
+                _ => return false,
+            }
+        }
+        true
+    }
+}
+
+const CONFIG_FILE: &str = "cluster.json";
+
+pub fn load_config(operator_dir: &std::path::Path) -> DxClusterConfig {
+    std::fs::read_to_string(operator_dir.join(CONFIG_FILE))
+        .ok()
+        .and_then(|s| serde_json::from_str(&s).ok())
+        .unwrap_or_default()
+}
+
+pub fn save_config(operator_dir: &std::path::Path, cfg: &DxClusterConfig) -> std::io::Result<()> {
+    let json = serde_json::to_string_pretty(cfg).unwrap_or_default();
+    std::fs::write(operator_dir.join(CONFIG_FILE), json)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Instant;
+
+    fn spot(band: Option<HamBand>, mode: Option<&str>) -> DxSpot {
+        DxSpot {
+            dx_call: "TEST".into(),
+            freq_hz: 14_050_000,
+            spotter: "X".into(),
+            comment: String::new(),
+            time_utc: String::new(),
+            mode_hint: mode.map(|m| m.to_string()),
+            band,
+            received_at: Instant::now(),
+        }
+    }
+
+    #[test]
+    fn current_band_only_hides_other_bands() {
+        let cfg = DxClusterConfig {
+            current_band_only: true,
+            ..Default::default()
+        };
+        assert!(cfg.show(&spot(Some(HamBand::B20), None), Some(HamBand::B20)));
+        assert!(!cfg.show(&spot(Some(HamBand::B40), None), Some(HamBand::B20)));
+        // No current band → nothing band-matches.
+        assert!(!cfg.show(&spot(Some(HamBand::B20), None), None));
+    }
+
+    #[test]
+    fn all_bands_when_toggle_off() {
+        let cfg = DxClusterConfig {
+            current_band_only: false,
+            ..Default::default()
+        };
+        assert!(cfg.show(&spot(Some(HamBand::B40), None), Some(HamBand::B20)));
+        assert!(cfg.show(&spot(None, None), None));
+    }
+
+    #[test]
+    fn mode_whitelist_filters() {
+        let cfg = DxClusterConfig {
+            current_band_only: false,
+            modes: vec!["FT8".into(), "CW".into()],
+            ..Default::default()
+        };
+        assert!(cfg.show(&spot(None, Some("CW")), None));
+        assert!(cfg.show(&spot(None, Some("ft8")), None)); // case-insensitive
+        assert!(!cfg.show(&spot(None, Some("RTTY")), None));
+        assert!(!cfg.show(&spot(None, None), None)); // unknown mode excluded when a whitelist is set
+    }
+
+    #[test]
+    fn login_call_falls_back_to_operator() {
+        let mut cfg = DxClusterConfig::default();
+        assert_eq!(cfg.login_call("w1abc"), "W1ABC");
+        cfg.call = "K9XYZ".into();
+        assert_eq!(cfg.login_call("w1abc"), "K9XYZ");
+    }
+
+    #[test]
+    fn matching_node_identifies_builtin() {
+        let cfg = DxClusterConfig::default();
+        assert_eq!(cfg.matching_node(), Some("VE7CC"));
+        let custom = DxClusterConfig {
+            host: "my.node".into(),
+            ..Default::default()
+        };
+        assert_eq!(custom.matching_node(), None);
+    }
+}

--- a/rigflow-client/src/cluster/mod.rs
+++ b/rigflow-client/src/cluster/mod.rs
@@ -1,0 +1,371 @@
+//! DX-cluster spots — pure model, wire-line parser, and spot-store lifecycle
+//! (dedupe + expiry). **This module is network-free and unit-tested**; the telnet
+//! thread (Phase 2), `UiState` wiring + filtering (Phase 3), and waterfall/spectrum
+//! rendering (Phase 4) live elsewhere. Design: `docs/release-review/dx-cluster-design.md`.
+//!
+//! Clusters are peered — every public node carries the same global feed — and speak
+//! line-based telnet. The one line we care about is the spot:
+//!
+//! ```text
+//! DX de W3LPL:     14025.0  JA1XYZ       CW  up 2                1432Z
+//!      └spotter    └freq kHz └DX call     └───comment────┘        └time UTC
+//! ```
+//!
+//! Line formats vary across cluster software (DXSpider / AR-Cluster / CC-Cluster):
+//! spacing differs and some append the DX country/grid to the comment. So the parser
+//! anchors on the `DX de` prefix and the freq/call tokens, tolerates extra trailing
+//! fields, and **drops any line it can't confidently parse** rather than guessing.
+
+pub mod client;
+pub mod config;
+
+use std::time::{Duration, Instant};
+
+use rigflow_core::radio::ham_band::{HamBand, band_from_frequency};
+
+/// A parsed cluster spot. Wire fields plus a derived `band` and a local
+/// `received_at` (set by the caller / parser, not read off the wire) used for
+/// aging and expiry.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DxSpot {
+    /// The spotted station (uppercased).
+    pub dx_call: String,
+    /// Spot frequency in Hz (wire is kHz).
+    pub freq_hz: u64,
+    /// Who posted the spot.
+    pub spotter: String,
+    /// Free-text comment (mode, "up 2", signal report, DX country, …).
+    pub comment: String,
+    /// Time as reported on the wire, e.g. `"1432Z"` — display-only.
+    pub time_utc: String,
+    /// Best-effort mode from the comment (`"FT8"`, `"CW"`, …); `None` if unknown.
+    pub mode_hint: Option<String>,
+    /// Ham band derived from `freq_hz`; `None` for out-of-band (e.g. VHF/UHF)
+    /// or unmapped frequencies — still a valid spot, just not on a known band.
+    pub band: Option<HamBand>,
+    /// When this spot was received locally. Used for aging/expiry only.
+    pub received_at: Instant,
+}
+
+/// Two spots of the **same call** within this many Hz are treated as the same
+/// spot (people spot the same station a hair apart). ±0.2 kHz.
+pub const DEDUPE_TOL_HZ: u64 = 200;
+
+/// Default time-to-live for a spot before it expires off the display.
+pub const DEFAULT_TTL: Duration = Duration::from_secs(20 * 60);
+
+/// Hard cap on retained spots (memory bound). Oldest is dropped past this.
+pub const MAX_SPOTS: usize = 4000;
+
+/// Parse one cluster line into a [`DxSpot`], or `None` if it isn't a spot line
+/// (or is malformed). `received_at` is injected so the parser stays pure and the
+/// tests are deterministic.
+pub fn parse_spot_line(line: &str, received_at: Instant) -> Option<DxSpot> {
+    // Anchor: the line must begin with "DX de" (case-insensitive). Everything
+    // else the node sends — WWV/WCY bulletins, chat, announcements, prompts — is
+    // silently ignored.
+    let line = line.trim();
+    let rest = strip_prefix_ci(line, "DX de")?.trim_start();
+
+    // Spotter runs up to the first ':' (its own colon; comments rarely lead with
+    // one, and the freq/call never contain ':'). Fall back to the first token if
+    // a node omits the colon.
+    let (spotter, after) = match rest.split_once(':') {
+        Some((s, a)) => (s.trim(), a.trim()),
+        None => {
+            let mut it = rest.splitn(2, char::is_whitespace);
+            (
+                it.next().unwrap_or("").trim(),
+                it.next().unwrap_or("").trim(),
+            )
+        }
+    };
+    if spotter.is_empty() {
+        return None;
+    }
+
+    let mut tokens: Vec<&str> = after.split_whitespace().collect();
+    if tokens.len() < 2 {
+        return None; // need at least freq + call
+    }
+
+    // Frequency (kHz → Hz).
+    let khz: f64 = tokens[0].parse().ok()?;
+    if !(khz.is_finite() && khz > 0.0) {
+        return None;
+    }
+    let freq_hz = (khz * 1000.0).round() as u64;
+
+    // DX call.
+    let dx_call = tokens[1].to_ascii_uppercase();
+    if dx_call.is_empty() {
+        return None;
+    }
+
+    // Trailing "NNNNZ" time, if present, is peeled off the end; the rest is the
+    // free-text comment.
+    let mut time_utc = String::new();
+    if let Some(last) = tokens.last() {
+        if is_time_token(last) {
+            time_utc = last.to_ascii_uppercase();
+            tokens.pop();
+        }
+    }
+    let comment = tokens.get(2..).map(|c| c.join(" ")).unwrap_or_default();
+
+    Some(DxSpot {
+        dx_call,
+        freq_hz,
+        spotter: spotter.to_string(),
+        mode_hint: mode_hint_from(&comment),
+        comment,
+        time_utc,
+        band: band_from_frequency(freq_hz),
+        received_at,
+    })
+}
+
+/// Insert a spot, collapsing a prior spot of the same call within
+/// [`DEDUPE_TOL_HZ`] (newest wins), and enforcing [`MAX_SPOTS`] by dropping the
+/// oldest. Keeps the store deduped and bounded.
+pub fn insert_spot(spots: &mut Vec<DxSpot>, spot: DxSpot) {
+    spots.retain(|s| !(s.dx_call == spot.dx_call && freq_close(s.freq_hz, spot.freq_hz)));
+    spots.push(spot);
+    while spots.len() > MAX_SPOTS {
+        if let Some((i, _)) = spots.iter().enumerate().min_by_key(|(_, s)| s.received_at) {
+            spots.remove(i);
+        } else {
+            break;
+        }
+    }
+}
+
+/// Drop spots older than `ttl` relative to `now`.
+pub fn expire(spots: &mut Vec<DxSpot>, now: Instant, ttl: Duration) {
+    spots.retain(|s| now.saturating_duration_since(s.received_at) < ttl);
+}
+
+fn freq_close(a: u64, b: u64) -> bool {
+    a.abs_diff(b) <= DEDUPE_TOL_HZ
+}
+
+/// Case-insensitive prefix strip returning the remainder.
+fn strip_prefix_ci<'a>(s: &'a str, prefix: &str) -> Option<&'a str> {
+    let plen = prefix.len();
+    if s.len() >= plen && s[..plen].eq_ignore_ascii_case(prefix) {
+        Some(&s[plen..])
+    } else {
+        None
+    }
+}
+
+/// A trailing spot-time token: 3–5 ASCII digits followed by `Z`/`z`, e.g.
+/// `1432Z`. (Not a real clock — just what the node printed.)
+fn is_time_token(tok: &str) -> bool {
+    let bytes = tok.as_bytes();
+    let n = bytes.len();
+    if !(4..=5).contains(&n) {
+        return false;
+    }
+    if !matches!(bytes[n - 1], b'Z' | b'z') {
+        return false;
+    }
+    bytes[..n - 1].iter().all(|b| b.is_ascii_digit())
+}
+
+/// Best-effort mode from a comment: first recognised digital/CW/phone keyword.
+/// Order matters — check longer/more-specific tokens first.
+fn mode_hint_from(comment: &str) -> Option<String> {
+    const MODES: [&str; 8] = ["FT8", "FT4", "RTTY", "PSK", "JT65", "CW", "SSB", "USB"];
+    let up = comment.to_ascii_uppercase();
+    MODES
+        .into_iter()
+        .find(|m| {
+            up.split(|c: char| !c.is_ascii_alphanumeric())
+                .any(|w| w == *m)
+        })
+        .map(|m| m.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn t0() -> Instant {
+        Instant::now()
+    }
+
+    #[test]
+    fn parses_dxspider_line() {
+        let s = parse_spot_line(
+            "DX de W3LPL:     14025.0  JA1XYZ       CW  up 2                1432Z",
+            t0(),
+        )
+        .expect("should parse");
+        assert_eq!(s.spotter, "W3LPL");
+        assert_eq!(s.freq_hz, 14_025_000);
+        assert_eq!(s.dx_call, "JA1XYZ");
+        assert_eq!(s.time_utc, "1432Z");
+        assert_eq!(s.band, Some(HamBand::B20));
+        assert_eq!(s.mode_hint.as_deref(), Some("CW"));
+        assert!(s.comment.contains("up 2"));
+        assert!(!s.comment.contains("1432Z")); // time peeled off
+    }
+
+    #[test]
+    fn parses_ar_cluster_line_with_ssid_and_trailing_country() {
+        // AR-Cluster: spotter has an SSID suffix, comment carries a signal
+        // report and the DX country.
+        let s = parse_spot_line(
+            "DX de K1ABC-#:   14195.0  EA8XYZ    59 Canary Is           2030Z",
+            t0(),
+        )
+        .expect("should parse");
+        assert_eq!(s.spotter, "K1ABC-#");
+        assert_eq!(s.freq_hz, 14_195_000);
+        assert_eq!(s.dx_call, "EA8XYZ");
+        assert_eq!(s.time_utc, "2030Z");
+        assert!(s.comment.contains("Canary Is"));
+    }
+
+    #[test]
+    fn parses_cc_cluster_ft8_line_with_portable_call() {
+        let s = parse_spot_line(
+            "DX de OH2XYZ:    3573.0  W1AW/4       FT8 -12 dB              2201Z",
+            t0(),
+        )
+        .expect("should parse");
+        assert_eq!(s.freq_hz, 3_573_000);
+        assert_eq!(s.dx_call, "W1AW/4"); // portable slash preserved
+        assert_eq!(s.band, Some(HamBand::B80));
+        assert_eq!(s.mode_hint.as_deref(), Some("FT8"));
+    }
+
+    #[test]
+    fn out_of_band_freq_is_valid_but_bandless() {
+        let s = parse_spot_line("DX de K7ABC:  144200.0  W5XYZ  SSB  1200Z", t0())
+            .expect("should parse");
+        assert_eq!(s.freq_hz, 144_200_000);
+        assert_eq!(s.band, None); // 2m not in the HF band table
+        assert_eq!(s.mode_hint.as_deref(), Some("SSB"));
+    }
+
+    #[test]
+    fn missing_time_token_is_ok() {
+        let s = parse_spot_line("DX de K1ABC:  7005.0  DL1XYZ  CW", t0()).expect("parse");
+        assert_eq!(s.dx_call, "DL1XYZ");
+        assert_eq!(s.time_utc, "");
+        assert_eq!(s.comment, "CW");
+    }
+
+    #[test]
+    fn drops_non_spot_lines() {
+        for junk in [
+            "WWV de VE7CC <18>:   SFI=140, A=7, K=2 -> No storms",
+            "To ALL de W3LPL: happy new year",
+            "Please enter your call:",
+            "",
+            "   ",
+            "login: ",
+            "DX de W3LPL:", // no freq/call
+            "DX de W3LPL:  notafreq  JA1XYZ  CW  1432Z",
+        ] {
+            assert!(
+                parse_spot_line(junk, t0()).is_none(),
+                "should have dropped: {junk:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn dedupe_same_call_within_tolerance_keeps_newest() {
+        let base = t0();
+        let older = base.checked_sub(Duration::from_secs(60)).unwrap();
+        let mut spots = Vec::new();
+        insert_spot(
+            &mut spots,
+            parse_spot_line("DX de A:  14025.0  JA1XYZ  CW  1000Z", older).unwrap(),
+        );
+        // Same call, 0.1 kHz away → collapses onto the newer one.
+        insert_spot(
+            &mut spots,
+            parse_spot_line("DX de B:  14025.1  JA1XYZ  CW  1001Z", base).unwrap(),
+        );
+        assert_eq!(spots.len(), 1);
+        assert_eq!(spots[0].spotter, "B");
+        assert_eq!(spots[0].received_at, base);
+    }
+
+    #[test]
+    fn dedupe_keeps_distinct_call_or_far_freq() {
+        let now = t0();
+        let mut spots = Vec::new();
+        insert_spot(
+            &mut spots,
+            parse_spot_line("DX de A:  14025.0  JA1XYZ  CW  1000Z", now).unwrap(),
+        );
+        // Different call, same freq → kept.
+        insert_spot(
+            &mut spots,
+            parse_spot_line("DX de A:  14025.0  DL1XYZ  CW  1000Z", now).unwrap(),
+        );
+        // Same call, 1 kHz away (> tolerance) → kept.
+        insert_spot(
+            &mut spots,
+            parse_spot_line("DX de A:  14026.0  JA1XYZ  CW  1000Z", now).unwrap(),
+        );
+        assert_eq!(spots.len(), 3);
+    }
+
+    #[test]
+    fn expire_drops_old_keeps_fresh() {
+        let now = t0();
+        let mut spots = Vec::new();
+        insert_spot(
+            &mut spots,
+            parse_spot_line("DX de A:  14025.0  FRESH  CW  1000Z", now).unwrap(),
+        );
+        insert_spot(
+            &mut spots,
+            parse_spot_line(
+                "DX de A:  14030.0  STALE  CW  0900Z",
+                now.checked_sub(Duration::from_secs(40 * 60)).unwrap(),
+            )
+            .unwrap(),
+        );
+        expire(&mut spots, now, DEFAULT_TTL);
+        assert_eq!(spots.len(), 1);
+        assert_eq!(spots[0].dx_call, "FRESH");
+    }
+
+    #[test]
+    fn max_spots_cap_drops_oldest() {
+        let base = t0();
+        let mut spots = Vec::new();
+        // Fill past the cap; each spot a distinct call, increasing timestamp.
+        for i in 0..(MAX_SPOTS + 5) {
+            let ts = base
+                .checked_sub(Duration::from_secs((MAX_SPOTS + 5 - i) as u64))
+                .unwrap();
+            let spot = DxSpot {
+                dx_call: format!("CALL{i}"),
+                freq_hz: 14_000_000 + i as u64 * 1000,
+                spotter: "X".into(),
+                comment: String::new(),
+                time_utc: String::new(),
+                mode_hint: None,
+                band: Some(HamBand::B20),
+                received_at: ts,
+            };
+            insert_spot(&mut spots, spot);
+        }
+        assert_eq!(spots.len(), MAX_SPOTS);
+        // The five oldest (CALL0..CALL4) should have been evicted.
+        assert!(!spots.iter().any(|s| s.dx_call == "CALL0"));
+        assert!(
+            spots
+                .iter()
+                .any(|s| s.dx_call == format!("CALL{}", MAX_SPOTS + 4))
+        );
+    }
+}

--- a/rigflow-client/src/cluster/mod.rs
+++ b/rigflow-client/src/cluster/mod.rs
@@ -60,13 +60,21 @@ pub const MAX_SPOTS: usize = 4000;
 /// Parse one cluster line into a [`DxSpot`], or `None` if it isn't a spot line
 /// (or is malformed). `received_at` is injected so the parser stays pure and the
 /// tests are deterministic.
+///
+/// Two on-wire formats are handled: **live** spots (`DX de <spotter>: <freq>
+/// <call> …`) and the **`sh/dx` backfill** format sent on connect (`<freq>
+/// <call> <date> <time> … <spotter>` — freq-first, spotter in angle brackets).
+/// Everything else the node sends (WWV/WCY bulletins, chat, prompts) is dropped.
 pub fn parse_spot_line(line: &str, received_at: Instant) -> Option<DxSpot> {
-    // Anchor: the line must begin with "DX de" (case-insensitive). Everything
-    // else the node sends — WWV/WCY bulletins, chat, announcements, prompts — is
-    // silently ignored.
     let line = line.trim();
-    let rest = strip_prefix_ci(line, "DX de")?.trim_start();
+    if let Some(rest) = strip_prefix_ci(line, "DX de") {
+        return parse_dx_de(rest.trim_start(), received_at);
+    }
+    parse_show_dx_line(line, received_at)
+}
 
+/// Live spot: the text after the `DX de` prefix — `<spotter>: <freq> <call> …`.
+fn parse_dx_de(rest: &str, received_at: Instant) -> Option<DxSpot> {
     // Spotter runs up to the first ':' (its own colon; comments rarely lead with
     // one, and the freq/call never contain ':'). Fall back to the first token if
     // a node omits the colon.
@@ -89,14 +97,12 @@ pub fn parse_spot_line(line: &str, received_at: Instant) -> Option<DxSpot> {
         return None; // need at least freq + call
     }
 
-    // Frequency (kHz → Hz).
     let khz: f64 = tokens[0].parse().ok()?;
     if !(khz.is_finite() && khz > 0.0) {
         return None;
     }
     let freq_hz = (khz * 1000.0).round() as u64;
 
-    // DX call.
     let dx_call = tokens[1].to_ascii_uppercase();
     if dx_call.is_empty() {
         return None;
@@ -117,6 +123,67 @@ pub fn parse_spot_line(line: &str, received_at: Instant) -> Option<DxSpot> {
         dx_call,
         freq_hz,
         spotter: spotter.to_string(),
+        mode_hint: mode_hint_from(&comment),
+        comment,
+        time_utc,
+        band: band_from_frequency(freq_hz),
+        received_at,
+    })
+}
+
+/// `sh/dx` backfill: `<freq> <call> <date> <time> <comment> <spotter>` — freq
+/// first, the spotter in `<…>` at the end. Requires a plausible call and either
+/// a bracketed spotter or a `NNNNZ` time, so headers/chatter are rejected.
+fn parse_show_dx_line(line: &str, received_at: Instant) -> Option<DxSpot> {
+    // Spotter is in angle brackets at the end; strip it and keep the body.
+    let (spotter, body) = match (line.rfind('<'), line.rfind('>')) {
+        (Some(lt), Some(gt)) if gt > lt + 1 => {
+            (Some(line[lt + 1..gt].trim().to_string()), &line[..lt])
+        }
+        _ => (None, line),
+    };
+
+    let tokens: Vec<&str> = body.split_whitespace().collect();
+    if tokens.len() < 2 {
+        return None;
+    }
+
+    let khz: f64 = tokens[0].parse().ok()?;
+    if !(khz.is_finite() && khz > 0.0) {
+        return None;
+    }
+    let freq_hz = (khz * 1000.0).round() as u64;
+
+    let dx_call = tokens[1].to_ascii_uppercase();
+    if !looks_like_call(&dx_call) {
+        return None;
+    }
+
+    let time_utc = tokens
+        .iter()
+        .find(|t| is_time_token(t))
+        .map(|t| t.to_ascii_uppercase())
+        .unwrap_or_default();
+
+    // Guard against arbitrary "<a> … <b>" chatter that happens to start with a
+    // number: demand a spotter or a time.
+    if spotter.is_none() && time_utc.is_empty() {
+        return None;
+    }
+
+    // Comment is the middle, minus the date and time tokens.
+    let comment = tokens
+        .iter()
+        .skip(2)
+        .filter(|t| !is_time_token(t) && !is_date_token(t))
+        .copied()
+        .collect::<Vec<_>>()
+        .join(" ");
+
+    Some(DxSpot {
+        dx_call,
+        freq_hz,
+        spotter: spotter.unwrap_or_default(),
         mode_hint: mode_hint_from(&comment),
         comment,
         time_utc,
@@ -171,6 +238,21 @@ fn is_time_token(tok: &str) -> bool {
         return false;
     }
     bytes[..n - 1].iter().all(|b| b.is_ascii_digit())
+}
+
+/// A date token in `sh/dx` output, e.g. `19-Jul-2026` — two dashes and a month
+/// abbreviation. Used to keep the date out of the parsed comment.
+fn is_date_token(tok: &str) -> bool {
+    tok.matches('-').count() == 2 && tok.chars().any(|c| c.is_ascii_alphabetic())
+}
+
+/// A plausible callsign: ≥3 chars, alphanumeric + `/`, with at least one digit
+/// and one letter. Guards the freq-first `sh/dx` parse against header rows.
+fn looks_like_call(s: &str) -> bool {
+    s.len() >= 3
+        && s.chars().all(|c| c.is_ascii_alphanumeric() || c == '/')
+        && s.chars().any(|c| c.is_ascii_digit())
+        && s.chars().any(|c| c.is_ascii_alphabetic())
 }
 
 /// Best-effort mode from a comment: first recognised digital/CW/phone keyword.
@@ -248,6 +330,38 @@ mod tests {
         assert_eq!(s.freq_hz, 144_200_000);
         assert_eq!(s.band, None); // 2m not in the HF band table
         assert_eq!(s.mode_hint.as_deref(), Some("SSB"));
+    }
+
+    #[test]
+    fn parses_show_dx_backfill_line() {
+        // sh/dx format: freq-first, date + time, spotter in <…>.
+        let s = parse_spot_line(
+            "  14025.0  JA1XYZ       19-Jul-2026 1432Z  CW                   <W3LPL>",
+            t0(),
+        )
+        .expect("should parse");
+        assert_eq!(s.freq_hz, 14_025_000);
+        assert_eq!(s.dx_call, "JA1XYZ");
+        assert_eq!(s.spotter, "W3LPL");
+        assert_eq!(s.time_utc, "1432Z");
+        assert_eq!(s.band, Some(HamBand::B20));
+        assert_eq!(s.mode_hint.as_deref(), Some("CW"));
+        assert_eq!(s.comment, "CW"); // date + time excluded
+    }
+
+    #[test]
+    fn show_dx_rejects_headers_and_chatter() {
+        for junk in [
+            "Date       Time  Freq   DX        Info",
+            "50 years on the air",
+            "Spots for the last hour:",
+            "14074.0 is a busy frequency", // token[1] not a call
+        ] {
+            assert!(
+                parse_spot_line(junk, t0()).is_none(),
+                "should have dropped: {junk:?}"
+            );
+        }
     }
 
     #[test]

--- a/rigflow-client/src/logging/callbook/callook.rs
+++ b/rigflow-client/src/logging/callbook/callook.rs
@@ -1,0 +1,100 @@
+//! Callook.info callsign lookup — US only, free, no auth. `GET
+//! https://callook.info/<call>/json`. A valid response is by definition a US
+//! call, so DXCC is 291 / United States; city + state come from the address.
+
+use serde::Deserialize;
+
+use super::{CallbookResult, Provider, Source};
+
+const BASE: &str = "https://callook.info";
+
+#[derive(Deserialize)]
+struct Resp {
+    status: String,
+    name: Option<String>,
+    address: Option<Address>,
+    location: Option<Location>,
+    current: Option<Current>,
+}
+
+#[derive(Deserialize)]
+struct Address {
+    line2: Option<String>, // "CITY, ST ZIP"
+}
+
+#[derive(Deserialize)]
+struct Location {
+    gridsquare: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct Current {
+    #[serde(rename = "operClass")]
+    oper_class: Option<String>,
+}
+
+/// Look up a US callsign. `Ok(Some)` = valid US call, `Ok(None)` = not a valid
+/// US call (or Callook has nothing), `Err` = transport/parse error.
+pub fn lookup(agent: &ureq::Agent, call: &str) -> Result<Option<CallbookResult>, String> {
+    let url = format!("{BASE}/{call}/json");
+    let resp = match agent.get(&url).call() {
+        Ok(r) => r,
+        Err(ureq::Error::Status(404, _)) => return Ok(None),
+        Err(e) => return Err(super::redact(e)),
+    };
+    let body = resp
+        .into_string()
+        .map_err(|e| format!("reading Callook response: {e}"))?;
+    let r: Resp = serde_json::from_str(&body).map_err(|e| format!("parsing Callook JSON: {e}"))?;
+    if !r.status.eq_ignore_ascii_case("VALID") {
+        return Ok(None);
+    }
+    let (qth, state) = r
+        .address
+        .and_then(|a| a.line2)
+        .map(|l| split_city_state(&l))
+        .unwrap_or((None, None));
+    Ok(Some(CallbookResult {
+        name: r.name.filter(|s| !s.trim().is_empty()),
+        grid: r
+            .location
+            .and_then(|l| l.gridsquare)
+            .filter(|s| !s.trim().is_empty()),
+        qth,
+        state,
+        county: None,
+        country: Some("United States".into()),
+        dxcc: Some(291), // a valid Callook result is a US call
+        cq_zone: None,   // varies by call area — leave to the prefix baseline/provider
+        itu_zone: None,
+        license_class: r.current.and_then(|c| c.oper_class),
+        source: Source::Provider(Provider::Callook),
+    }))
+}
+
+/// Split "NEWINGTON, CT 06111" → (Some("NEWINGTON"), Some("CT")).
+fn split_city_state(line2: &str) -> (Option<String>, Option<String>) {
+    let Some((city, rest)) = line2.split_once(',') else {
+        return (None, None);
+    };
+    let city = city.trim();
+    let state = rest.split_whitespace().next().unwrap_or("");
+    (
+        (!city.is_empty()).then(|| city.to_string()),
+        (!state.is_empty()).then(|| state.to_string()),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn splits_city_and_state() {
+        assert_eq!(
+            split_city_state("NEWINGTON, CT 06111"),
+            (Some("NEWINGTON".into()), Some("CT".into()))
+        );
+        assert_eq!(split_city_state("nowhere"), (None, None));
+    }
+}

--- a/rigflow-client/src/logging/callbook/hamqth.rs
+++ b/rigflow-client/src/logging/callbook/hamqth.rs
@@ -1,0 +1,100 @@
+//! HamQTH callsign lookup. Two-step: log in (username+password → `session_id`,
+//! 1-hour TTL), then look up (`id=<sid>&callsign=<call>&prg=rigflow`). Free with
+//! registration. Session handling is in [`super::CallbookClient`]; this module
+//! owns URL building + XML parsing.
+
+use super::{CallbookResult, Provider, Source, redact, xml_tag};
+
+const BASE: &str = "https://www.hamqth.com/xml.php";
+
+/// Log in and return the session id, or an error string.
+pub fn login(agent: &ureq::Agent, user: &str, password: &str) -> Result<String, String> {
+    let body = agent
+        .get(BASE)
+        .query("u", user)
+        .query("p", password)
+        .call()
+        .map_err(redact)?
+        .into_string()
+        .map_err(|e| format!("reading HamQTH response: {e}"))?;
+    match xml_tag(&body, "session_id") {
+        Some(sid) => Ok(sid),
+        None => Err(xml_tag(&body, "error").unwrap_or_else(|| "HamQTH login failed".into())),
+    }
+}
+
+/// Raw lookup response for `call` using `session_id`.
+pub fn lookup_raw(agent: &ureq::Agent, sid: &str, call: &str) -> Result<String, String> {
+    agent
+        .get(BASE)
+        .query("id", sid)
+        .query("callsign", call)
+        .query("prg", "rigflow")
+        .call()
+        .map_err(redact)?
+        .into_string()
+        .map_err(|e| format!("reading HamQTH response: {e}"))
+}
+
+/// Whether the response says the session expired/invalid (→ caller re-logs in).
+pub fn session_invalid(body: &str) -> bool {
+    xml_tag(body, "error")
+        .unwrap_or_default()
+        .to_ascii_lowercase()
+        .contains("session")
+}
+
+/// Parse a search response. `Ok(Some)` = found, `Ok(None)` = not found, `Err` =
+/// a real error (a session error is left for the caller's check first).
+pub fn parse_search(body: &str) -> Result<Option<CallbookResult>, String> {
+    if let Some(err) = xml_tag(body, "error") {
+        if err.to_ascii_lowercase().contains("not found") {
+            return Ok(None);
+        }
+        return Err(err);
+    }
+    if xml_tag(body, "callsign").is_none() {
+        return Ok(None);
+    }
+    Ok(Some(CallbookResult {
+        // `adr_name` is the licensee's real name; `nick` is a handle.
+        name: xml_tag(body, "adr_name").or_else(|| xml_tag(body, "nick")),
+        grid: xml_tag(body, "grid"),
+        qth: xml_tag(body, "qth"),
+        state: xml_tag(body, "us_state"),
+        county: xml_tag(body, "us_county"),
+        country: xml_tag(body, "country"),
+        dxcc: xml_tag(body, "adif").and_then(|s| s.trim().parse().ok()),
+        cq_zone: xml_tag(body, "cq"),
+        itu_zone: xml_tag(body, "itu"),
+        license_class: None,
+        source: Source::Provider(Provider::HamQTH),
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_a_search() {
+        let xml = "<HamQTH><search><callsign>ok7an</callsign><nick>Petr</nick>\
+                   <adr_name>Petr Novak</adr_name><qth>Praha</qth><country>Czech Republic</country>\
+                   <adif>503</adif><grid>JO70</grid><cq>15</cq><itu>28</itu></search></HamQTH>";
+        let r = parse_search(xml).unwrap().unwrap();
+        assert_eq!(r.name.as_deref(), Some("Petr Novak"));
+        assert_eq!(r.grid.as_deref(), Some("JO70"));
+        assert_eq!(r.dxcc, Some(503));
+        assert_eq!(r.itu_zone.as_deref(), Some("28"));
+    }
+
+    #[test]
+    fn not_found_and_session_error() {
+        let nf = "<HamQTH><session><error>Callsign not found</error></session></HamQTH>";
+        assert_eq!(parse_search(nf).unwrap(), None);
+        assert!(!session_invalid(nf));
+        let se =
+            "<HamQTH><session><error>Session does not exist or expired</error></session></HamQTH>";
+        assert!(session_invalid(se));
+    }
+}

--- a/rigflow-client/src/logging/callbook/mod.rs
+++ b/rigflow-client/src/logging/callbook/mod.rs
@@ -1,0 +1,420 @@
+//! Callbook lookup — enrich a QSO with the operator's details (name, grid, QTH,
+//! DXCC/zones) from an online callbook, with an always-on offline prefix baseline.
+//!
+//! Design: `docs/release-review/callbook-lookup-design.md`. This module is the
+//! **pure core** — providers ([`qrz`], [`hamqth`], [`callook`]), the offline
+//! [`prefix`] baseline, and the [`CallbookClient`] orchestration (priority order,
+//! first-match-wins, session caching). The worker wiring and the `L`-window merge
+//! live elsewhere (see the design's §7/§8).
+//!
+//! Providers differ in auth (QRZ + HamQTH need a session from username+password;
+//! Callook is no-auth, US-only) but every one returns a normalized
+//! [`CallbookResult`]. The **merge** (Typed > Online > Prefix) happens in the UI
+//! against the draft; here we just produce results.
+
+pub mod callook;
+pub mod hamqth;
+pub mod prefix;
+pub mod qrz;
+
+/// An online callbook.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Provider {
+    Qrz,
+    HamQTH,
+    Callook,
+}
+
+impl Provider {
+    pub const ALL: [Provider; 3] = [Provider::Qrz, Provider::HamQTH, Provider::Callook];
+
+    /// Stable config key.
+    pub fn key(self) -> &'static str {
+        match self {
+            Provider::Qrz => "qrz",
+            Provider::HamQTH => "hamqth",
+            Provider::Callook => "callook",
+        }
+    }
+
+    pub fn from_key(k: &str) -> Option<Provider> {
+        Provider::ALL.into_iter().find(|p| p.key() == k)
+    }
+
+    /// Credential-store key (distinct from the sync service keys). Callook has none.
+    pub fn cred_key(self) -> Option<&'static str> {
+        match self {
+            Provider::Qrz => Some("qrz-xml"),
+            Provider::HamQTH => Some("hamqth"),
+            Provider::Callook => None,
+        }
+    }
+
+    pub fn name(self) -> &'static str {
+        match self {
+            Provider::Qrz => "QRZ",
+            Provider::HamQTH => "HamQTH",
+            Provider::Callook => "Callook",
+        }
+    }
+}
+
+/// Per-operator callbook configuration: which providers are on, and in what
+/// priority order. Persisted as `callbook.json` in the operator directory
+/// (credentials themselves live in the keyring/file store, not here).
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct CallbookConfig {
+    #[serde(default = "default_order")]
+    pub order: Vec<String>,
+    #[serde(default)]
+    pub enabled: Vec<String>,
+}
+
+fn default_order() -> Vec<String> {
+    vec!["qrz".into(), "hamqth".into(), "callook".into()]
+}
+
+impl Default for CallbookConfig {
+    fn default() -> Self {
+        CallbookConfig {
+            order: default_order(),
+            enabled: Vec::new(),
+        }
+    }
+}
+
+impl CallbookConfig {
+    pub fn is_enabled(&self, p: Provider) -> bool {
+        self.enabled.iter().any(|k| k == p.key())
+    }
+
+    pub fn set_enabled(&mut self, p: Provider, on: bool) {
+        self.enabled.retain(|k| k != p.key());
+        if on {
+            self.enabled.push(p.key().to_string());
+        }
+    }
+
+    /// Providers in priority order (unknown keys skipped, missing ones appended).
+    pub fn ordered(&self) -> Vec<Provider> {
+        let mut out: Vec<Provider> = self
+            .order
+            .iter()
+            .filter_map(|k| Provider::from_key(k))
+            .collect();
+        for p in Provider::ALL {
+            if !out.contains(&p) {
+                out.push(p);
+            }
+        }
+        out
+    }
+
+    /// Enabled providers in priority order — what the worker actually queries.
+    pub fn active(&self) -> Vec<Provider> {
+        self.ordered()
+            .into_iter()
+            .filter(|p| self.is_enabled(*p))
+            .collect()
+    }
+
+    pub fn move_up(&mut self, p: Provider) {
+        self.normalize_order();
+        if let Some(i) = self.order.iter().position(|k| k == p.key())
+            && i > 0
+        {
+            self.order.swap(i, i - 1);
+        }
+    }
+
+    pub fn move_down(&mut self, p: Provider) {
+        self.normalize_order();
+        if let Some(i) = self.order.iter().position(|k| k == p.key())
+            && i + 1 < self.order.len()
+        {
+            self.order.swap(i, i + 1);
+        }
+    }
+
+    /// Ensure `order` lists every provider exactly once (self-heal a hand-edited
+    /// or older file) before a swap.
+    fn normalize_order(&mut self) {
+        self.order = self.ordered().iter().map(|p| p.key().to_string()).collect();
+    }
+}
+
+const CONFIG_FILE: &str = "callbook.json";
+
+pub fn load_config(operator_dir: &std::path::Path) -> CallbookConfig {
+    std::fs::read_to_string(operator_dir.join(CONFIG_FILE))
+        .ok()
+        .and_then(|s| serde_json::from_str(&s).ok())
+        .unwrap_or_default()
+}
+
+pub fn save_config(operator_dir: &std::path::Path, cfg: &CallbookConfig) -> std::io::Result<()> {
+    let json = serde_json::to_string_pretty(cfg).unwrap_or_default();
+    std::fs::write(operator_dir.join(CONFIG_FILE), json)
+}
+
+/// Loaded credentials for the auth'd providers. A provider with `None` here is
+/// skipped even if it appears in the priority order.
+#[derive(Debug, Clone, Default)]
+pub struct CallbookCreds {
+    pub qrz: Option<super::credentials::Credential>,
+    pub hamqth: Option<super::credentials::Credential>,
+}
+
+/// A normalized callbook result. Every field is optional — different providers
+/// and the offline prefix baseline fill different subsets. `None` means "this
+/// source had nothing for this field", which is what lets the UI merge sources
+/// per-field (online overwrites prefix only where online actually has a value).
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct CallbookResult {
+    pub name: Option<String>,
+    pub grid: Option<String>,
+    pub qth: Option<String>,
+    pub state: Option<String>,
+    pub county: Option<String>,
+    pub country: Option<String>,
+    pub dxcc: Option<i64>,
+    pub cq_zone: Option<String>,
+    pub itu_zone: Option<String>,
+    pub license_class: Option<String>,
+    /// Which source produced this (for the UI's "via QRZ / via prefix" note).
+    pub source: Source,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum Source {
+    #[default]
+    Prefix,
+    Provider(Provider),
+}
+
+impl Source {
+    /// Short label for the "via …" note — the provider's name, or "prefix".
+    pub fn label(self) -> &'static str {
+        match self {
+            Source::Prefix => "prefix",
+            Source::Provider(p) => p.name(),
+        }
+    }
+}
+
+impl CallbookResult {
+    /// Nothing useful was found.
+    pub fn is_empty(&self) -> bool {
+        self.name.is_none()
+            && self.grid.is_none()
+            && self.qth.is_none()
+            && self.state.is_none()
+            && self.county.is_none()
+            && self.country.is_none()
+            && self.dxcc.is_none()
+            && self.cq_zone.is_none()
+            && self.itu_zone.is_none()
+    }
+
+    /// The ADIF `extra` fields this result contributes (everything that is not a
+    /// modeled `Qso` column — `gridsquare`/`dxcc` are columns and handled by the
+    /// caller). Only present values are emitted.
+    pub fn extra_fields(&self) -> Vec<(&'static str, String)> {
+        let mut out = Vec::new();
+        let mut push = |k: &'static str, v: &Option<String>| {
+            if let Some(v) = v.as_ref().filter(|s| !s.trim().is_empty()) {
+                out.push((k, v.trim().to_string()));
+            }
+        };
+        push("NAME", &self.name);
+        push("QTH", &self.qth);
+        push("STATE", &self.state);
+        push("CNTY", &self.county);
+        push("COUNTRY", &self.country);
+        push("CQZ", &self.cq_zone);
+        push("ITUZ", &self.itu_zone);
+        out
+    }
+}
+
+/// Overlay `online` onto `prefix`, per field — online wins where it has a value,
+/// prefix fills the rest. Either may be absent. This is how the instant offline
+/// floor and the async provider result combine into one effective result.
+pub fn merge(
+    prefix: Option<CallbookResult>,
+    online: Option<CallbookResult>,
+) -> Option<CallbookResult> {
+    match (prefix, online) {
+        (None, None) => None,
+        (Some(r), None) | (None, Some(r)) => Some(r),
+        (Some(p), Some(o)) => Some(CallbookResult {
+            name: o.name.or(p.name),
+            grid: o.grid.or(p.grid),
+            qth: o.qth.or(p.qth),
+            state: o.state.or(p.state),
+            county: o.county.or(p.county),
+            country: o.country.or(p.country),
+            dxcc: o.dxcc.or(p.dxcc),
+            cq_zone: o.cq_zone.or(p.cq_zone),
+            itu_zone: o.itu_zone.or(p.itu_zone),
+            license_class: o.license_class.or(p.license_class),
+            source: o.source, // the online provider that supplied the overlay
+        }),
+    }
+}
+
+/// Holds the ureq agent and cached provider sessions. The worker owns one; the
+/// sessions persist across lookups and are re-acquired lazily when a provider
+/// reports an expired/invalid session.
+pub struct CallbookClient {
+    agent: ureq::Agent,
+    qrz_session: Option<String>,
+    hamqth_session: Option<String>,
+}
+
+impl Default for CallbookClient {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl CallbookClient {
+    pub fn new() -> Self {
+        CallbookClient {
+            agent: ureq::AgentBuilder::new()
+                .timeout(std::time::Duration::from_secs(15))
+                .build(),
+            qrz_session: None,
+            hamqth_session: None,
+        }
+    }
+
+    /// Look a callsign up, trying each enabled provider in `order` until one
+    /// returns a non-empty result. A provider that errors or has no match is
+    /// skipped (errors are logged, redacted). `None` = nobody had it.
+    pub fn lookup(
+        &mut self,
+        order: &[Provider],
+        creds: &CallbookCreds,
+        call: &str,
+    ) -> Option<CallbookResult> {
+        let call = call.trim().to_ascii_uppercase();
+        if call.is_empty() {
+            return None;
+        }
+        for &p in order {
+            let got = match p {
+                Provider::Qrz => match &creds.qrz {
+                    Some(c) => self.qrz_lookup(&c.login, &c.password, &call),
+                    None => continue,
+                },
+                Provider::HamQTH => match &creds.hamqth {
+                    Some(c) => self.hamqth_lookup(&c.login, &c.password, &call),
+                    None => continue,
+                },
+                Provider::Callook => callook::lookup(&self.agent, &call),
+            };
+            match got {
+                Ok(Some(r)) if !r.is_empty() => return Some(r),
+                Ok(_) => {} // not found → next provider
+                Err(e) => eprintln!("callbook: {} lookup failed: {e}", p.name()),
+            }
+        }
+        None
+    }
+
+    /// QRZ XML: cached session key, re-login once on an expired/invalid session.
+    fn qrz_lookup(
+        &mut self,
+        user: &str,
+        password: &str,
+        call: &str,
+    ) -> Result<Option<CallbookResult>, String> {
+        for attempt in 0..2 {
+            if self.qrz_session.is_none() {
+                self.qrz_session = Some(qrz::login(&self.agent, user, password)?);
+            }
+            let key = self.qrz_session.clone().unwrap();
+            let body = qrz::lookup_raw(&self.agent, &key, call)?;
+            if qrz::session_expired(&body) && attempt == 0 {
+                self.qrz_session = None; // force re-login and retry once
+                continue;
+            }
+            return qrz::parse_callsign(&body);
+        }
+        Ok(None)
+    }
+
+    /// HamQTH: cached session id, re-login once on an invalid session.
+    fn hamqth_lookup(
+        &mut self,
+        user: &str,
+        password: &str,
+        call: &str,
+    ) -> Result<Option<CallbookResult>, String> {
+        for attempt in 0..2 {
+            if self.hamqth_session.is_none() {
+                self.hamqth_session = Some(hamqth::login(&self.agent, user, password)?);
+            }
+            let sid = self.hamqth_session.clone().unwrap();
+            let body = hamqth::lookup_raw(&self.agent, &sid, call)?;
+            if hamqth::session_invalid(&body) && attempt == 0 {
+                self.hamqth_session = None;
+                continue;
+            }
+            return hamqth::parse_search(&body);
+        }
+        Ok(None)
+    }
+}
+
+// ---- shared parse/redact helpers used by the XML providers ----
+
+/// Extract the text of the first `<tag>…</tag>` (case-insensitive tag match),
+/// trimmed, `None` if absent or empty. Good enough for QRZ/HamQTH's flat XML —
+/// no XML dependency, no nesting to worry about for the fields we read.
+pub(crate) fn xml_tag(body: &str, tag: &str) -> Option<String> {
+    let lower = body.to_ascii_lowercase();
+    let open = format!("<{}>", tag.to_ascii_lowercase());
+    let close = format!("</{}>", tag.to_ascii_lowercase());
+    let start = lower.find(&open)? + open.len();
+    let end = lower[start..].find(&close)? + start;
+    let v = body.get(start..end)?.trim();
+    (!v.is_empty()).then(|| v.to_string())
+}
+
+/// Redact a ureq transport error — the QRZ/HamQTH login URLs carry the password
+/// as a query param, so their `Display` must never reach a log or the UI.
+pub(crate) fn redact(e: ureq::Error) -> String {
+    match e {
+        ureq::Error::Status(code, _) => format!("HTTP {code}"),
+        ureq::Error::Transport(t) => format!("network error ({})", t.kind()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn xml_tag_extracts_case_insensitively() {
+        let xml = "<Callsign><call>W1AW</call><grid>FN31pr</grid></Callsign>";
+        assert_eq!(xml_tag(xml, "call").as_deref(), Some("W1AW"));
+        assert_eq!(xml_tag(xml, "GRID").as_deref(), Some("FN31pr"));
+        assert_eq!(xml_tag(xml, "name"), None);
+    }
+
+    #[test]
+    fn extra_fields_emits_only_present_values() {
+        let r = CallbookResult {
+            name: Some("Dave".into()),
+            qth: Some("  ".into()), // blank → skipped
+            state: Some("CT".into()),
+            ..Default::default()
+        };
+        let f = r.extra_fields();
+        assert!(f.contains(&("NAME", "Dave".to_string())));
+        assert!(f.contains(&("STATE", "CT".to_string())));
+        assert!(!f.iter().any(|(k, _)| *k == "QTH"));
+    }
+}

--- a/rigflow-client/src/logging/callbook/prefix.rs
+++ b/rigflow-client/src/logging/callbook/prefix.rs
@@ -1,0 +1,151 @@
+//! Offline prefix baseline — derive DXCC entity + CQ/ITU zone from a callsign's
+//! prefix, with no network. The always-on instant floor under the online
+//! providers (design §5.1).
+//!
+//! **v1 uses a curated starter table**, matched longest-prefix-first with basic
+//! portable-call handling. It covers the common entities but is deliberately
+//! incomplete; the completion is to load the full `cty.dat` (AD1C country file)
+//! that N1MM/DXLab use — a self-contained follow-up that keeps this same
+//! `resolve()` interface. Online providers return the same fields, so an
+//! incomplete table only limits *offline* coverage, never a provider lookup.
+
+use super::{CallbookResult, Source};
+
+/// (prefix, dxcc, country, cq_zone, itu_zone). Longest matching prefix wins, so
+/// more-specific entries (KH6, KL, KP4) must be able to beat the generic (K/W/N).
+/// US call areas don't change the entity, so a single K/W/N/A entry suffices for
+/// the contiguous US; the offshore US prefixes are listed separately.
+const TABLE: &[(&str, i64, &str, u8, u8)] = &[
+    // United States (contiguous) and offshore
+    ("KH6", 110, "Hawaii", 31, 61),
+    ("KH7", 110, "Hawaii", 31, 61),
+    ("KL", 6, "Alaska", 1, 1),
+    ("KP4", 202, "Puerto Rico", 8, 11),
+    ("KP2", 285, "US Virgin Islands", 8, 11),
+    ("K", 291, "United States", 5, 8),
+    ("W", 291, "United States", 5, 8),
+    ("N", 291, "United States", 5, 8),
+    ("AA", 291, "United States", 5, 8),
+    ("AK", 291, "United States", 5, 8),
+    ("AL", 291, "United States", 5, 8),
+    // Canada
+    ("VE", 1, "Canada", 5, 9),
+    ("VA", 1, "Canada", 5, 9),
+    ("VO", 1, "Canada", 5, 9),
+    ("VY", 1, "Canada", 5, 9),
+    // England / UK family (broad; sub-entities left to cty.dat)
+    ("G", 223, "England", 14, 27),
+    ("M", 223, "England", 14, 27),
+    ("2E", 223, "England", 14, 27),
+    // Germany
+    ("DL", 230, "Germany", 14, 28),
+    ("DA", 230, "Germany", 14, 28),
+    ("DK", 230, "Germany", 14, 28),
+    ("DD", 230, "Germany", 14, 28),
+    // Japan
+    ("JA", 339, "Japan", 25, 45),
+    ("JR", 339, "Japan", 25, 45),
+    ("JH", 339, "Japan", 25, 45),
+    ("7K", 339, "Japan", 25, 45),
+    // Oceania
+    ("VK", 150, "Australia", 30, 59),
+    ("ZL", 170, "New Zealand", 32, 60),
+    ("FK", 162, "New Caledonia", 32, 56),
+    // South / Central America (entities seen in the log)
+    ("PY", 108, "Brazil", 11, 15),
+    ("PP", 108, "Brazil", 11, 15),
+    ("PT", 108, "Brazil", 11, 15),
+    ("HK", 116, "Colombia", 9, 12),
+    ("HP", 88, "Panama", 7, 11),
+    ("3E", 88, "Panama", 7, 11),
+];
+
+/// Resolve entity + zones from `call`, offline. `None` if the prefix isn't in the
+/// v1 table (an online provider may still know it).
+pub fn resolve(call: &str) -> Option<CallbookResult> {
+    let up = call.trim().to_ascii_uppercase();
+    if up.is_empty() {
+        return None;
+    }
+    // Portable calls: consider each `/`-segment that isn't a plain suffix, and let
+    // the longest matched prefix across them win (so W1AW/KH6 → Hawaii, not US).
+    let segments: Vec<&str> = up.split('/').filter(|s| !is_suffix(s)).collect();
+    let candidates: Vec<&str> = if segments.is_empty() {
+        vec![up.as_str()]
+    } else {
+        segments
+    };
+
+    let (_, dxcc, country, cq, itu) = candidates
+        .iter()
+        .filter_map(|c| match_entity(c))
+        .max_by_key(|(plen, ..)| *plen)?;
+
+    Some(CallbookResult {
+        country: Some(country.to_string()),
+        dxcc: Some(dxcc),
+        cq_zone: Some(cq.to_string()),
+        itu_zone: Some(itu.to_string()),
+        source: Source::Prefix,
+        ..Default::default()
+    })
+}
+
+/// The table entry whose prefix `call` starts with, longest first. Returns the
+/// matched prefix length so a caller can pick the best across portable segments.
+fn match_entity(call: &str) -> Option<(usize, i64, &'static str, u8, u8)> {
+    TABLE
+        .iter()
+        .filter(|(p, ..)| call.starts_with(p))
+        .max_by_key(|(p, ..)| p.len())
+        .map(|&(p, dxcc, country, cq, itu)| (p.len(), dxcc, country, cq, itu))
+}
+
+/// A `/`-segment that is a portable/status suffix, not a location prefix — these
+/// don't change the DXCC entity (a `/`-number changes US call area only).
+fn is_suffix(seg: &str) -> bool {
+    matches!(seg, "P" | "M" | "MM" | "AM" | "A" | "QRP" | "QRPP")
+        || (seg.len() == 1 && seg.chars().all(|c| c.is_ascii_digit()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolves_common_entities() {
+        assert_eq!(resolve("W1AW").unwrap().dxcc, Some(291));
+        assert_eq!(
+            resolve("N5WXB").unwrap().country.as_deref(),
+            Some("United States")
+        );
+        assert_eq!(resolve("3E40CDW").unwrap().dxcc, Some(88)); // Panama
+        assert_eq!(
+            resolve("PY1USK").unwrap().country.as_deref(),
+            Some("Brazil")
+        );
+        assert_eq!(resolve("VK3ABC").unwrap().dxcc, Some(150));
+    }
+
+    #[test]
+    fn longest_prefix_and_offshore_us_win() {
+        // KH6 must beat the generic K entry.
+        assert_eq!(resolve("KH6XYZ").unwrap().dxcc, Some(110)); // Hawaii
+        assert_eq!(resolve("KL7ABC").unwrap().dxcc, Some(6)); // Alaska
+        assert_eq!(resolve("KP4AA").unwrap().dxcc, Some(202)); // Puerto Rico
+    }
+
+    #[test]
+    fn portable_uses_the_location_prefix() {
+        // Operating from Hawaii → Hawaii, not the home US call.
+        assert_eq!(resolve("W1AW/KH6").unwrap().dxcc, Some(110));
+        // A plain /P or /M suffix doesn't change the entity.
+        assert_eq!(resolve("G3XYZ/P").unwrap().dxcc, Some(223));
+        assert_eq!(resolve("W1AW/7").unwrap().dxcc, Some(291));
+    }
+
+    #[test]
+    fn unknown_prefix_is_none() {
+        assert_eq!(resolve("XX9ZZ"), None);
+    }
+}

--- a/rigflow-client/src/logging/callbook/qrz.rs
+++ b/rigflow-client/src/logging/callbook/qrz.rs
@@ -1,0 +1,117 @@
+//! QRZ XML callsign lookup. Two-step: log in (username+password → session key),
+//! then look up (`s=<key>;callsign=<call>`). Requires an XML Logbook Data
+//! subscription. Session handling (cache + re-login) is in [`super::CallbookClient`];
+//! this module owns URL building + XML parsing (pure, unit-tested).
+//!
+//! NB the credential here is the qrz.com **login** (XML API), NOT the QRZ Logbook
+//! API KEY used for QSO sync.
+
+use super::{CallbookResult, Provider, Source, redact, xml_tag};
+
+const BASE: &str = "https://xmldata.qrz.com/xml/current/";
+
+/// Log in and return the session key, or an error string.
+pub fn login(agent: &ureq::Agent, user: &str, password: &str) -> Result<String, String> {
+    // The spec shows `;`-separated params; ureq joins with `&` (and url-encodes),
+    // which QRZ's ColdFusion accepts. Switch to a manual `;` URL if lookups fail.
+    let body = agent
+        .get(BASE)
+        .query("username", user)
+        .query("password", password)
+        .query("agent", "rigflow")
+        .call()
+        .map_err(redact)?
+        .into_string()
+        .map_err(|e| format!("reading QRZ response: {e}"))?;
+    match xml_tag(&body, "Key") {
+        Some(key) => Ok(key),
+        None => Err(xml_tag(&body, "Error").unwrap_or_else(|| "QRZ login failed".into())),
+    }
+}
+
+/// Raw lookup response for `call` using session `key`.
+pub fn lookup_raw(agent: &ureq::Agent, key: &str, call: &str) -> Result<String, String> {
+    agent
+        .get(BASE)
+        .query("s", key)
+        .query("callsign", call)
+        .call()
+        .map_err(redact)?
+        .into_string()
+        .map_err(|e| format!("reading QRZ response: {e}"))
+}
+
+/// Whether the response says the session expired/invalid (→ caller re-logs in).
+pub fn session_expired(body: &str) -> bool {
+    let e = xml_tag(body, "Error")
+        .unwrap_or_default()
+        .to_ascii_lowercase();
+    e.contains("session") && (e.contains("timeout") || e.contains("invalid"))
+}
+
+/// Parse a lookup response. `Ok(Some)` = found, `Ok(None)` = not found, `Err` =
+/// a real error (a session error is left for the caller's expiry check first).
+pub fn parse_callsign(body: &str) -> Result<Option<CallbookResult>, String> {
+    if let Some(err) = xml_tag(body, "Error") {
+        let low = err.to_ascii_lowercase();
+        if low.starts_with("not found") {
+            return Ok(None);
+        }
+        return Err(err);
+    }
+    if xml_tag(body, "call").is_none() {
+        return Ok(None);
+    }
+    Ok(Some(CallbookResult {
+        name: full_name(body),
+        grid: xml_tag(body, "grid"),
+        qth: xml_tag(body, "addr2"), // city/town
+        state: xml_tag(body, "state"),
+        county: xml_tag(body, "county"),
+        country: xml_tag(body, "country"),
+        dxcc: xml_tag(body, "dxcc").and_then(|s| s.trim().parse().ok()),
+        cq_zone: xml_tag(body, "cqzone"),
+        itu_zone: xml_tag(body, "ituzone"),
+        license_class: xml_tag(body, "class"),
+        source: Source::Provider(Provider::Qrz),
+    }))
+}
+
+/// `<fname>` + `<name>` (first + last).
+fn full_name(body: &str) -> Option<String> {
+    match (xml_tag(body, "fname"), xml_tag(body, "name")) {
+        (Some(f), Some(l)) => Some(format!("{f} {l}")),
+        (Some(f), None) => Some(f),
+        (None, Some(l)) => Some(l),
+        (None, None) => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_a_callsign() {
+        let xml = "<QRZDatabase><Callsign><call>W1AW</call><fname>ARRL HQ</fname>\
+                   <name>OPERATORS CLUB</name><addr2>Newington</addr2><state>CT</state>\
+                   <county>Hartford</county><country>United States</country><dxcc>291</dxcc>\
+                   <grid>FN31pr</grid><cqzone>5</cqzone><ituzone>8</ituzone><class>C</class>\
+                   </Callsign></QRZDatabase>";
+        let r = parse_callsign(xml).unwrap().unwrap();
+        assert_eq!(r.name.as_deref(), Some("ARRL HQ OPERATORS CLUB"));
+        assert_eq!(r.grid.as_deref(), Some("FN31pr"));
+        assert_eq!(r.state.as_deref(), Some("CT"));
+        assert_eq!(r.dxcc, Some(291));
+        assert_eq!(r.cq_zone.as_deref(), Some("5"));
+    }
+
+    #[test]
+    fn not_found_is_none_expiry_is_flagged() {
+        let nf = "<QRZDatabase><Session><Error>Not found: g1srdd</Error></Session></QRZDatabase>";
+        assert_eq!(parse_callsign(nf).unwrap(), None);
+        let to = "<QRZDatabase><Session><Error>Session Timeout</Error></Session></QRZDatabase>";
+        assert!(session_expired(to));
+        assert!(!session_expired(nf));
+    }
+}

--- a/rigflow-client/src/logging/export.rs
+++ b/rigflow-client/src/logging/export.rs
@@ -32,6 +32,7 @@ use rigflow_log::export::{
 use rigflow_log::import::ImportPlan;
 use rigflow_log::normalize::{self, ModeClass};
 
+use crate::logging::callbook::{CallbookClient, CallbookCreds, CallbookResult, Provider};
 use crate::logging::services::{Direction, Service};
 
 /// How long the UI waits after the last edit before re-querying.
@@ -374,6 +375,14 @@ pub enum ExportJob {
         /// `not_uploaded_to` filter). The service dedups any real duplicates.
         force: bool,
     },
+    /// Look a callsign up in the online callbook(s), off the UI thread. Coalesced
+    /// like `CallLookup` — while the operator types, only the newest matters.
+    CallbookLookup {
+        order: Vec<Provider>,
+        creds: Box<CallbookCreds>,
+        call: String,
+        seq: u64,
+    },
 }
 
 /// What the worker reports back.
@@ -405,6 +414,13 @@ pub enum ExportEvent {
         service: Service,
         result: Result<SyncOutcome, String>,
     },
+    /// A callbook lookup finished (`seq`/`call` echoed for stale-drop). `None` =
+    /// no provider had the call.
+    CallbookResolved {
+        seq: u64,
+        call: String,
+        result: Option<Box<CallbookResult>>,
+    },
 }
 
 /// What a completed [`ExportJob::ServiceSync`] produced.
@@ -435,10 +451,13 @@ pub fn spawn_export_worker() -> (Sender<ExportJob>, Receiver<ExportEvent>) {
     std::thread::Builder::new()
         .name("export".into())
         .spawn(move || {
+            // Persists across jobs so QRZ/HamQTH sessions are cached + reused.
+            let mut callbook = CallbookClient::new();
             while let Ok(job) = job_rx.recv() {
                 let mut latest_query: Option<ExportJob> = None;
                 let mut latest_lookup: Option<ExportJob> = None;
                 let mut latest_count: Option<ExportJob> = None;
+                let mut latest_callbook: Option<ExportJob> = None;
                 let mut jobs = vec![job];
                 jobs.extend(job_rx.try_iter());
 
@@ -447,6 +466,7 @@ pub fn spawn_export_worker() -> (Sender<ExportJob>, Receiver<ExportEvent>) {
                         q @ ExportJob::Query { .. } => latest_query = Some(q),
                         l @ ExportJob::CallLookup { .. } => latest_lookup = Some(l),
                         c @ ExportJob::Count { .. } => latest_count = Some(c),
+                        cb @ ExportJob::CallbookLookup { .. } => latest_callbook = Some(cb),
                         // Never coalesced: each is an explicit operator action.
                         w @ (ExportJob::Write { .. }
                         | ExportJob::PlanImport { .. }
@@ -462,6 +482,21 @@ pub fn spawn_export_worker() -> (Sender<ExportJob>, Receiver<ExportEvent>) {
                     .flatten()
                 {
                     if evt_tx.send(run(job)).is_err() {
+                        return;
+                    }
+                }
+                if let Some(ExportJob::CallbookLookup {
+                    order,
+                    creds,
+                    call,
+                    seq,
+                }) = latest_callbook
+                {
+                    let result = callbook.lookup(&order, &creds, &call).map(Box::new);
+                    if evt_tx
+                        .send(ExportEvent::CallbookResolved { seq, call, result })
+                        .is_err()
+                    {
                         return;
                     }
                 }
@@ -545,6 +580,10 @@ fn run(job: ExportJob) -> ExportEvent {
                 Direction::Upload => run_upload(&db_path, service, &login, &password, force),
             };
             ExportEvent::ServiceSynced { service, result }
+        }
+        // Handled in the worker loop (needs the persistent CallbookClient), never here.
+        ExportJob::CallbookLookup { .. } => {
+            unreachable!("CallbookLookup is handled in the worker loop, not run()")
         }
     }
 }

--- a/rigflow-client/src/logging/lifecycle.rs
+++ b/rigflow-client/src/logging/lifecycle.rs
@@ -56,6 +56,19 @@ impl RigflowApp {
         let mut qso = qso;
         qso.normalize();
 
+        // Offline prefix baseline: give any QSO that arrives without a DXCC entity
+        // (notably WSJT-X captures) its entity + CQ/ITU zones before the journal
+        // write. Instant, network-free, fill-absent — the manual `L` path already
+        // set these via the callbook merge, so this is a no-op there.
+        if qso.dxcc.is_none()
+            && let Some(p) = crate::logging::callbook::prefix::resolve(&qso.call)
+        {
+            qso.dxcc = p.dxcc;
+            for (k, v) in p.extra_fields() {
+                qso.extra.entry(k.to_string()).or_insert(v);
+            }
+        }
+
         let (op, name, profile) = {
             let s = self.state.lock().unwrap();
             (

--- a/rigflow-client/src/logging/mod.rs
+++ b/rigflow-client/src/logging/mod.rs
@@ -5,6 +5,7 @@
 //! per-operator `LogStore` and the insert/query paths. The egui surfaces (entry
 //! window, contact-view window, Station panel) live under `ui/`.
 
+pub mod callbook;
 pub mod capture;
 pub mod credentials;
 pub mod eqsl;

--- a/rigflow-client/src/logging/mod.rs
+++ b/rigflow-client/src/logging/mod.rs
@@ -16,10 +16,11 @@ pub mod qrz;
 pub mod services;
 pub mod wsjtx_listener;
 
-/// Editable draft behind the manual log-entry window. The frozen-at-open
-/// capture (date/time/freq/mode/split) sits alongside the operator-typed fields
-/// so the logged time and frequency reflect when the entry opened, not when the
-/// operator finally hits save. Not persisted.
+/// Editable draft behind the manual log-entry window. The frozen-at-open capture
+/// (freq/mode/split) sits alongside the operator-typed fields. `TIME_ON` is NOT
+/// frozen here — it's stamped when the operator commits the QSO (see
+/// `commit_log_entry`), so a prep-ahead entry gets the completion time, not the
+/// window-open time. Not persisted.
 #[derive(Debug, Clone, Default)]
 pub struct LogEntryDraft {
     // Operator-entered fields.
@@ -36,8 +37,6 @@ pub struct LogEntryDraft {
     pub freq_rx_hz_str: String,
 
     // Frozen at open.
-    pub qso_date: String,
-    pub time_on: String,
     pub tx_freq_hz: u64,
     pub split_active: bool,
     pub derived_freq_rx_hz: Option<u64>,

--- a/rigflow-client/src/main.rs
+++ b/rigflow-client/src/main.rs
@@ -110,6 +110,7 @@ mod alsa_quiet;
 mod audio_metrics;
 mod audio_recorder;
 mod client_runtime;
+mod cluster;
 mod cw_decode;
 mod cw_text;
 mod digital_audio;

--- a/rigflow-client/src/ui/app.rs
+++ b/rigflow-client/src/ui/app.rs
@@ -104,6 +104,17 @@ pub struct RigflowApp {
     pub(crate) contacts_total: usize,
     /// Receiver for decoded WSJT-X `LoggedADIF` events from the UDP-2237 thread.
     pub(crate) wsjtx_rx: std::sync::mpsc::Receiver<crate::logging::wsjtx_listener::LogEvent>,
+    /// DX-cluster telnet thread handle: send connect/disconnect, read the shared
+    /// spot book (rendered on the waterfall/spectrum).
+    pub(crate) dx_cluster: crate::cluster::client::DxClusterHandle,
+    /// Per-operator cluster config (node, login call, display filter). Loaded
+    /// lazily by `load_cluster_config`; not in `UiState` (cloned every frame).
+    pub(crate) dx_cluster_config: crate::cluster::config::DxClusterConfig,
+    pub(crate) dx_cluster_loaded_for: Option<String>,
+    /// Guards the per-operator connect/disconnect apply in `sync_cluster_state`.
+    pub(crate) dx_cluster_synced_for: Option<String>,
+    /// Whether the DX-cluster config window is open.
+    pub(crate) show_cluster: bool,
 
     // ── Contact filter / export ──────────────────────────────────────────
     // All of this lives here rather than in `UiState`: only the logging windows
@@ -243,6 +254,10 @@ impl RigflowApp {
         // LoggedADIF events we drain each frame.
         let wsjtx_rx = crate::logging::wsjtx_listener::spawn_wsjtx_listener(Arc::clone(&state));
 
+        // The DX-cluster telnet thread: idles until a Connect command (Phase 3
+        // config drives it). Spots land in its shared book for the renderer.
+        let dx_cluster = crate::cluster::client::spawn_dx_cluster(Arc::clone(&state));
+
         // The export worker: read-only DB access on its own thread, so a large
         // export streams to disk without stalling the frame loop.
         let (export_tx, export_rx) = crate::logging::export::spawn_export_worker();
@@ -289,6 +304,11 @@ impl RigflowApp {
             contacts_cache_dirty: true,
             contacts_total: 0,
             wsjtx_rx,
+            dx_cluster,
+            dx_cluster_config: crate::cluster::config::DxClusterConfig::default(),
+            dx_cluster_loaded_for: None,
+            dx_cluster_synced_for: None,
+            show_cluster: false,
             qso_filter: crate::logging::export::QsoFilterDraft::default(),
             qso_filter_last: None,
             show_filter: false,
@@ -877,6 +897,7 @@ impl eframe::App for RigflowApp {
         self.draw_delete_selection_confirm(ctx);
         self.draw_sync_window(ctx, &snapshot.operator_id);
         self.draw_callbook_window(ctx, &snapshot.operator_id);
+        self.draw_cluster_window(ctx, &snapshot.operator_id);
 
         // Per-operator audio recording + voice keyer: ensure dirs / refresh the
         // clip list on an operator switch, run any UI-requested action, and
@@ -887,6 +908,10 @@ impl eframe::App for RigflowApp {
         // Contact logging: open/reopen the per-operator log store on an operator
         // switch (mirrors the audio-recording sync above).
         self.sync_log_state(&snapshot);
+
+        // DX cluster: on an operator switch, load that operator's config and
+        // auto-connect if they've enabled it (disconnect otherwise).
+        self.sync_cluster_state(&snapshot.operator_id);
 
         // Persist the global station profile when the Station panel flagged a
         // committed edit (it only has `&self`, so it defers the save to here).

--- a/rigflow-client/src/ui/app.rs
+++ b/rigflow-client/src/ui/app.rs
@@ -194,6 +194,38 @@ pub struct RigflowApp {
     /// (operator, service) whose credentials are loaded into the fields, so the
     /// window loads once per operator+service rather than every frame.
     pub(crate) sync_loaded_for: Option<(String, crate::logging::services::Service)>,
+
+    // ── callbook config (QRZ XML / HamQTH / Callook) ─────────────────────
+    /// Callbook settings window open flag.
+    pub(crate) show_callbook: bool,
+    /// Per-operator provider enable + priority order (persisted `callbook.json`).
+    pub(crate) callbook_config: crate::logging::callbook::CallbookConfig,
+    /// Credential input fields for the two auth'd providers (Callook needs none).
+    pub(crate) callbook_qrz: crate::logging::credentials::Credential,
+    pub(crate) callbook_hamqth: crate::logging::credentials::Credential,
+    /// Where each provider's saved credential lives (keyring vs file), for a note.
+    pub(crate) callbook_qrz_backend: Option<crate::logging::credentials::Backend>,
+    pub(crate) callbook_hamqth_backend: Option<crate::logging::credentials::Backend>,
+    /// Operator whose callbook config + creds are loaded into the fields.
+    pub(crate) callbook_loaded_for: Option<String>,
+    /// Result / error line for the callbook settings window.
+    pub(crate) callbook_status: String,
+
+    // ── callbook lookup, driving the log-entry (`L`) window ───────────────
+    /// The (uppercased) call the current results are for; invalidated on change.
+    pub(crate) cb_call: String,
+    /// Instant offline prefix result and the async online result for `cb_call`.
+    pub(crate) cb_prefix: Option<crate::logging::callbook::CallbookResult>,
+    pub(crate) cb_online: Option<crate::logging::callbook::CallbookResult>,
+    /// Whether the operator hand-edited the Name / Grid fields (Typed wins).
+    pub(crate) cb_name_edited: bool,
+    pub(crate) cb_grid_edited: bool,
+    /// When the debounced online lookup should fire (`None` = nothing pending).
+    pub(crate) cb_due: Option<std::time::Instant>,
+    /// Sequence for the in-flight lookup, to drop stale replies.
+    pub(crate) cb_seq: u64,
+    /// An online lookup is in flight (drives the "looking up…" indicator).
+    pub(crate) cb_busy: bool,
 }
 
 impl RigflowApp {
@@ -293,6 +325,22 @@ impl RigflowApp {
             sync_busy: false,
             sync_status: String::new(),
             sync_loaded_for: None,
+            show_callbook: false,
+            callbook_config: crate::logging::callbook::CallbookConfig::default(),
+            callbook_qrz: crate::logging::credentials::Credential::default(),
+            callbook_hamqth: crate::logging::credentials::Credential::default(),
+            callbook_qrz_backend: None,
+            callbook_hamqth_backend: None,
+            callbook_loaded_for: None,
+            callbook_status: String::new(),
+            cb_call: String::new(),
+            cb_prefix: None,
+            cb_online: None,
+            cb_name_edited: false,
+            cb_grid_edited: false,
+            cb_due: None,
+            cb_seq: 0,
+            cb_busy: false,
         };
 
         // Enumerate input devices once for the dropdown (one-time; cheap enough
@@ -828,6 +876,7 @@ impl eframe::App for RigflowApp {
         self.draw_delete_contact_confirm(ctx);
         self.draw_delete_selection_confirm(ctx);
         self.draw_sync_window(ctx, &snapshot.operator_id);
+        self.draw_callbook_window(ctx, &snapshot.operator_id);
 
         // Per-operator audio recording + voice keyer: ensure dirs / refresh the
         // clip list on an operator switch, run any UI-requested action, and

--- a/rigflow-client/src/ui/app_callbook.rs
+++ b/rigflow-client/src/ui/app_callbook.rs
@@ -1,0 +1,337 @@
+//! The **Callbook** settings window — enable QRZ / HamQTH / Callook, enter their
+//! credentials, and set the lookup priority order. This is where callbook
+//! accounts are configured (never prompted for mid-QSO). Design:
+//! `docs/release-review/callbook-lookup-design.md` §3–§4.
+//!
+//! Config (enable + order) persists to `callbook.json` in the operator dir;
+//! credentials go to the keyring / `0600`-file store (keys `qrz-xml`, `hamqth`).
+
+use eframe::egui;
+
+use crate::logging::callbook::{self, Provider};
+use crate::logging::credentials::{self, Credential};
+use crate::ui::app::RigflowApp;
+use crate::ui::panels::note_text;
+
+impl RigflowApp {
+    /// Open the callbook settings window, loading this operator's config + creds.
+    pub(crate) fn open_callbook(&mut self, operator_id: &str) {
+        self.show_callbook = true;
+        self.callbook_status.clear();
+        self.load_callbook(operator_id);
+    }
+
+    /// Load config + saved credentials into the fields, once per operator.
+    pub(crate) fn load_callbook(&mut self, operator_id: &str) {
+        if self.callbook_loaded_for.as_deref() == Some(operator_id) {
+            return;
+        }
+        let dir = self.operator_dir(operator_id);
+        self.callbook_config = callbook::load_config(&dir);
+
+        let load = |p: Provider| -> (Credential, Option<credentials::Backend>) {
+            match p
+                .cred_key()
+                .and_then(|k| credentials::load(k, operator_id, &dir))
+            {
+                Some((c, b)) => (c, Some(b)),
+                None => (Credential::default(), None),
+            }
+        };
+        (self.callbook_qrz, self.callbook_qrz_backend) = load(Provider::Qrz);
+        (self.callbook_hamqth, self.callbook_hamqth_backend) = load(Provider::HamQTH);
+        self.callbook_loaded_for = Some(operator_id.to_string());
+    }
+
+    /// Save config + any entered credentials.
+    fn save_callbook(&mut self, operator_id: &str) {
+        let dir = self.operator_dir(operator_id);
+        let save_cred = |p: Provider, cred: &Credential| -> Option<credentials::Backend> {
+            let key = p.cred_key()?;
+            if cred.login.trim().is_empty() && cred.password.is_empty() {
+                return None; // nothing entered — leave any existing store alone
+            }
+            credentials::store(key, operator_id, cred, &dir).ok()
+        };
+        if let Some(b) = save_cred(Provider::Qrz, &self.callbook_qrz) {
+            self.callbook_qrz_backend = Some(b);
+        }
+        if let Some(b) = save_cred(Provider::HamQTH, &self.callbook_hamqth) {
+            self.callbook_hamqth_backend = Some(b);
+        }
+        match callbook::save_config(&dir, &self.callbook_config) {
+            Ok(()) => self.callbook_status = "saved".to_string(),
+            Err(e) => self.callbook_status = format!("could not save config: {e}"),
+        }
+    }
+
+    // ── lookup driving (for the log-entry `L` window) ────────────────────
+
+    /// Per-frame callbook step for the `L` window: detect a call change (reset +
+    /// instant prefix resolve + schedule online), fill the non-edited Name/Grid
+    /// from the merged result, and fire the debounced online lookup when due.
+    pub(crate) fn callbook_step(
+        &mut self,
+        draft: &mut crate::logging::LogEntryDraft,
+        operator_id: &str,
+        ctx: &egui::Context,
+    ) {
+        let call = draft.call.trim().to_ascii_uppercase();
+        if call != self.cb_call {
+            // New identity: drop stale callbook-filled visible fields (keep the
+            // operator's own edits), reset, and resolve the offline floor now.
+            if !self.cb_name_edited {
+                draft.name.clear();
+            }
+            if !self.cb_grid_edited {
+                draft.gridsquare.clear();
+            }
+            self.cb_name_edited = false;
+            self.cb_grid_edited = false;
+            self.cb_call = call.clone();
+            self.cb_online = None;
+            self.cb_busy = false;
+            self.cb_prefix = callbook::prefix::resolve(&call);
+            self.load_callbook(operator_id);
+            let ready = call.len() >= 3 && !self.callbook_config.active().is_empty();
+            self.cb_due =
+                ready.then(|| std::time::Instant::now() + crate::logging::export::QUERY_DEBOUNCE);
+        }
+
+        // Fill non-edited visible fields from the effective (online-over-prefix)
+        // result. Online arriving later overwrites the prefix value automatically.
+        if let Some(eff) = callbook::merge(self.cb_prefix.clone(), self.cb_online.clone()) {
+            if !self.cb_name_edited
+                && let Some(n) = &eff.name
+            {
+                draft.name = n.clone();
+            }
+            if !self.cb_grid_edited
+                && let Some(g) = &eff.grid
+            {
+                draft.gridsquare = g.clone();
+            }
+        }
+
+        // Fire the debounced online lookup.
+        if let Some(due) = self.cb_due {
+            if std::time::Instant::now() < due {
+                ctx.request_repaint_after(crate::logging::export::QUERY_DEBOUNCE);
+            } else {
+                self.cb_due = None;
+                self.dispatch_callbook_lookup(operator_id);
+            }
+        }
+    }
+
+    fn dispatch_callbook_lookup(&mut self, operator_id: &str) {
+        use crate::logging::callbook::CallbookCreds;
+        self.load_callbook(operator_id);
+        let order = self.callbook_config.active();
+        if order.is_empty() {
+            return;
+        }
+        let present = |c: &Credential| {
+            (!c.login.trim().is_empty() || !c.password.is_empty()).then(|| c.clone())
+        };
+        let creds = CallbookCreds {
+            qrz: self
+                .callbook_config
+                .is_enabled(Provider::Qrz)
+                .then(|| present(&self.callbook_qrz))
+                .flatten(),
+            hamqth: self
+                .callbook_config
+                .is_enabled(Provider::HamQTH)
+                .then(|| present(&self.callbook_hamqth))
+                .flatten(),
+        };
+        self.cb_seq += 1;
+        self.cb_busy = true;
+        let _ = self
+            .export_tx
+            .send(crate::logging::export::ExportJob::CallbookLookup {
+                order,
+                creds: Box::new(creds),
+                call: self.cb_call.clone(),
+                seq: self.cb_seq,
+            });
+    }
+
+    /// A short status line for the `L` window: "looking up…" or "via callbook ·
+    /// United States (291)". `None` when there's nothing to show.
+    pub(crate) fn callbook_note(&self) -> Option<String> {
+        if self.cb_call.is_empty() {
+            return None;
+        }
+        if self.cb_busy {
+            return Some("looking up…".to_string());
+        }
+        let eff = callbook::merge(self.cb_prefix.clone(), self.cb_online.clone())?;
+        // Name the actual source: "via QRZ" / "via HamQTH" / "via Callook" once an
+        // online provider answers, else "via prefix" for the offline baseline.
+        let mut s = format!("via {}", eff.source.label());
+        if let Some(c) = &eff.country {
+            let d = eff.dxcc.map(|d| format!(" · DXCC {d}")).unwrap_or_default();
+            s.push_str(&format!(" · {c}{d}"));
+        }
+        Some(s)
+    }
+
+    /// Merge the callbook result into a QSO at save time: set `dxcc` (if unset)
+    /// and add the `extra` ADIF fields (QTH/STATE/…) the visible form doesn't
+    /// carry. Only applies when the result is for this QSO's call.
+    pub(crate) fn callbook_apply_to_qso(&self, qso: &mut rigflow_log::Qso) {
+        if self.cb_call != qso.call {
+            return;
+        }
+        let Some(eff) = callbook::merge(self.cb_prefix.clone(), self.cb_online.clone()) else {
+            return;
+        };
+        if qso.dxcc.is_none() {
+            qso.dxcc = eff.dxcc;
+        }
+        for (k, v) in eff.extra_fields() {
+            qso.extra.entry(k.to_string()).or_insert(v);
+        }
+    }
+
+    pub(crate) fn draw_callbook_window(&mut self, ctx: &egui::Context, operator_id: &str) {
+        if !self.show_callbook {
+            return;
+        }
+        if operator_id.trim().is_empty() {
+            self.show_callbook = false;
+            return;
+        }
+        self.load_callbook(operator_id);
+
+        let mut open = true;
+        let mut save = false;
+        let mut toggle: Option<(Provider, bool)> = None;
+        let mut reorder: Option<(Provider, bool)> = None; // (provider, move_up?)
+        let mut forget: Option<Provider> = None;
+
+        egui::Window::new("Callbook")
+            .open(&mut open)
+            .default_width(420.0)
+            .show(ctx, |ui| {
+                ui.label(note_text(
+                    "Fill a contact's name / QTH / grid / DXCC from an online callbook as \
+                     you log. Providers are tried in priority order; the first with a match \
+                     wins. An offline prefix baseline always fills the DXCC entity and zones.",
+                ));
+                ui.separator();
+
+                let order = self.callbook_config.ordered();
+                let n = order.len();
+                for (idx, p) in order.into_iter().enumerate() {
+                    ui.horizontal(|ui| {
+                        // Priority reorder. Plain-text labels — arrow glyphs
+                        // (↑/↓) aren't in egui's default font and render as tofu.
+                        if ui.add_enabled(idx > 0, egui::Button::new("Up")).clicked() {
+                            reorder = Some((p, true));
+                        }
+                        if ui
+                            .add_enabled(idx + 1 < n, egui::Button::new("Down"))
+                            .clicked()
+                        {
+                            reorder = Some((p, false));
+                        }
+                        let mut en = self.callbook_config.is_enabled(p);
+                        if ui.checkbox(&mut en, "").changed() {
+                            toggle = Some((p, en));
+                        }
+                        ui.strong(p.name());
+                        if p == Provider::Callook {
+                            ui.label(note_text("US only · no account needed"));
+                        }
+                    });
+
+                    // Credential fields for the auth'd providers.
+                    let cred = match p {
+                        Provider::Qrz => Some(&mut self.callbook_qrz),
+                        Provider::HamQTH => Some(&mut self.callbook_hamqth),
+                        Provider::Callook => None,
+                    };
+                    if let Some(cred) = cred {
+                        if p == Provider::Qrz {
+                            ui.label(note_text(
+                                "Uses your qrz.com login (XML API) — NOT the QRZ Logbook API \
+                                 key used for QSO sync. Requires an XML Logbook Data subscription.",
+                            ));
+                        }
+                        egui::Grid::new(format!("cb_creds_{}", p.key()))
+                            .num_columns(2)
+                            .spacing([8.0, 4.0])
+                            .show(ui, |ui| {
+                                ui.label("Username");
+                                ui.text_edit_singleline(&mut cred.login);
+                                ui.end_row();
+                                ui.label("Password");
+                                ui.add(
+                                    egui::TextEdit::singleline(&mut cred.password).password(true),
+                                );
+                                ui.end_row();
+                            });
+                        let backend = match p {
+                            Provider::Qrz => self.callbook_qrz_backend,
+                            _ => self.callbook_hamqth_backend,
+                        };
+                        ui.horizontal(|ui| {
+                            if let Some(b) = backend {
+                                ui.label(note_text(b.note()));
+                            }
+                            if ui.button("Forget").clicked() {
+                                forget = Some(p);
+                            }
+                        });
+                    }
+                    ui.separator();
+                }
+
+                ui.horizontal(|ui| {
+                    if ui.button("Save").clicked() {
+                        save = true;
+                    }
+                    if !self.callbook_status.is_empty() {
+                        ui.label(&self.callbook_status);
+                    }
+                });
+            });
+
+        if let Some((p, on)) = toggle {
+            self.callbook_config.set_enabled(p, on);
+        }
+        if let Some((p, up)) = reorder {
+            if up {
+                self.callbook_config.move_up(p);
+            } else {
+                self.callbook_config.move_down(p);
+            }
+        }
+        if let Some(p) = forget {
+            if let Some(key) = p.cred_key() {
+                credentials::clear(key, operator_id, &self.operator_dir(operator_id));
+            }
+            match p {
+                Provider::Qrz => {
+                    self.callbook_qrz = Credential::default();
+                    self.callbook_qrz_backend = None;
+                }
+                Provider::HamQTH => {
+                    self.callbook_hamqth = Credential::default();
+                    self.callbook_hamqth_backend = None;
+                }
+                Provider::Callook => {}
+            }
+            self.callbook_status = format!("{} credentials forgotten", p.name());
+        }
+        if save {
+            self.save_callbook(operator_id);
+        }
+        if !open {
+            self.show_callbook = false;
+        }
+    }
+}

--- a/rigflow-client/src/ui/app_callbook.rs
+++ b/rigflow-client/src/ui/app_callbook.rs
@@ -171,6 +171,18 @@ impl RigflowApp {
         // Name the actual source: "via QRZ" / "via HamQTH" / "via Callook" once an
         // online provider answers, else "via prefix" for the offline baseline.
         let mut s = format!("via {}", eff.source.label());
+        // Human-readable location, since grid squares are opaque: "City, ST".
+        // Only online providers carry city/state; the offline prefix baseline
+        // resolves country + zones only, so this is empty until a lookup lands.
+        let loc: Vec<&str> = [eff.qth.as_deref(), eff.state.as_deref()]
+            .into_iter()
+            .flatten()
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .collect();
+        if !loc.is_empty() {
+            s.push_str(&format!(" · {}", loc.join(", ")));
+        }
         if let Some(c) = &eff.country {
             let d = eff.dxcc.map(|d| format!(" · DXCC {d}")).unwrap_or_default();
             s.push_str(&format!(" · {c}{d}"));

--- a/rigflow-client/src/ui/app_center.rs
+++ b/rigflow-client/src/ui/app_center.rs
@@ -36,6 +36,10 @@ impl RigflowApp {
     pub(crate) fn draw_center_panel(&mut self, ctx: &egui::Context, snapshot: &UiState) {
         // Advance any in-flight flick-momentum pan before drawing this frame.
         self.advance_pan_momentum(ctx, snapshot);
+        // DX-cluster spots to overlay on VFO A's spectrum + waterfall, filtered
+        // to the current band/mode (empty when the feature is off). Computed once
+        // per frame off the shared spot book.
+        let spots = self.visible_spots();
         egui::CentralPanel::default().show(ctx, |ui| {
             egui::Frame::NONE
                 .fill(egui::Color32::BLACK)
@@ -109,6 +113,7 @@ impl RigflowApp {
                                 spectrum_db_min,
                                 spectrum_db_max,
                                 &state_snapshot,
+                                &spots,
                             );
 
                             // Bookmark clicks take precedence; all other mouse
@@ -153,6 +158,7 @@ impl RigflowApp {
                                     db_min,
                                     db_max,
                                     b_view,
+                                    &[], // spots are a VFO-A operating aid only
                                 );
                                 // Full VFO B tuning — click / drag / wheel / recenter,
                                 // identical to VFO A but on VFO B's centre/target.
@@ -246,6 +252,22 @@ impl RigflowApp {
                                             }
                                         },
                                     );
+
+                                    // Spot markers over the waterfall image, same
+                                    // behaviour as the spectrum: click tunes to
+                                    // the spot's exact frequency.
+                                    let painter = ui.painter_at(rect);
+                                    if let Some(hz) = crate::ui::spectrum_view::draw_spot_overlay(
+                                        &painter,
+                                        rect,
+                                        spectrum_len,
+                                        &state_snapshot,
+                                        &spots,
+                                        response.hover_pos(),
+                                        response.clicked(),
+                                    ) {
+                                        mouse.tune_to_hz = Some(hz as f32);
+                                    }
                                 });
 
                                 self.apply_view_interaction(&mouse, snapshot, TuneVfo::A);

--- a/rigflow-client/src/ui/app_cluster.rs
+++ b/rigflow-client/src/ui/app_cluster.rs
@@ -6,6 +6,7 @@
 use eframe::egui::{self, Color32};
 use rigflow_core::radio::ham_band::band_from_frequency;
 
+use crate::ControlCommand;
 use crate::cluster::DxSpot;
 use crate::cluster::client::DxClusterStatus;
 use crate::cluster::config;
@@ -77,6 +78,48 @@ impl RigflowApp {
             .filter(|s| cfg.show(s, current_band))
             .cloned()
             .collect()
+    }
+
+    /// Total spots currently held in the shared book (pre-filter), for the
+    /// panel's diagnostics line.
+    pub(crate) fn total_spots(&self) -> usize {
+        self.dx_cluster.spots.lock().map(|s| s.len()).unwrap_or(0)
+    }
+
+    /// Tune to a clicked spot from the list. Unlike a spectrum marker click
+    /// (which stays inside the current window), a list spot can be anywhere on
+    /// the band, so this **recenters the LO** on it — same effect as recalling a
+    /// bookmark. Gated by the dial lock and the RF-range check.
+    pub(crate) fn tune_to_cluster_spot(&mut self, freq_hz: u64) {
+        let f = freq_hz as f32;
+        let rejection = {
+            let state = self.state.lock().unwrap();
+            if state.dial_locked {
+                Some("dial locked: unlock to tune to a spot".to_string())
+            } else {
+                crate::ui::freq_limits::bookmark_rejection_message(f, &state).map(|m| m.to_string())
+            }
+        };
+        if let Some(msg) = rejection {
+            if let Ok(mut s) = self.state.lock() {
+                s.bookmark_status = msg;
+            }
+            return;
+        }
+        if let Ok(mut state) = self.state.lock() {
+            state.center_freq_hz = f;
+            state.target_freq_hz = f;
+        }
+        let _ = self.ws_cmd_tx.send(ControlCommand::RadioMessage(
+            rigflow_protocol::ClientRadioMessage::SetCenterFrequency {
+                center_freq_hz: freq_hz,
+            },
+        ));
+        let _ = self.ws_cmd_tx.send(ControlCommand::RadioMessage(
+            rigflow_protocol::ClientRadioMessage::SetTargetFrequency {
+                target_freq_hz: freq_hz,
+            },
+        ));
     }
 
     /// Open the DX-cluster config window for this operator.

--- a/rigflow-client/src/ui/app_cluster.rs
+++ b/rigflow-client/src/ui/app_cluster.rs
@@ -1,0 +1,242 @@
+//! DX-cluster app glue (Phase 3): per-operator config load/save, applying the
+//! config to the telnet thread (connect/disconnect), and producing the filtered
+//! spot list the waterfall/spectrum renderer draws (Phase 4). The config window
+//! itself is Phase 5.
+
+use eframe::egui::{self, Color32};
+use rigflow_core::radio::ham_band::band_from_frequency;
+
+use crate::cluster::DxSpot;
+use crate::cluster::client::DxClusterStatus;
+use crate::cluster::config;
+use crate::ui::app::RigflowApp;
+use crate::ui::panels::note_text;
+
+/// Common modes offered as filter toggles in the config window.
+const FILTER_MODES: [&str; 6] = ["CW", "SSB", "FT8", "FT4", "RTTY", "PSK"];
+
+/// Status text + colour for the connection state (colour, not size — no glyphs).
+pub(crate) fn cluster_status_display(status: &DxClusterStatus) -> (String, Color32) {
+    match status {
+        DxClusterStatus::Disconnected => ("disconnected".to_string(), Color32::from_gray(160)),
+        DxClusterStatus::Connecting => ("connecting…".to_string(), Color32::from_rgb(235, 200, 90)),
+        DxClusterStatus::Connected => ("connected".to_string(), Color32::from_rgb(120, 205, 140)),
+        DxClusterStatus::Error(e) => (format!("{e} — retrying"), Color32::from_rgb(230, 130, 120)),
+    }
+}
+
+impl RigflowApp {
+    /// Load this operator's cluster config, once per operator.
+    pub(crate) fn load_cluster_config(&mut self, operator_id: &str) {
+        if self.dx_cluster_loaded_for.as_deref() == Some(operator_id) {
+            return;
+        }
+        let dir = self.operator_dir(operator_id);
+        self.dx_cluster_config = config::load_config(&dir);
+        self.dx_cluster_loaded_for = Some(operator_id.to_string());
+    }
+
+    /// Persist this operator's cluster config.
+    pub(crate) fn save_cluster_config(&mut self, operator_id: &str) {
+        let dir = self.operator_dir(operator_id);
+        if let Err(e) = config::save_config(&dir, &self.dx_cluster_config) {
+            self.set_log_status(format!("cluster config save failed: {e}"));
+        }
+    }
+
+    /// Drive the telnet thread from the current config: connect when enabled
+    /// (with a resolvable login callsign), disconnect otherwise. Idempotent —
+    /// safe to call after any config change or on an operator switch.
+    pub(crate) fn apply_cluster_connection(&mut self, operator_id: &str) {
+        let call = self.dx_cluster_config.login_call(operator_id);
+        if self.dx_cluster_config.enabled && !call.is_empty() {
+            self.dx_cluster.connect(
+                self.dx_cluster_config.host.clone(),
+                self.dx_cluster_config.port,
+                call,
+            );
+        } else {
+            self.dx_cluster.disconnect();
+        }
+    }
+
+    /// The spots the renderer should draw: the shared book filtered by the
+    /// config (current-band / mode) against the currently tuned band. Cloned
+    /// once per frame — filtered to the current band this is a small set.
+    pub(crate) fn visible_spots(&self) -> Vec<DxSpot> {
+        let current_band = {
+            let s = self.state.lock().unwrap();
+            band_from_frequency(s.target_freq_hz.max(0.0) as u64)
+        };
+        let cfg = &self.dx_cluster_config;
+        let Ok(spots) = self.dx_cluster.spots.lock() else {
+            return Vec::new();
+        };
+        spots
+            .iter()
+            .filter(|s| cfg.show(s, current_band))
+            .cloned()
+            .collect()
+    }
+
+    /// Open the DX-cluster config window for this operator.
+    pub(crate) fn open_cluster(&mut self, operator_id: &str) {
+        self.show_cluster = true;
+        self.load_cluster_config(operator_id);
+    }
+
+    /// On an operator switch (or first frame), load that operator's cluster
+    /// config and apply it — auto-connecting when they've enabled the feature,
+    /// disconnecting otherwise. A no-op while the operator is unchanged.
+    pub(crate) fn sync_cluster_state(&mut self, operator_id: &str) {
+        if self.dx_cluster_synced_for.as_deref() == Some(operator_id) {
+            return;
+        }
+        if operator_id.trim().is_empty() {
+            self.dx_cluster.disconnect();
+        } else {
+            self.load_cluster_config(operator_id);
+            self.apply_cluster_connection(operator_id);
+        }
+        self.dx_cluster_synced_for = Some(operator_id.to_string());
+    }
+
+    /// The DX-cluster configuration window: node, login callsign, display
+    /// filter, and connect/disconnect. Editing is locked while connected to a
+    /// rigflow server (operator-settings rule).
+    pub(crate) fn draw_cluster_window(&mut self, ctx: &egui::Context, operator_id: &str) {
+        if !self.show_cluster {
+            return;
+        }
+        if operator_id.trim().is_empty() {
+            self.show_cluster = false;
+            return;
+        }
+        self.load_cluster_config(operator_id);
+
+        let (locked, status) = {
+            let s = self.state.lock().unwrap();
+            (s.config_locked, s.dx_cluster_status.clone())
+        };
+
+        let mut open = true;
+        let mut save = false;
+        let mut disconnect = false;
+
+        egui::Window::new("DX Cluster")
+            .open(&mut open)
+            .default_width(380.0)
+            .show(ctx, |ui| {
+                ui.label(note_text(
+                    "Connect to a DX-cluster node and overlay live spots on the spectrum and \
+                     waterfall. Click a spot to tune to it.",
+                ));
+                ui.separator();
+
+                ui.horizontal(|ui| {
+                    ui.strong("Status:");
+                    let (txt, col) = cluster_status_display(&status);
+                    ui.label(egui::RichText::new(txt).color(col));
+                });
+                ui.separator();
+
+                if locked {
+                    ui.label(note_text(
+                        "Locked while connected to a rigflow server — disconnect from the \
+                         server to change cluster settings.",
+                    ));
+                }
+
+                ui.add_enabled_ui(!locked, |ui| {
+                    ui.checkbox(&mut self.dx_cluster_config.enabled, "Enabled");
+
+                    let current = self.dx_cluster_config.matching_node().unwrap_or("Custom");
+                    egui::ComboBox::from_label("Node")
+                        .selected_text(current)
+                        .show_ui(ui, |ui| {
+                            for n in config::NODES {
+                                if ui.selectable_label(current == n.name, n.name).clicked() {
+                                    self.dx_cluster_config.host = n.host.to_string();
+                                    self.dx_cluster_config.port = n.port;
+                                }
+                            }
+                            // "Custom" leaves host/port as-is for manual editing.
+                            let _ =
+                                ui.selectable_label(current == "Custom", "Custom (edit host/port)");
+                        });
+
+                    egui::Grid::new("cluster_fields")
+                        .num_columns(2)
+                        .spacing([8.0, 4.0])
+                        .show(ui, |ui| {
+                            ui.label("Host");
+                            ui.text_edit_singleline(&mut self.dx_cluster_config.host);
+                            ui.end_row();
+                            ui.label("Port");
+                            let mut port_str = self.dx_cluster_config.port.to_string();
+                            if ui.text_edit_singleline(&mut port_str).changed()
+                                && let Ok(p) = port_str.trim().parse::<u16>()
+                            {
+                                self.dx_cluster_config.port = p;
+                            }
+                            ui.end_row();
+                            ui.label("Callsign");
+                            ui.text_edit_singleline(&mut self.dx_cluster_config.call);
+                            ui.end_row();
+                        });
+                    ui.label(note_text(
+                        "Callsign is your login — public nodes have no password. Leave blank to \
+                         use your operator callsign.",
+                    ));
+
+                    ui.separator();
+                    ui.checkbox(
+                        &mut self.dx_cluster_config.current_band_only,
+                        "Show only the currently tuned band",
+                    );
+                    ui.horizontal(|ui| {
+                        ui.label("Modes:");
+                        for m in FILTER_MODES {
+                            let mut on = self.dx_cluster_config.modes.iter().any(|x| x == m);
+                            if ui.checkbox(&mut on, m).changed() {
+                                self.dx_cluster_config.modes.retain(|x| x != m);
+                                if on {
+                                    self.dx_cluster_config.modes.push(m.to_string());
+                                }
+                            }
+                        }
+                    });
+                    ui.label(note_text("No modes selected = all modes."));
+                });
+
+                ui.separator();
+                ui.horizontal(|ui| {
+                    if ui
+                        .add_enabled(!locked, egui::Button::new("Save & apply"))
+                        .clicked()
+                    {
+                        save = true;
+                    }
+                    if ui
+                        .add_enabled(!locked, egui::Button::new("Disconnect"))
+                        .clicked()
+                    {
+                        disconnect = true;
+                    }
+                });
+            });
+
+        if save {
+            self.save_cluster_config(operator_id);
+            self.apply_cluster_connection(operator_id);
+        }
+        if disconnect {
+            self.dx_cluster_config.enabled = false;
+            self.save_cluster_config(operator_id);
+            self.dx_cluster.disconnect();
+        }
+        if !open {
+            self.show_cluster = false;
+        }
+    }
+}

--- a/rigflow-client/src/ui/app_export.rs
+++ b/rigflow-client/src/ui/app_export.rs
@@ -318,6 +318,14 @@ impl crate::ui::app::RigflowApp {
                 ExportEvent::ServiceSynced { service, result } => {
                     self.apply_service_sync(service, result)
                 }
+
+                ExportEvent::CallbookResolved { seq, call, result } => {
+                    // Drop a reply for a call the operator has already typed past.
+                    if seq == self.cb_seq && call == self.cb_call {
+                        self.cb_online = result.map(|b| *b);
+                        self.cb_busy = false;
+                    }
+                }
             }
         }
         if got {

--- a/rigflow-client/src/ui/app_logging.rs
+++ b/rigflow-client/src/ui/app_logging.rs
@@ -110,7 +110,6 @@ impl RigflowApp {
     /// draft. Called from the `L` hotkey.
     pub(crate) fn open_log_entry(&mut self, snapshot: &UiState) {
         let captured = capture::capture_radio_state(snapshot);
-        let (qso_date, time_on) = rigflow_log::now_utc_adif();
         let derived_rx = captured.derive_freq_rx();
         let mode = capture::effective_tx_mode(snapshot);
 
@@ -123,8 +122,6 @@ impl RigflowApp {
             gridsquare: String::new(),
             mode: captured.tx_mode.clone(),
             freq_rx_hz_str: derived_rx.map(|h| h.to_string()).unwrap_or_default(),
-            qso_date,
-            time_on,
             tx_freq_hz: captured.tx_freq_hz,
             split_active: captured.split_active,
             derived_freq_rx_hz: derived_rx,
@@ -160,26 +157,23 @@ impl RigflowApp {
             .resizable(false)
             .default_width(320.0)
             .show(ctx, |ui| {
-                // Frozen capture — read-only.
+                // Frequency + mode captured at open (you're sitting on the
+                // station), shown read-only. The timestamp is deliberately NOT
+                // shown: it's stamped when you press Log, not now, so a frozen
+                // open-time would only distract. Adjust after the fact in Contacts.
                 let tx_mhz = draft.tx_freq_hz as f64 / 1_000_000.0;
                 if draft.split_active {
                     let rx_txt = draft
                         .derived_freq_rx_hz
                         .map(|h| format!("{:.4}", h as f64 / 1_000_000.0))
                         .unwrap_or_else(|| "—".to_string());
-                    ui.label(format!("{tx_mhz:.4} ↑ / {rx_txt} ↓ MHz  ({})", draft.mode));
+                    ui.label(format!(
+                        "TX {tx_mhz:.4} / RX {rx_txt} MHz  ({})",
+                        draft.mode
+                    ));
                 } else {
                     ui.label(format!("{tx_mhz:.4} MHz  ({})", draft.mode));
                 }
-                // Seconds shown here (unlike the list): this is the frozen instant
-                // the contact will be logged at, so the operator is checking it.
-                // Formatted via the helpers rather than sliced — `&time_on[..4]`
-                // would panic on any value shorter than 4 chars.
-                ui.label(format!(
-                    "{} {}Z UTC",
-                    display::date(&draft.qso_date),
-                    display::time_hhmmss(&draft.time_on)
-                ));
                 ui.separator();
 
                 egui::Grid::new("log_entry_grid")
@@ -310,6 +304,13 @@ impl RigflowApp {
             return;
         }
 
+        // TIME_ON is stamped now, when the operator commits the QSO — not when the
+        // entry window opened. In search-and-pounce you open the window and prep
+        // the call well before you actually get through, so open-time would be too
+        // early. (Frequency/mode stay as captured at open — you're sitting on the
+        // station.) Back-dating for a late log is done in the Contacts view.
+        let (qso_date, time_on) = rigflow_log::now_utc_adif();
+
         let mut extra = BTreeMap::new();
         for (k, v) in [
             ("NAME", draft.name.trim()),
@@ -334,8 +335,8 @@ impl RigflowApp {
 
         let mut qso = rigflow_log::Qso {
             call: draft.call.trim().to_ascii_uppercase(),
-            qso_date: draft.qso_date.clone(),
-            time_on: draft.time_on.clone(),
+            qso_date,
+            time_on,
             band: String::new(), // derived from freq_hz by normalize()
             mode: draft.mode.clone(),
             submode: None,

--- a/rigflow-client/src/ui/app_logging.rs
+++ b/rigflow-client/src/ui/app_logging.rs
@@ -151,6 +151,10 @@ impl RigflowApp {
         let focus_pending = snapshot.log_entry_focus_pending;
         let mut focus_consumed = false;
 
+        // Callbook: instant prefix fill + debounced online lookup, merged into the
+        // draft's Name/Grid (Typed > Online > Prefix). Runs before the fields render.
+        self.callbook_step(&mut draft, &snapshot.operator_id, ctx);
+
         egui::Window::new("Log Contact")
             .collapsible(false)
             .resizable(false)
@@ -205,10 +209,14 @@ impl RigflowApp {
                             ui.end_row();
                         }
                         ui.label("Name");
-                        ui.text_edit_singleline(&mut draft.name);
+                        if ui.text_edit_singleline(&mut draft.name).changed() {
+                            self.cb_name_edited = true; // Typed wins over callbook
+                        }
                         ui.end_row();
                         ui.label("Grid");
-                        ui.text_edit_singleline(&mut draft.gridsquare);
+                        if ui.text_edit_singleline(&mut draft.gridsquare).changed() {
+                            self.cb_grid_edited = true;
+                        }
                         ui.end_row();
                         ui.label("Comment");
                         ui.text_edit_singleline(&mut draft.comment);
@@ -217,6 +225,10 @@ impl RigflowApp {
 
                 // Live "worked before?" hints from the in-memory index.
                 self.show_worked_before_hints(ui, &draft);
+                // Callbook status: "looking up…" / "via callbook · United States (291)".
+                if let Some(note) = self.callbook_note() {
+                    ui.label(note_text(note));
+                }
 
                 ui.separator();
                 ui.horizontal(|ui| {
@@ -320,7 +332,7 @@ impl RigflowApp {
             (!t.is_empty()).then(|| t.to_string())
         };
 
-        let qso = rigflow_log::Qso {
+        let mut qso = rigflow_log::Qso {
             call: draft.call.trim().to_ascii_uppercase(),
             qso_date: draft.qso_date.clone(),
             time_on: draft.time_on.clone(),
@@ -336,6 +348,10 @@ impl RigflowApp {
             dxcc: None,
             extra,
         };
+
+        // Fold in the callbook result (dxcc column + QTH/STATE/… extras the form
+        // doesn't show). NAME/COMMENT already set above win via or_insert.
+        self.callbook_apply_to_qso(&mut qso);
 
         self.log_contact(qso);
 
@@ -363,6 +379,7 @@ impl RigflowApp {
         let mut open_export = false;
         let mut open_import = false;
         let mut open_sync = false;
+        let mut open_callbook = false;
         let mut open_filter = false;
         let mut clear_filter = false;
         // Row actions, applied after the window closure so the immutable borrow of
@@ -415,6 +432,9 @@ impl RigflowApp {
                     }
                     if ui.button("Sync…").clicked() {
                         open_sync = true;
+                    }
+                    if ui.button("Callbook…").clicked() {
+                        open_callbook = true;
                     }
                     if ui.button("Refresh").clicked() {
                         self.contacts_cache_dirty = true;
@@ -553,6 +573,9 @@ impl RigflowApp {
         }
         if open_sync {
             self.open_sync(&operator_id);
+        }
+        if open_callbook {
+            self.open_callbook(&operator_id);
         }
         if let Some(edit) = open_edit {
             self.edit_contact = Some(edit);

--- a/rigflow-client/src/ui/app_sync.rs
+++ b/rigflow-client/src/ui/app_sync.rs
@@ -28,7 +28,7 @@ impl RigflowApp {
     }
 
     /// The per-operator directory that backs the credential file fallback.
-    fn operator_dir(&self, operator_id: &str) -> std::path::PathBuf {
+    pub(crate) fn operator_dir(&self, operator_id: &str) -> std::path::PathBuf {
         self.persistence_store
             .qso_log_db_path(operator_id)
             .parent()

--- a/rigflow-client/src/ui/mod.rs
+++ b/rigflow-client/src/ui/mod.rs
@@ -17,6 +17,7 @@ mod app_actions;
 mod app_audio;
 mod app_callbook;
 mod app_center;
+mod app_cluster;
 mod app_dialogs;
 mod app_export;
 mod app_filter;

--- a/rigflow-client/src/ui/mod.rs
+++ b/rigflow-client/src/ui/mod.rs
@@ -15,6 +15,7 @@ pub mod waterfall;
 
 mod app_actions;
 mod app_audio;
+mod app_callbook;
 mod app_center;
 mod app_dialogs;
 mod app_export;

--- a/rigflow-client/src/ui/panels/cluster.rs
+++ b/rigflow-client/src/ui/panels/cluster.rs
@@ -1,3 +1,5 @@
+use std::time::{Duration, Instant};
+
 use eframe::egui;
 
 use crate::ui::app::RigflowApp;
@@ -5,9 +7,11 @@ use crate::ui::app_cluster::cluster_status_display;
 use crate::ui::state::UiState;
 
 impl RigflowApp {
-    /// Compact left-panel section: at-a-glance DX-cluster status + a button to
-    /// open the full config window. The spots themselves render on the
-    /// spectrum/waterfall, not here.
+    /// Left-panel "DX Cluster" section: status, a receive/shown count, and a
+    /// scrollable **spot list** (band map). The list is the primary way to see
+    /// spots — the spectrum/waterfall markers only cover the narrow visible
+    /// span, whereas the list shows every spot passing the filter and each row
+    /// clicks to tune (recentering on it).
     pub(crate) fn draw_cluster_panel(&mut self, ui: &mut egui::Ui, snapshot: &UiState) {
         ui.collapsing(super::panel_header("DX Cluster"), |ui| {
             ui.horizontal(|ui| {
@@ -15,9 +19,84 @@ impl RigflowApp {
                 let (txt, col) = cluster_status_display(&snapshot.dx_cluster_status);
                 ui.label(egui::RichText::new(txt).color(col));
             });
+
+            // Received vs. shown, so "connected but nothing on screen" is
+            // diagnosable: 0 received = not arriving/parsing; received > shown =
+            // hidden by the band/mode filter.
+            let total = self.total_spots();
+            let mut spots = self.visible_spots();
+            ui.label(format!("Spots: {total} received · {} shown", spots.len()));
+
+            if total == 0 {
+                ui.label(super::note_text(
+                    "No spots yet — they arrive as stations are spotted. Check your \
+                     connection if this stays at zero on a busy band.",
+                ));
+                if ui.button("Configure…").clicked() {
+                    self.open_cluster(&snapshot.operator_id);
+                }
+                return;
+            }
+
+            if spots.is_empty() {
+                ui.label(super::note_text(
+                    "Spots received but none pass the current filter — turn off \
+                     \"current band only\" or clear the mode filter in Configure.",
+                ));
+            } else {
+                // Sort by frequency so the list reads like a band map.
+                spots.sort_by_key(|s| s.freq_hz);
+                let now = Instant::now();
+                egui::ScrollArea::vertical()
+                    .max_height(220.0)
+                    .auto_shrink([false, true])
+                    .show(ui, |ui| {
+                        for spot in &spots {
+                            let mhz = spot.freq_hz as f64 / 1_000_000.0;
+                            let age = fmt_age(now.saturating_duration_since(spot.received_at));
+                            let mode = spot
+                                .mode_hint
+                                .as_deref()
+                                .map(|m| format!("  {m}"))
+                                .unwrap_or_default();
+                            let label = format!("{mhz:9.3}  {:<10}{mode}   {age}", spot.dx_call);
+                            if ui
+                                .add(
+                                    egui::Button::new(egui::RichText::new(label).monospace())
+                                        .frame(false),
+                                )
+                                .on_hover_text(format!(
+                                    "de {} · {}",
+                                    spot.spotter,
+                                    if spot.comment.is_empty() {
+                                        "—"
+                                    } else {
+                                        &spot.comment
+                                    }
+                                ))
+                                .clicked()
+                            {
+                                self.tune_to_cluster_spot(spot.freq_hz);
+                            }
+                        }
+                    });
+            }
+
             if ui.button("Configure…").clicked() {
                 self.open_cluster(&snapshot.operator_id);
             }
         });
+    }
+}
+
+/// Compact age like `12s`, `4m`, `1h`.
+fn fmt_age(age: Duration) -> String {
+    let secs = age.as_secs();
+    if secs < 60 {
+        format!("{secs}s")
+    } else if secs < 3600 {
+        format!("{}m", secs / 60)
+    } else {
+        format!("{}h", secs / 3600)
     }
 }

--- a/rigflow-client/src/ui/panels/cluster.rs
+++ b/rigflow-client/src/ui/panels/cluster.rs
@@ -47,9 +47,17 @@ impl RigflowApp {
                 // Sort by frequency so the list reads like a band map.
                 spots.sort_by_key(|s| s.freq_hz);
                 let now = Instant::now();
+                // Inset the list so its scrollbar sits clear of the left panel's
+                // own scrollbar at the pane edge (otherwise the two merge and the
+                // list looks like it doesn't scroll).
+                let list_width = (ui.available_width() - 18.0).max(120.0);
                 egui::ScrollArea::vertical()
                     .max_height(220.0)
+                    .max_width(list_width)
                     .auto_shrink([false, true])
+                    // Always show the scrollbar so it's obvious the list scrolls
+                    // (the default floating bar only appears on hover).
+                    .scroll_bar_visibility(egui::scroll_area::ScrollBarVisibility::AlwaysVisible)
                     .show(ui, |ui| {
                         for spot in &spots {
                             let mhz = spot.freq_hz as f64 / 1_000_000.0;

--- a/rigflow-client/src/ui/panels/cluster.rs
+++ b/rigflow-client/src/ui/panels/cluster.rs
@@ -1,0 +1,23 @@
+use eframe::egui;
+
+use crate::ui::app::RigflowApp;
+use crate::ui::app_cluster::cluster_status_display;
+use crate::ui::state::UiState;
+
+impl RigflowApp {
+    /// Compact left-panel section: at-a-glance DX-cluster status + a button to
+    /// open the full config window. The spots themselves render on the
+    /// spectrum/waterfall, not here.
+    pub(crate) fn draw_cluster_panel(&mut self, ui: &mut egui::Ui, snapshot: &UiState) {
+        ui.collapsing(super::panel_header("DX Cluster"), |ui| {
+            ui.horizontal(|ui| {
+                ui.label("Status:");
+                let (txt, col) = cluster_status_display(&snapshot.dx_cluster_status);
+                ui.label(egui::RichText::new(txt).color(col));
+            });
+            if ui.button("Configure…").clicked() {
+                self.open_cluster(&snapshot.operator_id);
+            }
+        });
+    }
+}

--- a/rigflow-client/src/ui/panels/mod.rs
+++ b/rigflow-client/src/ui/panels/mod.rs
@@ -157,6 +157,7 @@ pub(crate) fn lock_button(ui: &mut egui::Ui, locked: &mut bool, size: f32) -> bo
 }
 
 mod bookmarks;
+mod cluster;
 mod latency;
 mod operator;
 mod problems;
@@ -259,6 +260,8 @@ impl RigflowApp {
                         self.draw_latency_panel(ui, snapshot);
                         ui.separator();
                         self.draw_bookmarks_panel(ui);
+                        ui.separator();
+                        self.draw_cluster_panel(ui, snapshot);
                         ui.separator();
                     });
                 // Feed the scroll offset to the wheel-dwell logic so controls

--- a/rigflow-client/src/ui/spectrum_view.rs
+++ b/rigflow-client/src/ui/spectrum_view.rs
@@ -1,5 +1,9 @@
+use std::time::Instant;
+
 use eframe::egui::{self, Align2, Color32, FontId, Pos2, Rect, Sense, Stroke};
 use rigflow_core::dsp::modes::DemodMode;
+
+use crate::cluster::DxSpot;
 
 use crate::ui::{
     bands::visible_radio_bands,
@@ -30,6 +34,7 @@ pub fn draw_spectrum_plot(
     db_min: f32,
     db_max: f32,
     state: &UiState,
+    spots: &[DxSpot],
 ) -> SpectrumInteraction {
     let size = egui::vec2(size.x.max(300.0), size.y.max(180.0));
 
@@ -99,6 +104,18 @@ pub fn draw_spectrum_plot(
         }
     }
 
+    // Incoming DX-cluster spots ride along the top of the plot (disjoint from the
+    // bottom-anchored bookmark strip). A click on a spot tunes to it precisely.
+    let clicked_spot = draw_spot_overlay(
+        &painter,
+        plot_rect,
+        spectrum_len,
+        state,
+        spots,
+        pointer_pos,
+        pointer_clicked,
+    );
+
     // Shared mouse interaction (identical to the waterfall): wheel fine-tune /
     // zoom and click/double-click tuning.  The spectrum maps screen-x →
     // frequency via the currently-visible (zoomed) range across `plot_rect`.
@@ -117,13 +134,114 @@ pub fn draw_spectrum_plot(
     // span) or when a bookmark overlay was clicked; wheel / zoom / center still
     // apply (they don't depend on the click position).
     if visible_range.is_none() || clicked_bookmark_id.is_some() {
+        // Bookmark clicks (and a missing mapping) suppress plain click-tune.
         mouse.tune_to_hz = None;
+    } else if let Some(hz) = clicked_spot {
+        // A spot click tunes precisely to the spot's frequency, overriding the
+        // click-position frequency.
+        mouse.tune_to_hz = Some(hz as f32);
     }
 
     SpectrumInteraction {
         clicked_bookmark_id,
         mouse,
     }
+}
+
+/// Draw incoming DX-cluster spots as ticks + callsign labels along the **top** of
+/// `rect` (the spectrum plot or the waterfall image). Only spots within the
+/// visible span are drawn; markers fade with age. Returns the frequency of a
+/// clicked spot (for the caller to tune to) and draws its own hover tooltip.
+/// Shared by the spectrum and waterfall so both behave identically.
+pub(crate) fn draw_spot_overlay(
+    painter: &egui::Painter,
+    rect: Rect,
+    spectrum_len: usize,
+    state: &UiState,
+    spots: &[DxSpot],
+    pointer_pos: Option<Pos2>,
+    pointer_clicked: bool,
+) -> Option<u64> {
+    if spots.is_empty() {
+        return None;
+    }
+
+    let font_id = FontId::monospace(10.0);
+    let now = Instant::now();
+    let ttl = crate::cluster::DEFAULT_TTL.as_secs_f32().max(1.0);
+
+    let mut clicked_freq: Option<u64> = None;
+    let mut hovered: Option<&DxSpot> = None;
+
+    for (idx, spot) in spots.iter().enumerate() {
+        let Some(x) = freq_to_plot_x_egui(spot.freq_hz as f32, rect, spectrum_len, state) else {
+            continue; // out of the visible span
+        };
+        if !x.is_finite() {
+            continue;
+        }
+
+        // Fade older spots: fresh → bright, near-TTL → dim.
+        let age_frac = (now
+            .saturating_duration_since(spot.received_at)
+            .as_secs_f32()
+            / ttl)
+            .clamp(0.0, 1.0);
+        let alpha = (235.0 - age_frac * 150.0) as u8; // 235 → 85
+        let color = Color32::from_rgba_unmultiplied(120, 205, 255, alpha);
+
+        // Two-row vertical stagger reduces label overlap between near spots.
+        let row = (idx % 2) as f32;
+        let tick_top = rect.top() + 1.0;
+        let tick_bottom = tick_top + 8.0;
+        let label_y = tick_bottom + 1.0 + row * 13.0;
+
+        painter.line_segment(
+            [Pos2::new(x, tick_top), Pos2::new(x, tick_bottom)],
+            Stroke::new(1.5_f32, color),
+        );
+
+        let galley = painter.layout_no_wrap(spot.dx_call.clone(), font_id.clone(), color);
+        let w = galley.size().x;
+        let h = galley.size().y;
+        let lx = (x - w * 0.5).clamp(
+            rect.left() + 2.0,
+            (rect.right() - w - 2.0).max(rect.left() + 2.0),
+        );
+        let label_rect = Rect::from_min_size(Pos2::new(lx, label_y), egui::vec2(w, h));
+        painter.galley(label_rect.min, galley, color);
+
+        if let Some(p) = pointer_pos {
+            let hit = Rect::from_min_max(
+                Pos2::new(label_rect.left() - 2.0, tick_top),
+                Pos2::new(label_rect.right() + 2.0, label_rect.bottom() + 1.0),
+            );
+            if hit.contains(p) {
+                hovered = Some(spot);
+                if pointer_clicked {
+                    clicked_freq = Some(spot.freq_hz);
+                }
+            }
+        }
+    }
+
+    if let (Some(spot), Some(p)) = (hovered, pointer_pos) {
+        let mut lines = vec![
+            spot.dx_call.clone(),
+            format!("{} MHz", format_mhz(spot.freq_hz as f32)),
+            format!("de {}", spot.spotter),
+        ];
+        let comment = spot.comment.trim();
+        if !comment.is_empty() {
+            lines.push(comment.to_string());
+        }
+        if !spot.time_utc.is_empty() {
+            lines.push(spot.time_utc.clone());
+        }
+        draw_tooltip_bubble(painter, rect, &lines, p);
+    }
+
+    clicked_freq
 }
 
 fn draw_grid_and_y_axis(

--- a/rigflow-client/src/ui/state.rs
+++ b/rigflow-client/src/ui/state.rs
@@ -344,6 +344,10 @@ pub struct UiState {
     pub log_status: String,
     /// WSJT-X UDP listener status (bind result / errors), surfaced for the user.
     pub wsjtx_listen_status: String,
+    /// DX-cluster connection state, surfaced for the status line. The spots
+    /// themselves live in a separate `Arc<Mutex<Vec<DxSpot>>>` (not here — this
+    /// struct is cloned every frame).
+    pub dx_cluster_status: crate::cluster::client::DxClusterStatus,
 
     // =====================================================================
     // PER-DEMOD OPERATOR PREFERENCES
@@ -781,6 +785,7 @@ impl Default for UiState {
             show_contact_view: false,
             log_status: String::new(),
             wsjtx_listen_status: String::new(),
+            dx_cluster_status: crate::cluster::client::DxClusterStatus::default(),
 
             // =================================================================
             // BOOKMARKS


### PR DESCRIPTION
 ## Summary                                                                                                                                                            
                                                                                                                                                                        
  The 1.0 release turns Rigflow into a complete operating position: alongside                                                                                           
  receive, transmit, and digital, you can now log contacts, look callsigns up, and                                                                                      
  see cluster spots on the waterfall.                                                                                                                                   
                                                                                                                                                                        
  ## What's new                                                                                                                                                         
                                                                                                                                                                        
  ### Contact logging                                                                                                                                                   
  - **Built-in logbook** — press **`L`** to log; frequency/mode captured automatically,                                                                                 
    time stamped when you press **Log**. **Worked-before hints** flag new calls/bands/dupes.                                                                            
  - **WSJT-X / FT8 auto-logging** — QSOs logged in WSJT-X are ingested automatically (dupes skipped).                                                                   
  - **Contacts view (`V`)** — filter, edit any field (incl. date/time), delete, multi-select;                                                                           
    the view filter is **shared with export**.                                                                                                                          
  - **ADIF import/export** — plan→preview→commit import (skips dupes, imports confirmations);                                                                           
    streaming export with an incremental "since last export". Local SQLite log + append-only ADIF journal.                                                              
  - **Online sync** — upload to / download confirmations from **LoTW, eQSL, QRZ Logbook**, with                                                                         
    confirmation badges. Credentials in the OS secure keyring (encrypted-file fallback), never in logs/ADIF.                                                            
  - **Station profile** — callsign, grid, state/county/zones written as the `MY_*` fields on every contact.                                                             
                                                                                                                                                                        
  ### Callbook lookup                                                                                                                                                   
  - Auto-fills **name, QTH, grid, state/county, country, DXCC/zones** as you type a call.                                                                               
  - Providers in priority order: **QRZ XML** (qrz.com login + XML subscription), **HamQTH** (free),                                                                     
    **Callook** (US, no account), over an always-on **offline prefix baseline** (DXCC + zones, no network).                                                             
    Your typed values always win.                                                                                                                                       
                                                                                                                                                                        
  ### DX cluster                                                                                                                                                        
  - Connect to a node; live spots on the **spectrum/waterfall** and a scrollable, click-to-tune **band map**.                                                           
    Built-in nodes (VE7CC / NC7J / W3LPL / HRD) or a custom host.                                                                                                       
  - Filter by current band + mode; spots age out; auto-reconnect on drop.                                                                                               
                                                                                                                                                                        
  ### Quality of life                                                                                                                                                   
  - Callbook location shown in plain language (`via QRZ · Chicago, IL · United States`) instead of a bare grid.                                                         
                                                                                                                                                                        
  ## Docs & versioning                                                                                                                                                  
  - Full user documentation: README, Operator guide (new logging/callbook/DX-cluster sections, plus                                                                     
    backfilled dual-watch/split/RIT-XIT and voice keyer), RELEASE_NOTES v1.0.0, installation (client                                                                    
    Linux now needs **libdbus** for keyring credentials; file fallback), and troubleshooting.                                                                           
  - Workspace version bumped **0.1.5 → 1.0.0** (`Cargo.toml` + `Cargo.lock`, all crates).                                                                               
                                                                                                                                                                        
  ## Compatibility                                                                                                                                                      
  The 1.0 headline features are **client-side** (the log, callbook, and cluster live in the client),                                                                    
  so a 1.0 client works against a 0.1.5 server — but installing the matching **1.0** client + server                                                                    
  pair is recommended.                                                                                                                                                  
                                                                                                                                                                        
  ## Testing                                                                                                                                                            
  - `rigflow-log` unit tests pass; the callbook/cluster parsers are unit-tested; client type-checks                                                                     
    clean with no new clippy warnings.                                                                                                                                  
  - Verified on the air: contact logging + ADIF/LoTW/eQSL/QRZ round-trip, callbook auto-fill, and the                                                                   
    DX-cluster spot list / click-to-tune.                               