### PR TITLE
Add atomic VFO frequency updates

### DIFF
--- a/rigflow-client/src/ui/app_actions.rs
+++ b/rigflow-client/src/ui/app_actions.rs
@@ -864,13 +864,9 @@ impl RigflowApp {
             }
 
             let _ = self.ws_cmd_tx.send(ControlCommand::RadioMessage(
-                rigflow_protocol::ClientRadioMessage::SetCenterFrequency {
+                rigflow_protocol::ClientRadioMessage::SetVfoFrequencies {
+                    vfo: rigflow_core::radio::vfo::VfoSelect::A,
                     center_freq_hz: bookmark.frequency_hz as u64,
-                },
-            ));
-
-            let _ = self.ws_cmd_tx.send(ControlCommand::RadioMessage(
-                rigflow_protocol::ClientRadioMessage::SetTargetFrequency {
                     target_freq_hz: bookmark.frequency_hz as u64,
                 },
             ));

--- a/rigflow-client/src/ui/app_center.rs
+++ b/rigflow-client/src/ui/app_center.rs
@@ -639,25 +639,25 @@ impl RigflowApp {
         );
 
         if let Ok(mut state) = self.state.lock() {
-            vfo.set_center(&mut state, new_center);
-            vfo.set_target(&mut state, new_target);
+            vfo.set_frequencies(&mut state, new_center, new_target);
         }
         // Retune the LO only when it actually panned.
         if (new_center - cur_center).abs() > 0.5 {
             let _ = self.ws_cmd_tx.send(ControlCommand::RadioMessage(
-                vfo.center_msg(new_center as u64),
+                vfo.frequencies_msg(new_center as u64, new_target as u64),
+            ));
+        } else {
+            let _ = self.ws_cmd_tx.send(ControlCommand::RadioMessage(
+                vfo.target_msg(new_target as u64),
             ));
         }
-        let _ = self.ws_cmd_tx.send(ControlCommand::RadioMessage(
-            vfo.target_msg(new_target as u64),
-        ));
     }
 
     /// Pan the target frequency by `delta_hz`, applying the same soft-edge LO
     /// pan as [`tune_target_relative`] but with **throttled** control-channel
     /// sends so a 60 fps drag / momentum sweep doesn't flood the server with
     /// retunes.  Local UI state is updated on every call (smooth display);
-    /// `SetTargetFrequency` / `SetCenterFrequency` are sent at most once per
+    /// Tuning commands are sent at most once per
     /// [`PAN_SEND_INTERVAL`] unless `force_send` is set (used for the final,
     /// exact value when a gesture ends, so the server lands on the settled
     /// frequency with the correct band filters).
@@ -708,8 +708,7 @@ impl RigflowApp {
                 Ok(s) => s,
                 Err(_) => return moved,
             };
-            vfo.set_center(&mut state, new_center);
-            vfo.set_target(&mut state, new_target);
+            vfo.set_frequencies(&mut state, new_center, new_target);
 
             let now = Instant::now();
             let allow = force_send || now.duration_since(state.last_pan_send) >= PAN_SEND_INTERVAL;
@@ -730,10 +729,9 @@ impl RigflowApp {
 
         if do_center {
             let _ = self.ws_cmd_tx.send(ControlCommand::RadioMessage(
-                vfo.center_msg(new_center as u64),
+                vfo.frequencies_msg(new_center as u64, new_target as u64),
             ));
-        }
-        if do_target {
+        } else if do_target {
             let _ = self.ws_cmd_tx.send(ControlCommand::RadioMessage(
                 vfo.target_msg(new_target as u64),
             ));
@@ -869,11 +867,9 @@ impl RigflowApp {
                     &limits,
                 );
                 if let Ok(mut state) = self.state.lock() {
-                    vfo.set_center(&mut state, new_center);
-                    vfo.set_target(&mut state, new_target);
+                    vfo.set_frequencies(&mut state, new_center, new_target);
                 }
-                send(vfo.center_msg(new_center as u64));
-                send(vfo.target_msg(new_target as u64));
+                send(vfo.frequencies_msg(new_center as u64, new_target as u64));
             } else if let Ok(mut state) = self.state.lock() {
                 state.server_status = "cannot tune: no radio acquired".to_string();
             }
@@ -953,20 +949,16 @@ impl RigflowApp {
             self.tune_target_relative(&state_snapshot, delta, vfo);
         }
 
-        if let Some(new_center_hz) = new_center_freq_hz {
+        if let (Some(new_center_hz), Some(new_target_hz)) = (new_center_freq_hz, new_target_freq_hz)
+        {
+            // Centre and target form one offset-preserving LO operation. Apply
+            // and send them as a pair so neither local readers nor server echoes
+            // can observe a half-updated tuning state during a continuous drag.
             if let Ok(mut state) = self.state.lock() {
-                vfo.set_center(&mut state, new_center_hz);
+                vfo.set_frequencies(&mut state, new_center_hz, new_target_hz);
             }
             let _ = self.ws_cmd_tx.send(ControlCommand::RadioMessage(
-                vfo.center_msg(new_center_hz as u64),
-            ));
-        }
-        if let Some(new_target_hz) = new_target_freq_hz {
-            if let Ok(mut state) = self.state.lock() {
-                vfo.set_target(&mut state, new_target_hz);
-            }
-            let _ = self.ws_cmd_tx.send(ControlCommand::RadioMessage(
-                vfo.target_msg(new_target_hz as u64),
+                vfo.frequencies_msg(new_center_hz as u64, new_target_hz as u64),
             ));
         }
 
@@ -1062,6 +1054,10 @@ impl TuneVfo {
             TuneVfo::B => s.vfo_b_target_freq_hz = hz,
         }
     }
+    fn set_frequencies(self, s: &mut UiState, center_hz: f32, target_hz: f32) {
+        self.set_center(s, center_hz);
+        self.set_target(s, target_hz);
+    }
     fn demod_mode(self, s: &UiState) -> rigflow_core::dsp::modes::DemodMode {
         match self {
             TuneVfo::A => s.demod_mode,
@@ -1084,18 +1080,25 @@ impl TuneVfo {
             TuneVfo::B => s.vfo_b_display_zoom,
         }
     }
-    fn center_msg(self, hz: u64) -> rigflow_protocol::ClientRadioMessage {
-        use rigflow_protocol::ClientRadioMessage as M;
-        match self {
-            TuneVfo::A => M::SetCenterFrequency { center_freq_hz: hz },
-            TuneVfo::B => M::SetVfoBCenterFrequency { center_freq_hz: hz },
-        }
-    }
     fn target_msg(self, hz: u64) -> rigflow_protocol::ClientRadioMessage {
         use rigflow_protocol::ClientRadioMessage as M;
         match self {
             TuneVfo::A => M::SetTargetFrequency { target_freq_hz: hz },
             TuneVfo::B => M::SetVfoBFrequency { target_freq_hz: hz },
+        }
+    }
+    fn frequencies_msg(
+        self,
+        center_freq_hz: u64,
+        target_freq_hz: u64,
+    ) -> rigflow_protocol::ClientRadioMessage {
+        rigflow_protocol::ClientRadioMessage::SetVfoFrequencies {
+            vfo: match self {
+                TuneVfo::A => rigflow_core::radio::vfo::VfoSelect::A,
+                TuneVfo::B => rigflow_core::radio::vfo::VfoSelect::B,
+            },
+            center_freq_hz,
+            target_freq_hz,
         }
     }
 }

--- a/rigflow-protocol/src/radio_control.rs
+++ b/rigflow-protocol/src/radio_control.rs
@@ -118,6 +118,17 @@ pub enum ClientRadioMessage {
         target_freq_hz: u64,
     },
 
+    /// Atomically set one VFO's LO/centre and tuned target frequencies.
+    ///
+    /// Use this when the two values describe one tuning operation (for example,
+    /// recentering while preserving an offset). The legacy single-field commands
+    /// remain available for operations that intentionally move only one value.
+    SetVfoFrequencies {
+        vfo: VfoSelect,
+        center_freq_hz: u64,
+        target_freq_hz: u64,
+    },
+
     SetDemodMode {
         mode: DemodMode,
     },
@@ -842,4 +853,56 @@ pub enum RadioAvailability {
 
     /// Error state (requires recovery or restart)
     Faulted,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn atomic_vfo_frequencies_round_trip_for_both_vfos() {
+        for vfo in [VfoSelect::A, VfoSelect::B] {
+            let message = ClientRadioMessage::SetVfoFrequencies {
+                vfo,
+                center_freq_hz: 14_000_000,
+                target_freq_hz: 14_074_000,
+            };
+
+            let json = serde_json::to_string(&message).expect("serialize tuning command");
+            let decoded: ClientRadioMessage =
+                serde_json::from_str(&json).expect("deserialize tuning command");
+
+            match decoded {
+                ClientRadioMessage::SetVfoFrequencies {
+                    vfo: decoded_vfo,
+                    center_freq_hz,
+                    target_freq_hz,
+                } => {
+                    assert_eq!(decoded_vfo, vfo);
+                    assert_eq!(center_freq_hz, 14_000_000);
+                    assert_eq!(target_freq_hz, 14_074_000);
+                }
+                _ => panic!("decoded the wrong message variant"),
+            }
+        }
+    }
+
+    #[test]
+    fn atomic_vfo_frequencies_has_stable_wire_shape() {
+        let message = ClientRadioMessage::SetVfoFrequencies {
+            vfo: VfoSelect::B,
+            center_freq_hz: 7_000_000,
+            target_freq_hz: 7_074_000,
+        };
+
+        assert_eq!(
+            serde_json::to_value(message).expect("serialize tuning command"),
+            serde_json::json!({
+                "type": "set_vfo_frequencies",
+                "vfo": "b",
+                "center_freq_hz": 7_000_000,
+                "target_freq_hz": 7_074_000,
+            })
+        );
+    }
 }

--- a/rigflow-protocol/src/radio_control.rs
+++ b/rigflow-protocol/src/radio_control.rs
@@ -121,8 +121,7 @@ pub enum ClientRadioMessage {
     /// Atomically set one VFO's LO/centre and tuned target frequencies.
     ///
     /// Use this when the two values describe one tuning operation (for example,
-    /// recentering while preserving an offset). The legacy single-field commands
-    /// remain available for operations that intentionally move only one value.
+    /// recentering while preserving an offset).
     SetVfoFrequencies {
         vfo: VfoSelect,
         center_freq_hz: u64,

--- a/rigflow-server/src/net/websocket.rs
+++ b/rigflow-server/src/net/websocket.rs
@@ -520,6 +520,25 @@ async fn handle_radio_message(
             }
         }
 
+        ClientRadioMessage::SetVfoFrequencies {
+            vfo,
+            center_freq_hz,
+            target_freq_hz,
+        } => {
+            forward_worker_command(
+                app_state,
+                session,
+                local_tx,
+                WorkerCommand::SetVfoFrequencies {
+                    vfo,
+                    center_freq_hz,
+                    target_freq_hz,
+                },
+                "set_vfo_frequencies_failed",
+            )
+            .await;
+        }
+
         ClientRadioMessage::SetDemodMode { mode } => {
             if let Err(err) = send_worker_command_for_session(
                 app_state,

--- a/rigflow-server/src/radio/types.rs
+++ b/rigflow-server/src/radio/types.rs
@@ -232,6 +232,12 @@ pub struct WorkerRuntimeState {
 /// Commands sent from server/session → worker.
 #[derive(Debug, Clone)]
 pub enum WorkerCommand {
+    /// Set one VFO's centre and target as a single control-state transaction.
+    SetVfoFrequencies {
+        vfo: VfoSelect,
+        center_freq_hz: u64,
+        target_freq_hz: u64,
+    },
     SetTargetFrequency {
         hz: u64,
     },

--- a/rigflow-server/src/radio/worker.rs
+++ b/rigflow-server/src/radio/worker.rs
@@ -179,6 +179,23 @@ struct SharedControlState {
 }
 
 impl SharedControlState {
+    /// Update a VFO's centre and target together while the caller holds the
+    /// control-state lock. Readers can therefore observe only the old pair or
+    /// the new pair, never a centre from one tuning operation and a target from
+    /// another.
+    fn set_vfo_frequencies(&mut self, vfo: VfoSelect, center_freq_hz: u64, target_freq_hz: u64) {
+        match vfo {
+            VfoSelect::A => {
+                self.center_freq_hz = center_freq_hz;
+                self.target_freq_hz = target_freq_hz;
+            }
+            VfoSelect::B => {
+                self.vfo.vfo_b_center_freq_hz = center_freq_hz;
+                self.vfo.vfo_b_target_freq_hz = target_freq_hz;
+            }
+        }
+    }
+
     /// Project VFO A's (flat) receiver settings as a `VfoState`.  VFO A's RIT
     /// lives in `vfo.rit_*`; everything else is the top-level flat fields.
     fn vfo_a_state(&self) -> VfoState {
@@ -1214,6 +1231,15 @@ fn spawn_command_thread(
         while !stop_requested(&stop_flag) {
             match cmd_rx.recv_timeout(Duration::from_millis(20)) {
                 Ok(cmd) => match cmd {
+                    WorkerCommand::SetVfoFrequencies {
+                        vfo,
+                        center_freq_hz,
+                        target_freq_hz,
+                    } => {
+                        if let Ok(mut control_state) = control.lock() {
+                            control_state.set_vfo_frequencies(vfo, center_freq_hz, target_freq_hz);
+                        }
+                    }
                     WorkerCommand::SetTargetFrequency { hz } => {
                         if let Ok(mut control_state) = control.lock() {
                             control_state.target_freq_hz = hz;
@@ -3741,5 +3767,34 @@ mod vfo_b_mirror_tests {
         assert_eq!(cs.vfo.vfo_b_agc_strength, 0.2);
         assert!(cs.vfo.vfo_b_rit_enabled);
         assert_eq!(cs.vfo.vfo_b_rit_offset_hz, -120);
+    }
+
+    #[test]
+    fn atomic_frequency_update_routes_to_vfo_a_only() {
+        let mut cs = vfo_a_control();
+        cs.vfo = distinct_vfo_b();
+        let old_b_center = cs.vfo.vfo_b_center_freq_hz;
+        let old_b_target = cs.vfo.vfo_b_target_freq_hz;
+
+        cs.set_vfo_frequencies(VfoSelect::A, 28_000_000, 28_074_000);
+
+        assert_eq!(cs.center_freq_hz, 28_000_000);
+        assert_eq!(cs.target_freq_hz, 28_074_000);
+        assert_eq!(cs.vfo.vfo_b_center_freq_hz, old_b_center);
+        assert_eq!(cs.vfo.vfo_b_target_freq_hz, old_b_target);
+    }
+
+    #[test]
+    fn atomic_frequency_update_routes_to_vfo_b_only() {
+        let mut cs = vfo_a_control();
+        let old_a_center = cs.center_freq_hz;
+        let old_a_target = cs.target_freq_hz;
+
+        cs.set_vfo_frequencies(VfoSelect::B, 7_000_000, 7_074_000);
+
+        assert_eq!(cs.vfo.vfo_b_center_freq_hz, 7_000_000);
+        assert_eq!(cs.vfo.vfo_b_target_freq_hz, 7_074_000);
+        assert_eq!(cs.center_freq_hz, old_a_center);
+        assert_eq!(cs.target_freq_hz, old_a_target);
     }
 }


### PR DESCRIPTION
## Summary

Add an atomic VFO tuning command that updates centre and target frequencies together.

- Add `SetVfoFrequencies` to the client/server protocol, with explicit VFO A/B selection.
- Apply both frequencies under one server control-state lock so readers cannot observe a half-updated tuning state.
- Use the paired update for client operations that change both values, including bookmark recall, centring on the target, offset-preserving LO tuning, and spectrum auto-pan.
- Keep the existing individual centre- and target-frequency commands for operations that only change one value.

## Motivation

Centre and target frequency form a pair for several tuning operations. Sending them as separate commands creates an intermediate state in which the server has received one value but not the other. Server state echoed during that interval can overwrite newer client state, causing the displayed frequency or LO offset to jump during continuous tuning.

Treating the pair as one command makes these operations consistent across the protocol, worker, and client state. It will also make it simpler to support more complex UI interactions.

## Testing

- `cargo fmt --all -- --check`
- `cargo check --workspace`
- Protocol serialization and stable wire-shape tests for both VFOs.
- Server tests verifying that paired updates affect only the selected VFO.
- Client test suite.
- Deployed against a connected radio and verified working.
