### PR TITLE
Add interactive LO frequency controls

### DIFF
--- a/rigflow-client/src/ui/app.rs
+++ b/rigflow-client/src/ui/app.rs
@@ -874,7 +874,6 @@ impl eframe::App for RigflowApp {
 
         self.ensure_mic();
         self.auto_relock_controls();
-        self.handle_keyboard_shortcuts(ctx);
         self.update_ptt_focus_latch(ctx);
         self.handle_cw_keying(ctx, &snapshot);
         self.handle_cw_macros(ctx, &snapshot);
@@ -898,6 +897,11 @@ impl eframe::App for RigflowApp {
         self.draw_sync_window(ctx, &snapshot.operator_id);
         self.draw_callbook_window(ctx, &snapshot.operator_id);
         self.draw_cluster_window(ctx, &snapshot.operator_id);
+
+        // Widgets get first refusal on keyboard events (for example, arrows over
+        // an LO digit). Anything they do not consume falls through to the global
+        // shortcuts after all controls have had a chance to handle the frame.
+        self.handle_keyboard_shortcuts(ctx);
 
         // Per-operator audio recording + voice keyer: ensure dirs / refresh the
         // clip list on an operator switch, run any UI-requested action, and

--- a/rigflow-client/src/ui/app_actions.rs
+++ b/rigflow-client/src/ui/app_actions.rs
@@ -864,13 +864,9 @@ impl RigflowApp {
             }
 
             let _ = self.ws_cmd_tx.send(ControlCommand::RadioMessage(
-                rigflow_protocol::ClientRadioMessage::SetCenterFrequency {
+                rigflow_protocol::ClientRadioMessage::SetVfoFrequencies {
+                    vfo: rigflow_core::radio::vfo::VfoSelect::A,
                     center_freq_hz: bookmark.frequency_hz as u64,
-                },
-            ));
-
-            let _ = self.ws_cmd_tx.send(ControlCommand::RadioMessage(
-                rigflow_protocol::ClientRadioMessage::SetTargetFrequency {
                     target_freq_hz: bookmark.frequency_hz as u64,
                 },
             ));

--- a/rigflow-client/src/ui/app_center.rs
+++ b/rigflow-client/src/ui/app_center.rs
@@ -919,9 +919,10 @@ impl RigflowApp {
         let dial_locked = state_snapshot.dial_locked;
         if let Some(new_center_hz) = crate::widgets::lo_frequency_widget::draw_lo_widget(
             ui,
+            ("lo", matches!(vfo, TuneVfo::B)),
             lo_pos,
             cur_center.max(0.0) as u64,
-            !dial_locked,
+            state_snapshot.radio_acquired && !dial_locked,
         ) {
             let limits = active_freq_limits(&state_snapshot);
             let clamped_center = clamp_center(new_center_hz as f32, &limits);
@@ -940,9 +941,10 @@ impl RigflowApp {
         let lo_offset_hz = (cur_target - cur_center).round() as i64;
         if let Some(new_offset_hz) = crate::widgets::lo_frequency_widget::draw_lo_offset_widget(
             ui,
+            ("lo_offset", matches!(vfo, TuneVfo::B)),
             lo_offset_pos,
             lo_offset_hz,
-            !dial_locked,
+            state_snapshot.radio_acquired && !dial_locked,
         ) {
             // Reuse the soft-edge LO pan (LO follows the target at the edge).
             let delta = (new_offset_hz - lo_offset_hz) as f32;

--- a/rigflow-client/src/ui/app_center.rs
+++ b/rigflow-client/src/ui/app_center.rs
@@ -639,25 +639,25 @@ impl RigflowApp {
         );
 
         if let Ok(mut state) = self.state.lock() {
-            vfo.set_center(&mut state, new_center);
-            vfo.set_target(&mut state, new_target);
+            vfo.set_frequencies(&mut state, new_center, new_target);
         }
         // Retune the LO only when it actually panned.
         if (new_center - cur_center).abs() > 0.5 {
             let _ = self.ws_cmd_tx.send(ControlCommand::RadioMessage(
-                vfo.center_msg(new_center as u64),
+                vfo.frequencies_msg(new_center as u64, new_target as u64),
+            ));
+        } else {
+            let _ = self.ws_cmd_tx.send(ControlCommand::RadioMessage(
+                vfo.target_msg(new_target as u64),
             ));
         }
-        let _ = self.ws_cmd_tx.send(ControlCommand::RadioMessage(
-            vfo.target_msg(new_target as u64),
-        ));
     }
 
     /// Pan the target frequency by `delta_hz`, applying the same soft-edge LO
     /// pan as [`tune_target_relative`] but with **throttled** control-channel
     /// sends so a 60 fps drag / momentum sweep doesn't flood the server with
     /// retunes.  Local UI state is updated on every call (smooth display);
-    /// `SetTargetFrequency` / `SetCenterFrequency` are sent at most once per
+    /// Tuning commands are sent at most once per
     /// [`PAN_SEND_INTERVAL`] unless `force_send` is set (used for the final,
     /// exact value when a gesture ends, so the server lands on the settled
     /// frequency with the correct band filters).
@@ -708,8 +708,7 @@ impl RigflowApp {
                 Ok(s) => s,
                 Err(_) => return moved,
             };
-            vfo.set_center(&mut state, new_center);
-            vfo.set_target(&mut state, new_target);
+            vfo.set_frequencies(&mut state, new_center, new_target);
 
             let now = Instant::now();
             let allow = force_send || now.duration_since(state.last_pan_send) >= PAN_SEND_INTERVAL;
@@ -730,10 +729,9 @@ impl RigflowApp {
 
         if do_center {
             let _ = self.ws_cmd_tx.send(ControlCommand::RadioMessage(
-                vfo.center_msg(new_center as u64),
+                vfo.frequencies_msg(new_center as u64, new_target as u64),
             ));
-        }
-        if do_target {
+        } else if do_target {
             let _ = self.ws_cmd_tx.send(ControlCommand::RadioMessage(
                 vfo.target_msg(new_target as u64),
             ));
@@ -869,11 +867,9 @@ impl RigflowApp {
                     &limits,
                 );
                 if let Ok(mut state) = self.state.lock() {
-                    vfo.set_center(&mut state, new_center);
-                    vfo.set_target(&mut state, new_target);
+                    vfo.set_frequencies(&mut state, new_center, new_target);
                 }
-                send(vfo.center_msg(new_center as u64));
-                send(vfo.target_msg(new_target as u64));
+                send(vfo.frequencies_msg(new_center as u64, new_target as u64));
             } else if let Ok(mut state) = self.state.lock() {
                 state.server_status = "cannot tune: no radio acquired".to_string();
             }
@@ -953,20 +949,16 @@ impl RigflowApp {
             self.tune_target_relative(&state_snapshot, delta, vfo);
         }
 
-        if let Some(new_center_hz) = new_center_freq_hz {
+        if let (Some(new_center_hz), Some(new_target_hz)) = (new_center_freq_hz, new_target_freq_hz)
+        {
+            // Centre and target form one offset-preserving LO operation. Apply
+            // and send them as a pair so neither local readers nor server echoes
+            // can observe a half-updated tuning state during a continuous drag.
             if let Ok(mut state) = self.state.lock() {
-                vfo.set_center(&mut state, new_center_hz);
+                vfo.set_frequencies(&mut state, new_center_hz, new_target_hz);
             }
             let _ = self.ws_cmd_tx.send(ControlCommand::RadioMessage(
-                vfo.center_msg(new_center_hz as u64),
-            ));
-        }
-        if let Some(new_target_hz) = new_target_freq_hz {
-            if let Ok(mut state) = self.state.lock() {
-                vfo.set_target(&mut state, new_target_hz);
-            }
-            let _ = self.ws_cmd_tx.send(ControlCommand::RadioMessage(
-                vfo.target_msg(new_target_hz as u64),
+                vfo.frequencies_msg(new_center_hz as u64, new_target_hz as u64),
             ));
         }
 
@@ -1062,6 +1054,10 @@ impl TuneVfo {
             TuneVfo::B => s.vfo_b_target_freq_hz = hz,
         }
     }
+    fn set_frequencies(self, s: &mut UiState, center_hz: f32, target_hz: f32) {
+        self.set_center(s, center_hz);
+        self.set_target(s, target_hz);
+    }
     fn demod_mode(self, s: &UiState) -> rigflow_core::dsp::modes::DemodMode {
         match self {
             TuneVfo::A => s.demod_mode,
@@ -1084,18 +1080,25 @@ impl TuneVfo {
             TuneVfo::B => s.vfo_b_display_zoom,
         }
     }
-    fn center_msg(self, hz: u64) -> rigflow_protocol::ClientRadioMessage {
-        use rigflow_protocol::ClientRadioMessage as M;
-        match self {
-            TuneVfo::A => M::SetCenterFrequency { center_freq_hz: hz },
-            TuneVfo::B => M::SetVfoBCenterFrequency { center_freq_hz: hz },
-        }
-    }
     fn target_msg(self, hz: u64) -> rigflow_protocol::ClientRadioMessage {
         use rigflow_protocol::ClientRadioMessage as M;
         match self {
             TuneVfo::A => M::SetTargetFrequency { target_freq_hz: hz },
             TuneVfo::B => M::SetVfoBFrequency { target_freq_hz: hz },
+        }
+    }
+    fn frequencies_msg(
+        self,
+        center_freq_hz: u64,
+        target_freq_hz: u64,
+    ) -> rigflow_protocol::ClientRadioMessage {
+        rigflow_protocol::ClientRadioMessage::SetVfoFrequencies {
+            vfo: match self {
+                TuneVfo::A => rigflow_core::radio::vfo::VfoSelect::A,
+                TuneVfo::B => rigflow_core::radio::vfo::VfoSelect::B,
+            },
+            center_freq_hz,
+            target_freq_hz,
         }
     }
 }

--- a/rigflow-client/src/widgets/lo_frequency_widget.rs
+++ b/rigflow-client/src/widgets/lo_frequency_widget.rs
@@ -118,7 +118,7 @@ fn editor_character_distance(current: char, next: char) -> Option<f32> {
 fn layout_editor_text(
     ui: &egui::Ui,
     text: &str,
-    wrap_width: f32,
+    _wrap_width: f32,
     font: &FontId,
     color: Color32,
 ) -> std::sync::Arc<egui::Galley> {
@@ -130,7 +130,9 @@ fn layout_editor_text(
             .collect()
     });
     let mut job = egui::text::LayoutJob::default();
-    job.wrap.max_width = wrap_width;
+    // Match TextEdit's built-in single-line layouter: do not wrap at the field
+    // width (or at separators), and let TextEdit horizontally clip/scroll.
+    job.break_on_newline = false;
 
     for (index, character) in chars.iter().copied().enumerate() {
         let format = egui::TextFormat {

--- a/rigflow-client/src/widgets/lo_frequency_widget.rs
+++ b/rigflow-client/src/widgets/lo_frequency_widget.rs
@@ -4,6 +4,14 @@ use eframe::egui::{
     self, Align2, Color32, CursorIcon, FontId, Key, Modifiers, Pos2, Rect, Sense, Vec2,
 };
 
+mod editor;
+
+const DIGIT_W: f32 = 13.0;
+const DIGIT_H: f32 = 24.0;
+const DIGIT_GAP: f32 = 1.0;
+const SEP_W: f32 = 7.0;
+const SIGN_W: f32 = 12.0;
+const LABEL_GAP: f32 = 8.0;
 const DRAG_POINTS_PER_STEP: f32 = 7.0;
 
 /// Controls how the digit widget is anchored relative to the provided origin.
@@ -13,16 +21,22 @@ pub enum DigitWheelAnchor {
     Right,
 }
 
-/// Specification for a digit-wheel widget.
+/// Specification for a digit-wheel widget shared by the LO and LO-offset controls.
 #[derive(Debug, Clone)]
 pub struct DigitWheelSpec<'a> {
+    /// Label drawn beside the digits.
     pub label: &'a str,
+    /// Total number of zero-padded digits.
     pub digit_count: usize,
+    /// Whether to render and accept a leading sign.
     pub signed: bool,
+    /// Left-to-right group widths, for example `[1, 3, 3, 3]`.
     pub groups: &'a [usize],
+    /// Whether `origin` identifies the left or right edge of the control.
     pub anchor: DigitWheelAnchor,
 }
 
+/// One independently interactive digit in the painted value.
 #[derive(Debug, Clone, Copy)]
 struct DigitCell {
     rect: Rect,
@@ -67,6 +81,7 @@ impl Default for DigitWheelState {
     }
 }
 
+/// Compute the per-digit tuning multiplier without floating-point conversion.
 fn pow10_u64(exp: usize) -> u64 {
     let mut v = 1u64;
     for _ in 0..exp {
@@ -75,94 +90,18 @@ fn pow10_u64(exp: usize) -> u64 {
     v
 }
 
+/// Format a value as the fixed-width ASCII digit array used by the painter.
 fn format_abs_digits(value: u64, digit_count: usize) -> Vec<u8> {
     let s = format!("{value:0width$}", width = digit_count);
     s.into_bytes()
 }
 
-fn format_editor_value(value: i64, spec: &DigitWheelSpec<'_>) -> String {
-    let digits = format!("{:0width$}", value.unsigned_abs(), width = spec.digit_count);
-    let grouped_width: usize = spec.groups.iter().sum();
-    debug_assert_eq!(grouped_width, spec.digit_count);
-
-    let mut out = String::with_capacity(digits.len() + spec.groups.len());
-    if spec.signed {
-        out.push(if value < 0 { '-' } else { '+' });
-    }
-
-    // If a caller supplies a value wider than the nominal digit count, retain
-    // the extra leading digits in the first group rather than truncating them.
-    let mut offset = 0;
-    let overflow = digits.len().saturating_sub(grouped_width);
-    for (group_index, group_width) in spec.groups.iter().copied().enumerate() {
-        if group_index != 0 {
-            out.push('.');
-        }
-        let width = group_width + usize::from(group_index == 0) * overflow;
-        out.push_str(&digits[offset..offset + width]);
-        offset += width;
-    }
-    out
-}
-
-fn editor_character_distance(current: char, next: char) -> Option<f32> {
-    match (current, next) {
-        (c, n) if c.is_ascii_digit() && n.is_ascii_digit() => Some(14.0),
-        (c, '.') if c.is_ascii_digit() => Some(11.0),
-        ('.', n) if n.is_ascii_digit() => Some(10.0),
-        ('+' | '-', n) if n.is_ascii_digit() => Some(13.5),
-        _ => None,
-    }
-}
-
-fn layout_editor_text(
-    ui: &egui::Ui,
-    text: &str,
-    _wrap_width: f32,
-    font: &FontId,
-    color: Color32,
-) -> std::sync::Arc<egui::Galley> {
-    let chars: Vec<char> = text.chars().collect();
-    let widths: Vec<f32> = ui.fonts(|fonts| {
-        chars
-            .iter()
-            .map(|character| fonts.glyph_width(font, *character))
-            .collect()
-    });
-    let mut job = egui::text::LayoutJob::default();
-    // Match TextEdit's built-in single-line layouter: do not wrap at the field
-    // width (or at separators), and let TextEdit horizontally clip/scroll.
-    job.break_on_newline = false;
-
-    for (index, character) in chars.iter().copied().enumerate() {
-        let format = egui::TextFormat {
-            font_id: font.clone(),
-            color,
-            ..Default::default()
-        };
-        let leading_space = if let Some(previous) = index.checked_sub(1)
-            && let Some(center_distance) = editor_character_distance(chars[previous], character)
-        {
-            // Match the fixed-cell painter by compensating for the actual glyph
-            // advances. This also remains correct if the chosen font's digits
-            // are not tabular.
-            center_distance - (widths[previous] + widths[index]) * 0.5
-        } else {
-            0.0
-        };
-        // Each character is a separate section so its gap can reflect the
-        // fixed digit/separator geometry. `extra_letter_spacing` would have no
-        // effect here because it only separates glyphs within one section.
-        job.append(&character.to_string(), leading_space, format);
-    }
-
-    ui.fonts(|fonts| fonts.layout_job(job))
-}
-
+/// Locate the first active digit so leading zeroes can be visually dimmed.
 fn first_nonzero_digit(digits: &[u8]) -> Option<usize> {
     digits.iter().position(|d| *d != b'0')
 }
 
+/// Return the decimal place represented by a left-to-right digit index.
 fn digit_step(digit_count: usize, digit_index: usize) -> i64 {
     let place_from_right = digit_count - 1 - digit_index;
     pow10_u64(place_from_right) as i64
@@ -194,74 +133,6 @@ fn set_drag_cursor(ctx: &egui::Context, grabbed: bool) {
     } else {
         egui::viewport::CursorGrab::None
     }));
-}
-
-fn parse_display_prefix(number: &str, spec: &DigitWheelSpec<'_>) -> Option<i64> {
-    let (sign, unsigned) = if let Some(unsigned) = number.strip_prefix('-') {
-        if !spec.signed {
-            return None;
-        }
-        ("-", unsigned)
-    } else if let Some(unsigned) = number.strip_prefix('+') {
-        ("+", unsigned)
-    } else {
-        ("", number)
-    };
-
-    // Without a display separator, bare input retains its documented literal-Hz
-    // meaning. A dotted value matching the widget's leading groups is instead
-    // treated as a possibly incomplete copy of the displayed value.
-    if !unsigned.contains('.') {
-        return None;
-    }
-    let entered_groups: Vec<&str> = unsigned.split('.').collect();
-    if entered_groups.len() > spec.groups.len() {
-        return None;
-    }
-
-    let mut digits = String::with_capacity(spec.digit_count);
-    for (index, width) in spec.groups.iter().copied().enumerate() {
-        let entered = entered_groups.get(index).copied().unwrap_or("");
-        if entered.len() > width || !entered.chars().all(|c| c.is_ascii_digit()) {
-            return None;
-        }
-        digits.push_str(entered);
-        digits.extend(std::iter::repeat_n('0', width - entered.len()));
-    }
-
-    format!("{sign}{digits}").parse().ok()
-}
-
-/// Parse an editor value. Bare values are Hz (grouping dots/commas are allowed);
-/// a left-to-right prefix of the dotted widget display is padded with trailing
-/// zeroes, and an explicit Hz/kHz/MHz suffix enables decimal unit input.
-fn parse_frequency(text: &str, spec: &DigitWheelSpec<'_>) -> Option<i64> {
-    let compact: String = text.chars().filter(|c| !c.is_whitespace()).collect();
-    let lower = compact.to_ascii_lowercase();
-    let (number, multiplier, has_unit) = if let Some(n) = lower.strip_suffix("mhz") {
-        (n, 1_000_000.0, true)
-    } else if let Some(n) = lower.strip_suffix("khz") {
-        (n, 1_000.0, true)
-    } else if let Some(n) = lower.strip_suffix("hz") {
-        (n, 1.0, true)
-    } else {
-        (lower.as_str(), 1.0, false)
-    };
-
-    let parsed = if has_unit {
-        let n = number.replace(',', "");
-        let hz = n.parse::<f64>().ok()? * multiplier;
-        if !hz.is_finite() || hz < i64::MIN as f64 || hz > i64::MAX as f64 {
-            return None;
-        }
-        hz.round() as i64
-    } else if let Some(parsed) = parse_display_prefix(number, spec) {
-        parsed
-    } else {
-        number.replace(['.', ',', '_'], "").parse::<i64>().ok()?
-    };
-
-    (spec.signed || parsed >= 0).then_some(parsed)
 }
 
 fn total_widget_width(
@@ -358,12 +229,6 @@ pub fn draw_digit_wheel_widget(
     let label_color = Color32::from_rgb(180, 180, 180);
     let sign_color = Color32::from_rgb(210, 210, 210);
 
-    const DIGIT_W: f32 = 13.0;
-    const DIGIT_H: f32 = 24.0;
-    const DIGIT_GAP: f32 = 1.0;
-    const SEP_W: f32 = 7.0;
-    const SIGN_W: f32 = 12.0;
-    const LABEL_GAP: f32 = 8.0;
     let label_w = match spec.label {
         "LO" => 18.0,
         "LO Offset" => 54.0,
@@ -408,55 +273,16 @@ pub fn draw_digit_wheel_widget(
             Pos2::new(top_left.x + label_w + LABEL_GAP, top_left.y),
             total_rect.right_bottom(),
         );
-        let mut layouter = |ui: &egui::Ui, text: &str, wrap_width: f32| {
-            layout_editor_text(ui, text, wrap_width, &font, active_color)
-        };
-        let response = ui.put(
+        let result = editor::draw(
+            ui,
+            editor_id,
             edit_rect,
-            egui::TextEdit::singleline(&mut state.draft)
-                .id(editor_id)
-                .font(font.clone())
-                .text_color(active_color)
-                .margin(egui::Margin::symmetric(2, 2))
-                .layouter(&mut layouter)
-                .desired_width(edit_rect.width()),
+            &mut state,
+            spec,
+            value,
+            &font,
+            active_color,
         );
-        if state.edit_error {
-            response
-                .clone()
-                .on_hover_text("Enter a frequency in Hz, or use an explicit kHz/MHz suffix");
-        }
-        if state.focus_editor {
-            response.request_focus();
-            let mut editor_state =
-                egui::TextEdit::load_state(ui.ctx(), editor_id).unwrap_or_default();
-            editor_state
-                .cursor
-                .set_char_range(Some(egui::text::CCursorRange::two(
-                    egui::text::CCursor::default(),
-                    egui::text::CCursor::new(state.draft.chars().count()),
-                )));
-            editor_state.store(ui.ctx(), editor_id);
-            state.focus_editor = false;
-        }
-
-        let escape = ui.input_mut(|i| i.consume_key(Modifiers::NONE, Key::Escape));
-        let enter = ui.input_mut(|i| i.consume_key(Modifiers::NONE, Key::Enter));
-        let mut result = None;
-        if escape {
-            state.editing = false;
-            state.edit_error = false;
-            response.surrender_focus();
-        } else if enter || response.lost_focus() {
-            if let Some(parsed) = parse_frequency(&state.draft, spec) {
-                state.editing = false;
-                state.edit_error = false;
-                result = (parsed != value).then_some(parsed);
-            } else {
-                state.edit_error = true;
-                state.focus_editor = true;
-            }
-        }
         ui.ctx().data_mut(|d| d.insert_temp(widget_id, state));
         return result;
     }
@@ -552,7 +378,7 @@ pub fn draw_digit_wheel_widget(
             state.editing = true;
             state.focus_editor = true;
             state.edit_error = false;
-            state.draft = format_editor_value(value, spec);
+            state.draft = editor::format_value(value, spec);
         }
 
         if enabled && response.hovered() {
@@ -604,6 +430,7 @@ pub fn draw_digit_wheel_widget(
     result
 }
 
+/// Draw the unsigned, left-anchored local-oscillator frequency control.
 pub fn draw_lo_widget(
     ui: &mut egui::Ui,
     id_salt: impl Hash,
@@ -622,6 +449,7 @@ pub fn draw_lo_widget(
         .map(|v| v.max(0) as u64)
 }
 
+/// Draw the signed, right-anchored local-oscillator offset control.
 pub fn draw_lo_offset_widget(
     ui: &mut egui::Ui,
     id_salt: impl Hash,
@@ -643,81 +471,11 @@ pub fn draw_lo_offset_widget(
 mod tests {
     use super::*;
 
-    fn lo_spec() -> DigitWheelSpec<'static> {
-        DigitWheelSpec {
-            label: "LO",
-            digit_count: 10,
-            signed: false,
-            groups: &[1, 3, 3, 3],
-            anchor: DigitWheelAnchor::Left,
-        }
-    }
-
-    fn offset_spec() -> DigitWheelSpec<'static> {
-        DigitWheelSpec {
-            label: "LO Offset",
-            digit_count: 6,
-            signed: true,
-            groups: &[3, 3],
-            anchor: DigitWheelAnchor::Right,
-        }
-    }
-
-    #[test]
-    fn parses_bare_grouped_hz() {
-        let spec = lo_spec();
-        assert_eq!(parse_frequency("14.074.000", &spec), Some(14_074_000));
-        assert_eq!(parse_frequency("145,500,000", &spec), Some(145_500_000));
-        assert_eq!(parse_frequency("98000123", &spec), Some(98_000_123));
-    }
-
-    #[test]
-    fn pads_incomplete_display_groups_with_trailing_zeroes() {
-        let spec = lo_spec();
-        assert_eq!(parse_frequency("0.098.000.", &spec), Some(98_000_000));
-        assert_eq!(parse_frequency("0.098.000", &spec), Some(98_000_000));
-        assert_eq!(parse_frequency("0.098.000.1", &spec), Some(98_000_100));
-        assert_eq!(parse_frequency("0.098.000.12", &spec), Some(98_000_120));
-    }
-
-    #[test]
-    fn parses_explicit_units() {
-        let spec = lo_spec();
-        assert_eq!(parse_frequency("14.074 MHz", &spec), Some(14_074_000));
-        assert_eq!(parse_frequency("14074 kHz", &spec), Some(14_074_000));
-        assert_eq!(parse_frequency("700 Hz", &spec), Some(700));
-    }
-
-    #[test]
-    fn signedness_is_enforced() {
-        assert_eq!(parse_frequency("-1500", &offset_spec()), Some(-1_500));
-        assert_eq!(parse_frequency("-1500", &lo_spec()), None);
-    }
-
     #[test]
     fn digit_places_match_display_positions() {
         assert_eq!(digit_step(10, 0), 1_000_000_000);
         assert_eq!(digit_step(10, 9), 1);
         assert_eq!(digit_step(6, 2), 1_000);
-    }
-
-    #[test]
-    fn editor_value_matches_the_grouped_digit_display() {
-        let lo = lo_spec();
-        let offset = offset_spec();
-
-        assert_eq!(format_editor_value(96_300_000, &lo), "0.096.300.000");
-        assert_eq!(format_editor_value(1_500, &offset), "+001.500");
-        assert_eq!(format_editor_value(-1_500, &offset), "-001.500");
-    }
-
-    #[test]
-    fn editor_spacing_matches_the_fixed_digit_cells() {
-        assert_eq!(editor_character_distance('1', '2'), Some(14.0));
-        assert_eq!(editor_character_distance('1', '.'), Some(11.0));
-        assert_eq!(editor_character_distance('.', '2'), Some(10.0));
-        assert_eq!(editor_character_distance('+', '2'), Some(13.5));
-        assert_eq!(editor_character_distance('M', 'H'), None);
     }
 
     #[test]

--- a/rigflow-client/src/widgets/lo_frequency_widget.rs
+++ b/rigflow-client/src/widgets/lo_frequency_widget.rs
@@ -4,6 +4,8 @@ use eframe::egui::{
     self, Align2, Color32, CursorIcon, FontId, Key, Modifiers, Pos2, Rect, Sense, Vec2,
 };
 
+const DRAG_POINTS_PER_STEP: f32 = 7.0;
+
 /// Controls how the digit widget is anchored relative to the provided origin.
 #[derive(Debug, Clone, Copy)]
 pub enum DigitWheelAnchor {
@@ -31,6 +33,7 @@ struct DigitCell {
 struct DragState {
     digit_index: usize,
     start_value: i64,
+    accumulated_points: f32,
 }
 
 #[derive(Debug, Clone)]
@@ -89,6 +92,21 @@ fn digit_step(digit_count: usize, digit_index: usize) -> i64 {
 fn adjusted_value(value: i64, delta: i64, signed: bool) -> i64 {
     let next = value.saturating_add(delta);
     if signed { next } else { next.max(0) }
+}
+
+fn dragged_value(
+    drag: &mut DragState,
+    frame_delta_y: f32,
+    digit_count: usize,
+    signed: bool,
+) -> i64 {
+    // `Response::drag_delta` is the movement in this frame, not the total
+    // displacement since the gesture started. Keep the total here so a still
+    // frame does not snap back to `start_value`, and retain sub-step movement.
+    drag.accumulated_points -= frame_delta_y;
+    let increments = (drag.accumulated_points / DRAG_POINTS_PER_STEP).trunc() as i64;
+    let delta = digit_step(digit_count, drag.digit_index).saturating_mul(increments);
+    adjusted_value(drag.start_value, delta, signed)
 }
 
 /// Parse an editor value. Bare values are Hz (grouping dots/commas are allowed);
@@ -220,8 +238,6 @@ pub fn draw_digit_wheel_widget(
     const SEP_W: f32 = 7.0;
     const SIGN_W: f32 = 12.0;
     const LABEL_GAP: f32 = 8.0;
-    const DRAG_POINTS_PER_STEP: f32 = 7.0;
-
     let label_w = match spec.label {
         "LO" => 18.0,
         "LO Offset" => 54.0,
@@ -365,14 +381,17 @@ pub fn draw_digit_wheel_widget(
             state.drag = Some(DragState {
                 digit_index: cell.digit_index,
                 start_value: value,
+                accumulated_points: 0.0,
             });
         }
         if enabled && response.dragged() {
-            if let Some(drag) = state.drag.filter(|d| d.digit_index == cell.digit_index) {
-                let increments = (-response.drag_delta().y / DRAG_POINTS_PER_STEP).trunc() as i64;
-                let delta =
-                    digit_step(spec.digit_count, drag.digit_index).saturating_mul(increments);
-                let next = adjusted_value(drag.start_value, delta, spec.signed);
+            if let Some(drag) = state
+                .drag
+                .as_mut()
+                .filter(|d| d.digit_index == cell.digit_index)
+            {
+                let next =
+                    dragged_value(drag, response.drag_delta().y, spec.digit_count, spec.signed);
                 result = (next != value).then_some(next);
             }
         }
@@ -498,5 +517,24 @@ mod tests {
         assert_eq!(digit_step(10, 0), 1_000_000_000);
         assert_eq!(digit_step(10, 9), 1);
         assert_eq!(digit_step(6, 2), 1_000);
+    }
+
+    #[test]
+    fn drag_accumulates_frame_deltas_without_snapping_back() {
+        let mut drag = DragState {
+            digit_index: 7,
+            start_value: 14_074_000,
+            accumulated_points: 0.0,
+        };
+
+        // Two sub-step upward movements combine into one 100 Hz step.
+        assert_eq!(dragged_value(&mut drag, -3.0, 10, false), 14_074_000);
+        assert_eq!(dragged_value(&mut drag, -4.0, 10, false), 14_074_100);
+
+        // A stationary frame retains the accumulated displacement and value.
+        assert_eq!(dragged_value(&mut drag, 0.0, 10, false), 14_074_100);
+
+        // Moving back to the gesture origin restores the original value.
+        assert_eq!(dragged_value(&mut drag, 7.0, 10, false), 14_074_000);
     }
 }

--- a/rigflow-client/src/widgets/lo_frequency_widget.rs
+++ b/rigflow-client/src/widgets/lo_frequency_widget.rs
@@ -418,6 +418,15 @@ pub fn draw_digit_wheel_widget(
         }
         if state.focus_editor {
             response.request_focus();
+            let mut editor_state =
+                egui::TextEdit::load_state(ui.ctx(), editor_id).unwrap_or_default();
+            editor_state
+                .cursor
+                .set_char_range(Some(egui::text::CCursorRange::two(
+                    egui::text::CCursor::default(),
+                    egui::text::CCursor::new(state.draft.chars().count()),
+                )));
+            editor_state.store(ui.ctx(), editor_id);
             state.focus_editor = false;
         }
 

--- a/rigflow-client/src/widgets/lo_frequency_widget.rs
+++ b/rigflow-client/src/widgets/lo_frequency_widget.rs
@@ -105,6 +105,58 @@ fn format_editor_value(value: i64, spec: &DigitWheelSpec<'_>) -> String {
     out
 }
 
+fn editor_character_distance(current: char, next: char) -> Option<f32> {
+    match (current, next) {
+        (c, n) if c.is_ascii_digit() && n.is_ascii_digit() => Some(14.0),
+        (c, '.') if c.is_ascii_digit() => Some(11.0),
+        ('.', n) if n.is_ascii_digit() => Some(10.0),
+        ('+' | '-', n) if n.is_ascii_digit() => Some(13.5),
+        _ => None,
+    }
+}
+
+fn layout_editor_text(
+    ui: &egui::Ui,
+    text: &str,
+    wrap_width: f32,
+    font: &FontId,
+    color: Color32,
+) -> std::sync::Arc<egui::Galley> {
+    let chars: Vec<char> = text.chars().collect();
+    let widths: Vec<f32> = ui.fonts(|fonts| {
+        chars
+            .iter()
+            .map(|character| fonts.glyph_width(font, *character))
+            .collect()
+    });
+    let mut job = egui::text::LayoutJob::default();
+    job.wrap.max_width = wrap_width;
+
+    for (index, character) in chars.iter().copied().enumerate() {
+        let format = egui::TextFormat {
+            font_id: font.clone(),
+            color,
+            ..Default::default()
+        };
+        let leading_space = if let Some(previous) = index.checked_sub(1)
+            && let Some(center_distance) = editor_character_distance(chars[previous], character)
+        {
+            // Match the fixed-cell painter by compensating for the actual glyph
+            // advances. This also remains correct if the chosen font's digits
+            // are not tabular.
+            center_distance - (widths[previous] + widths[index]) * 0.5
+        } else {
+            0.0
+        };
+        // Each character is a separate section so its gap can reflect the
+        // fixed digit/separator geometry. `extra_letter_spacing` would have no
+        // effect here because it only separates glyphs within one section.
+        job.append(&character.to_string(), leading_space, format);
+    }
+
+    ui.fonts(|fonts| fonts.layout_job(job))
+}
+
 fn first_nonzero_digit(digits: &[u8]) -> Option<usize> {
     digits.iter().position(|d| *d != b'0')
 }
@@ -305,6 +357,9 @@ pub fn draw_digit_wheel_widget(
             Pos2::new(top_left.x + label_w + LABEL_GAP, top_left.y),
             total_rect.right_bottom(),
         );
+        let mut layouter = |ui: &egui::Ui, text: &str, wrap_width: f32| {
+            layout_editor_text(ui, text, wrap_width, &font, active_color)
+        };
         let response = ui.put(
             edit_rect,
             egui::TextEdit::singleline(&mut state.draft)
@@ -312,6 +367,7 @@ pub fn draw_digit_wheel_widget(
                 .font(font.clone())
                 .text_color(active_color)
                 .margin(egui::Margin::symmetric(2, 2))
+                .layouter(&mut layouter)
                 .desired_width(edit_rect.width()),
         );
         if state.edit_error {
@@ -566,6 +622,15 @@ mod tests {
         assert_eq!(format_editor_value(96_300_000, &lo), "0.096.300.000");
         assert_eq!(format_editor_value(1_500, &offset), "+001.500");
         assert_eq!(format_editor_value(-1_500, &offset), "-001.500");
+    }
+
+    #[test]
+    fn editor_spacing_matches_the_fixed_digit_cells() {
+        assert_eq!(editor_character_distance('1', '2'), Some(14.0));
+        assert_eq!(editor_character_distance('1', '.'), Some(11.0));
+        assert_eq!(editor_character_distance('.', '2'), Some(10.0));
+        assert_eq!(editor_character_distance('+', '2'), Some(13.5));
+        assert_eq!(editor_character_distance('M', 'H'), None);
     }
 
     #[test]

--- a/rigflow-client/src/widgets/lo_frequency_widget.rs
+++ b/rigflow-client/src/widgets/lo_frequency_widget.rs
@@ -188,6 +188,14 @@ fn dragged_value(
     adjusted_value(drag.start_value, delta, signed)
 }
 
+fn set_drag_cursor(ctx: &egui::Context, grabbed: bool) {
+    ctx.send_viewport_cmd(egui::ViewportCommand::CursorGrab(if grabbed {
+        egui::viewport::CursorGrab::Locked
+    } else {
+        egui::viewport::CursorGrab::None
+    }));
+}
+
 fn parse_display_prefix(number: &str, spec: &DigitWheelSpec<'_>) -> Option<i64> {
     let (sign, unsigned) = if let Some(unsigned) = number.strip_prefix('-') {
         if !spec.signed {
@@ -377,7 +385,9 @@ pub fn draw_digit_wheel_widget(
         .unwrap_or_default();
     if !enabled {
         state.editing = false;
-        state.drag = None;
+        if state.drag.take().is_some() {
+            set_drag_cursor(ui.ctx(), false);
+        }
     }
 
     let painter = ui.painter();
@@ -516,20 +526,27 @@ pub fn draw_digit_wheel_widget(
                 start_value: value,
                 accumulated_points: 0.0,
             });
+            set_drag_cursor(ui.ctx(), true);
         }
         if enabled && response.dragged() {
+            ui.ctx().set_cursor_icon(CursorIcon::None);
             if let Some(drag) = state
                 .drag
                 .as_mut()
                 .filter(|d| d.digit_index == cell.digit_index)
             {
-                let next =
-                    dragged_value(drag, response.drag_delta().y, spec.digit_count, spec.signed);
+                let next = dragged_value(
+                    drag,
+                    response.drag_motion().y,
+                    spec.digit_count,
+                    spec.signed,
+                );
                 result = (next != value).then_some(next);
             }
         }
         if response.drag_stopped() {
             state.drag = None;
+            set_drag_cursor(ui.ctx(), false);
         }
         if enabled && response.clicked() {
             state.editing = true;

--- a/rigflow-client/src/widgets/lo_frequency_widget.rs
+++ b/rigflow-client/src/widgets/lo_frequency_widget.rs
@@ -505,7 +505,7 @@ pub fn draw_digit_wheel_widget(
                     Sense::hover()
                 },
             )
-            .on_hover_text("Scroll, drag vertically, or use ↑/↓; click to type a value");
+            .on_hover_text("Scroll or drag vertically; press Up/Down; click to type a value");
         if enabled && response.hovered() {
             hovered_digit = Some(cell.digit_index);
             ui.ctx().set_cursor_icon(CursorIcon::ResizeVertical);

--- a/rigflow-client/src/widgets/lo_frequency_widget.rs
+++ b/rigflow-client/src/widgets/lo_frequency_widget.rs
@@ -1,4 +1,8 @@
-use eframe::egui::{self, Align2, Color32, FontId, Pos2, Rect, Sense, Vec2};
+use std::hash::Hash;
+
+use eframe::egui::{
+    self, Align2, Color32, CursorIcon, FontId, Key, Modifiers, Pos2, Rect, Sense, Vec2,
+};
 
 /// Controls how the digit widget is anchored relative to the provided origin.
 #[derive(Debug, Clone, Copy)]
@@ -8,40 +12,58 @@ pub enum DigitWheelAnchor {
 }
 
 /// Specification for a digit-wheel widget.
-///
-/// This allows the same rendering logic to be reused for:
-/// - LO frequency (unsigned, large number)
-/// - LO offset (signed, smaller number)
 #[derive(Debug, Clone)]
 pub struct DigitWheelSpec<'a> {
     pub label: &'a str,
-
-    /// Total number of digits rendered (zero-padded)
     pub digit_count: usize,
-
-    /// Whether the value is signed (+ / -)
     pub signed: bool,
-
-    /// Digit grouping for visual separators (e.g. MHz formatting)
-    /// Example: &[1,3,3,3] → 1.234.567.890
     pub groups: &'a [usize],
-
-    /// Anchor direction (left or right aligned)
     pub anchor: DigitWheelAnchor,
 }
 
-/// A single digit cell on screen.
 #[derive(Debug, Clone, Copy)]
 struct DigitCell {
     rect: Rect,
-
-    /// Index in the digit string (0 = most significant)
     digit_index: usize,
 }
 
-/// Compute 10^exp as u64.
-///
-/// Used to determine step size for digit increments.
+#[derive(Debug, Clone, Copy)]
+struct DragState {
+    digit_index: usize,
+    start_value: i64,
+}
+
+#[derive(Debug, Clone)]
+struct DigitWheelState {
+    editing: bool,
+    focus_editor: bool,
+    draft: String,
+    edit_error: bool,
+    drag: Option<DragState>,
+    point_wheel_accumulator: f32,
+    point_wheel_direction: i8,
+    point_wheel_digit: Option<usize>,
+    last_point_wheel_at: f64,
+    last_point_step_at: f64,
+}
+
+impl Default for DigitWheelState {
+    fn default() -> Self {
+        Self {
+            editing: false,
+            focus_editor: false,
+            draft: String::new(),
+            edit_error: false,
+            drag: None,
+            point_wheel_accumulator: 0.0,
+            point_wheel_direction: 0,
+            point_wheel_digit: None,
+            last_point_wheel_at: f64::NEG_INFINITY,
+            last_point_step_at: f64::NEG_INFINITY,
+        }
+    }
+}
+
 fn pow10_u64(exp: usize) -> u64 {
     let mut v = 1u64;
     for _ in 0..exp {
@@ -50,28 +72,54 @@ fn pow10_u64(exp: usize) -> u64 {
     v
 }
 
-/// Format value into fixed-width zero-padded digit array.
 fn format_abs_digits(value: u64, digit_count: usize) -> Vec<u8> {
     let s = format!("{value:0width$}", width = digit_count);
     s.into_bytes()
 }
 
-/// Find first non-zero digit (for dimming leading zeros).
 fn first_nonzero_digit(digits: &[u8]) -> Option<usize> {
     digits.iter().position(|d| *d != b'0')
 }
 
-/// Compute step size for a given digit.
-///
-/// Example:
-/// - digit 0 (MSD) → 10^9
-/// - last digit → 1
 fn digit_step(digit_count: usize, digit_index: usize) -> i64 {
     let place_from_right = digit_count - 1 - digit_index;
     pow10_u64(place_from_right) as i64
 }
 
-/// Compute total widget width (used for anchoring and layout).
+fn adjusted_value(value: i64, delta: i64, signed: bool) -> i64 {
+    let next = value.saturating_add(delta);
+    if signed { next } else { next.max(0) }
+}
+
+/// Parse an editor value. Bare values are Hz (grouping dots/commas are allowed);
+/// an explicit Hz/kHz/MHz suffix enables decimal unit input.
+fn parse_frequency(text: &str, signed: bool) -> Option<i64> {
+    let compact: String = text.chars().filter(|c| !c.is_whitespace()).collect();
+    let lower = compact.to_ascii_lowercase();
+    let (number, multiplier, has_unit) = if let Some(n) = lower.strip_suffix("mhz") {
+        (n, 1_000_000.0, true)
+    } else if let Some(n) = lower.strip_suffix("khz") {
+        (n, 1_000.0, true)
+    } else if let Some(n) = lower.strip_suffix("hz") {
+        (n, 1.0, true)
+    } else {
+        (lower.as_str(), 1.0, false)
+    };
+
+    let parsed = if has_unit {
+        let n = number.replace(',', "");
+        let hz = n.parse::<f64>().ok()? * multiplier;
+        if !hz.is_finite() || hz < i64::MIN as f64 || hz > i64::MAX as f64 {
+            return None;
+        }
+        hz.round() as i64
+    } else {
+        number.replace(['.', ',', '_'], "").parse::<i64>().ok()?
+    };
+
+    (signed || parsed >= 0).then_some(parsed)
+}
+
 fn total_widget_width(
     label_w: f32,
     label_gap: f32,
@@ -84,208 +132,312 @@ fn total_widget_width(
     let digit_area = digit_w * spec.digit_count as f32
         + digit_gap * (spec.digit_count.saturating_sub(1)) as f32
         + sep_w * spec.groups.len().saturating_sub(1) as f32;
-
     let sign_area = if spec.signed { sign_w + digit_gap } else { 0.0 };
-
     label_w + label_gap + sign_area + digit_area
 }
 
-/// Draw a reusable digit-wheel widget.
+/// Normalize wheel input into one digit step.
 ///
-/// Behavior:
-/// - Each digit is individually scrollable via mouse wheel
-/// - Step size depends on digit position
-/// - Leading zeros are dimmed for readability
-///
-/// Returns:
-/// - `Some(new_value)` if a digit was changed
-/// - `None` if no interaction occurred
+/// A traditional wheel reports line events, whose magnitude is ignored. Windows
+/// precision wheels and touchpads report a stream of point events; those are
+/// accumulated to a small threshold and rate-limited so one gesture cannot tune
+/// once per rendered frame.
+fn wheel_direction(ui: &egui::Ui, state: &mut DigitWheelState, digit_index: usize) -> i64 {
+    const POINTS_PER_STEP: f32 = 32.0;
+    const POINT_STEP_INTERVAL: f64 = 0.075;
+    const GESTURE_GAP: f64 = 0.18;
+
+    let now = ui.input(|i| i.time);
+    let (line_y, point_y) = ui.input(|i| {
+        let mut line_y = 0.0;
+        let mut point_y = 0.0;
+        for event in &i.events {
+            if let egui::Event::MouseWheel { unit, delta, .. } = event {
+                match unit {
+                    egui::MouseWheelUnit::Point => point_y += delta.y,
+                    egui::MouseWheelUnit::Line | egui::MouseWheelUnit::Page => line_y += delta.y,
+                }
+            }
+        }
+        (line_y, point_y)
+    });
+
+    if line_y != 0.0 {
+        return line_y.signum() as i64;
+    }
+    if point_y == 0.0 {
+        return 0;
+    }
+
+    let direction = point_y.signum() as i8;
+    if now - state.last_point_wheel_at > GESTURE_GAP
+        || state.point_wheel_direction != direction
+        || state.point_wheel_digit != Some(digit_index)
+    {
+        state.point_wheel_accumulator = 0.0;
+    }
+    state.point_wheel_direction = direction;
+    state.point_wheel_digit = Some(digit_index);
+    state.last_point_wheel_at = now;
+    // Do not queue a long tail of future steps after one large precision-wheel
+    // event. At most one additional threshold is carried into the next event.
+    state.point_wheel_accumulator = (state.point_wheel_accumulator + point_y)
+        .clamp(-POINTS_PER_STEP * 2.0, POINTS_PER_STEP * 2.0);
+
+    if state.point_wheel_accumulator.abs() >= POINTS_PER_STEP
+        && now - state.last_point_step_at >= POINT_STEP_INTERVAL
+    {
+        state.point_wheel_accumulator -= direction as f32 * POINTS_PER_STEP;
+        state.last_point_step_at = now;
+        direction as i64
+    } else {
+        0
+    }
+}
+
+/// Draw a reusable digit wheel with per-digit wheel, drag and arrow adjustment.
+/// Clicking without dragging replaces the digits with a whole-value text editor.
 pub fn draw_digit_wheel_widget(
     ui: &mut egui::Ui,
+    id_salt: impl Hash,
     origin: Pos2,
     spec: &DigitWheelSpec<'_>,
     value: i64,
     enabled: bool,
 ) -> Option<i64> {
-    // --- Styling ----------------------------------------------------------
-
     let font = FontId::proportional(17.0);
     let label_font = FontId::proportional(12.0);
-
     let active_color = Color32::from_rgb(235, 235, 235);
     let inactive_color = Color32::from_rgb(90, 90, 90);
     let hover_bg = Color32::from_rgba_premultiplied(120, 120, 120, 40);
+    let error_color = Color32::from_rgb(240, 90, 90);
     let label_color = Color32::from_rgb(180, 180, 180);
     let sign_color = Color32::from_rgb(210, 210, 210);
 
-    // --- Layout constants -------------------------------------------------
+    const DIGIT_W: f32 = 13.0;
+    const DIGIT_H: f32 = 24.0;
+    const DIGIT_GAP: f32 = 1.0;
+    const SEP_W: f32 = 7.0;
+    const SIGN_W: f32 = 12.0;
+    const LABEL_GAP: f32 = 8.0;
+    const DRAG_POINTS_PER_STEP: f32 = 7.0;
 
-    let digit_w = 13.0;
-    let digit_h = 24.0;
-    let digit_gap = 1.0;
-    let sep_w = 7.0;
-    let sign_w = 12.0;
-    let label_gap = 8.0;
-
-    // Label width is fixed per label for alignment consistency
     let label_w = match spec.label {
         "LO" => 18.0,
         "LO Offset" => 54.0,
         _ => 46.0,
     };
-
-    let widget_w = total_widget_width(label_w, label_gap, digit_w, digit_gap, sep_w, sign_w, spec);
-
-    let widget_h = digit_h;
-
-    // Anchor determines left or right alignment
+    let widget_w = total_widget_width(label_w, LABEL_GAP, DIGIT_W, DIGIT_GAP, SEP_W, SIGN_W, spec);
     let top_left = match spec.anchor {
         DigitWheelAnchor::Left => origin,
         DigitWheelAnchor::Right => Pos2::new(origin.x - widget_w, origin.y),
     };
+    let total_rect = Rect::from_min_size(top_left, Vec2::new(widget_w, DIGIT_H));
+    ui.allocate_rect(total_rect, Sense::hover());
 
-    let total_rect = Rect::from_min_size(top_left, Vec2::new(widget_w, widget_h));
-    let response = ui.allocate_rect(total_rect, Sense::hover());
+    let widget_id = ui.make_persistent_id(("digit_wheel", id_salt));
+    let editor_id = widget_id.with("editor");
+    let mut state = ui
+        .ctx()
+        .data_mut(|d| d.get_temp::<DigitWheelState>(widget_id))
+        .unwrap_or_default();
+    if !enabled {
+        state.editing = false;
+        state.drag = None;
+    }
+
     let painter = ui.painter();
-
-    // --- Value → digit conversion ----------------------------------------
-
-    let abs_value = value.unsigned_abs();
-    let digits = format_abs_digits(abs_value, spec.digit_count);
-
-    // Used to dim leading zeros
-    let first_nonzero = first_nonzero_digit(&digits).unwrap_or(spec.digit_count - 1);
-
-    // --- Draw label -------------------------------------------------------
-
     painter.text(
-        Pos2::new(top_left.x, top_left.y + digit_h * 0.5),
+        Pos2::new(top_left.x, top_left.y + DIGIT_H * 0.5),
         Align2::LEFT_CENTER,
         spec.label,
         label_font,
-        label_color,
+        if state.edit_error {
+            error_color
+        } else {
+            label_color
+        },
     );
 
-    let mut x = top_left.x + label_w + label_gap;
+    if state.editing && enabled {
+        let edit_rect = Rect::from_min_max(
+            Pos2::new(top_left.x + label_w + LABEL_GAP, top_left.y),
+            total_rect.right_bottom(),
+        );
+        let response = ui.put(
+            edit_rect,
+            egui::TextEdit::singleline(&mut state.draft)
+                .id(editor_id)
+                .font(font)
+                .desired_width(edit_rect.width()),
+        );
+        if state.edit_error {
+            response
+                .clone()
+                .on_hover_text("Enter a frequency in Hz, or use an explicit kHz/MHz suffix");
+        }
+        if state.focus_editor {
+            response.request_focus();
+            state.focus_editor = false;
+        }
 
-    // --- Draw sign (if applicable) ---------------------------------------
+        let escape = ui.input_mut(|i| i.consume_key(Modifiers::NONE, Key::Escape));
+        let enter = ui.input_mut(|i| i.consume_key(Modifiers::NONE, Key::Enter));
+        let mut result = None;
+        if escape {
+            state.editing = false;
+            state.edit_error = false;
+            response.surrender_focus();
+        } else if enter || response.lost_focus() {
+            if let Some(parsed) = parse_frequency(&state.draft, spec.signed) {
+                state.editing = false;
+                state.edit_error = false;
+                result = (parsed != value).then_some(parsed);
+            } else {
+                state.edit_error = true;
+                state.focus_editor = true;
+            }
+        }
+        ui.ctx().data_mut(|d| d.insert_temp(widget_id, state));
+        return result;
+    }
 
+    let digits = format_abs_digits(value.unsigned_abs(), spec.digit_count);
+    let first_nonzero = first_nonzero_digit(&digits).unwrap_or(spec.digit_count - 1);
+    let mut x = top_left.x + label_w + LABEL_GAP;
     if spec.signed {
-        let sign_text = if value < 0 { "-" } else { "+" };
-
         painter.text(
-            Pos2::new(x + sign_w * 0.5, top_left.y + digit_h * 0.5),
+            Pos2::new(x + SIGN_W * 0.5, top_left.y + DIGIT_H * 0.5),
             Align2::CENTER_CENTER,
-            sign_text,
+            if value < 0 { "-" } else { "+" },
             font.clone(),
             sign_color,
         );
-
-        x += sign_w + digit_gap;
+        x += SIGN_W + DIGIT_GAP;
     }
-
-    // --- Layout digit cells ----------------------------------------------
 
     let mut digit_cells = Vec::with_capacity(spec.digit_count);
     let mut digit_i = 0;
-
     for (group_idx, group_len) in spec.groups.iter().enumerate() {
         for _ in 0..*group_len {
-            let rect = Rect::from_min_size(Pos2::new(x, top_left.y), Vec2::new(digit_w, digit_h));
-
+            let rect = Rect::from_min_size(Pos2::new(x, top_left.y), Vec2::new(DIGIT_W, DIGIT_H));
             digit_cells.push(DigitCell {
                 rect,
                 digit_index: digit_i,
             });
-
-            x += digit_w;
-
+            x += DIGIT_W;
             if digit_i < spec.digit_count - 1 {
-                x += digit_gap;
+                x += DIGIT_GAP;
             }
-
             digit_i += 1;
         }
-
-        // Draw group separator (".")
         if group_idx < spec.groups.len() - 1 {
             painter.text(
-                Pos2::new(x + sep_w * 0.5, top_left.y + digit_h * 0.52),
+                Pos2::new(x + SEP_W * 0.5, top_left.y + DIGIT_H * 0.52),
                 Align2::CENTER_CENTER,
                 ".",
                 font.clone(),
                 active_color,
             );
-            x += sep_w;
+            x += SEP_W;
         }
     }
 
-    // --- Hover detection --------------------------------------------------
-
-    // When disabled (dial lock), suppress hover + scroll so the digits are inert
-    // but still drawn at full brightness (the frequency stays readable).
-    let hovered_digit = if enabled {
-        response.hover_pos().and_then(|pos| {
-            digit_cells
-                .iter()
-                .find(|c| c.rect.contains(pos))
-                .map(|c| c.digit_index)
-        })
-    } else {
-        None
-    };
-
-    // --- Draw digits ------------------------------------------------------
-
+    let mut result = None;
+    let mut hovered_digit = None;
     for cell in &digit_cells {
-        if hovered_digit == Some(cell.digit_index) {
-            painter.rect_filled(cell.rect, 3.0, hover_bg);
+        let response = ui
+            .interact(
+                cell.rect,
+                widget_id.with(cell.digit_index),
+                if enabled {
+                    Sense::click_and_drag()
+                } else {
+                    Sense::hover()
+                },
+            )
+            .on_hover_text("Scroll, drag vertically, or use ↑/↓; click to type a value");
+        if enabled && response.hovered() {
+            hovered_digit = Some(cell.digit_index);
+            ui.ctx().set_cursor_icon(CursorIcon::ResizeVertical);
+        }
+        if enabled && response.drag_started() {
+            state.drag = Some(DragState {
+                digit_index: cell.digit_index,
+                start_value: value,
+            });
+        }
+        if enabled && response.dragged() {
+            if let Some(drag) = state.drag.filter(|d| d.digit_index == cell.digit_index) {
+                let increments = (-response.drag_delta().y / DRAG_POINTS_PER_STEP).trunc() as i64;
+                let delta =
+                    digit_step(spec.digit_count, drag.digit_index).saturating_mul(increments);
+                let next = adjusted_value(drag.start_value, delta, spec.signed);
+                result = (next != value).then_some(next);
+            }
+        }
+        if response.drag_stopped() {
+            state.drag = None;
+        }
+        if enabled && response.clicked() {
+            state.editing = true;
+            state.focus_editor = true;
+            state.edit_error = false;
+            state.draft = value.to_string();
         }
 
-        let d = digits[cell.digit_index] as char;
-
+        if enabled && response.hovered() {
+            painter.rect_filled(cell.rect, 3.0, hover_bg);
+        }
         let color = if cell.digit_index < first_nonzero {
-            inactive_color // leading zeros dimmed
+            inactive_color
         } else {
             active_color
         };
-
         painter.text(
             cell.rect.center(),
             Align2::CENTER_CENTER,
-            d,
+            digits[cell.digit_index] as char,
             font.clone(),
             color,
         );
     }
 
-    // --- Mouse wheel interaction -----------------------------------------
-
     if let Some(idx) = hovered_digit {
-        let scroll_y = ui.ctx().input(|i| i.raw_scroll_delta.y);
-
-        if scroll_y.abs() > 0.0 {
-            let step = digit_step(spec.digit_count, idx);
-
-            // Scroll up = increase, matching spectrum/waterfall fine tuning.
-            let delta = if scroll_y > 0.0 { step } else { -step };
-
-            let next = if spec.signed {
-                value.saturating_add(delta)
-            } else {
-                value.saturating_add(delta).max(0)
-            };
-
-            return Some(next);
+        let wheel_dir = wheel_direction(ui, &mut state, idx);
+        if wheel_dir != 0 {
+            let delta = digit_step(spec.digit_count, idx).saturating_mul(wheel_dir);
+            let next = adjusted_value(value, delta, spec.signed);
+            result = (next != value).then_some(next);
         }
+
+        let (up, down) = ui.input_mut(|i| {
+            (
+                i.count_and_consume_key(Modifiers::NONE, Key::ArrowUp),
+                i.count_and_consume_key(Modifiers::NONE, Key::ArrowDown),
+            )
+        });
+        let key_steps = up as i64 - down as i64;
+        if key_steps != 0 {
+            let delta = digit_step(spec.digit_count, idx).saturating_mul(key_steps);
+            let next = adjusted_value(value, delta, spec.signed);
+            result = (next != value).then_some(next);
+        }
+
+        // Prevent this wheel gesture from leaking to another control in the same UI.
+        ui.ctx().input_mut(|i| {
+            i.raw_scroll_delta = Vec2::ZERO;
+            i.smooth_scroll_delta = Vec2::ZERO;
+        });
     }
 
-    None
+    ui.ctx().data_mut(|d| d.insert_temp(widget_id, state));
+    result
 }
 
-/// LO frequency widget (center frequency).
 pub fn draw_lo_widget(
     ui: &mut egui::Ui,
+    id_salt: impl Hash,
     top_left: Pos2,
     center_freq_hz: u64,
     enabled: bool,
@@ -297,14 +449,13 @@ pub fn draw_lo_widget(
         groups: &[1, 3, 3, 3],
         anchor: DigitWheelAnchor::Left,
     };
-
-    draw_digit_wheel_widget(ui, top_left, &spec, center_freq_hz as i64, enabled)
+    draw_digit_wheel_widget(ui, id_salt, top_left, &spec, center_freq_hz as i64, enabled)
         .map(|v| v.max(0) as u64)
 }
 
-/// LO offset widget (relative tuning offset).
 pub fn draw_lo_offset_widget(
     ui: &mut egui::Ui,
+    id_salt: impl Hash,
     top_right: Pos2,
     offset_hz: i64,
     enabled: bool,
@@ -316,6 +467,36 @@ pub fn draw_lo_offset_widget(
         groups: &[3, 3],
         anchor: DigitWheelAnchor::Right,
     };
+    draw_digit_wheel_widget(ui, id_salt, top_right, &spec, offset_hz, enabled)
+}
 
-    draw_digit_wheel_widget(ui, top_right, &spec, offset_hz, enabled)
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_bare_grouped_hz() {
+        assert_eq!(parse_frequency("14.074.000", false), Some(14_074_000));
+        assert_eq!(parse_frequency("145,500,000", false), Some(145_500_000));
+    }
+
+    #[test]
+    fn parses_explicit_units() {
+        assert_eq!(parse_frequency("14.074 MHz", false), Some(14_074_000));
+        assert_eq!(parse_frequency("14074 kHz", false), Some(14_074_000));
+        assert_eq!(parse_frequency("700 Hz", false), Some(700));
+    }
+
+    #[test]
+    fn signedness_is_enforced() {
+        assert_eq!(parse_frequency("-1500", true), Some(-1_500));
+        assert_eq!(parse_frequency("-1500", false), None);
+    }
+
+    #[test]
+    fn digit_places_match_display_positions() {
+        assert_eq!(digit_step(10, 0), 1_000_000_000);
+        assert_eq!(digit_step(10, 9), 1);
+        assert_eq!(digit_step(6, 2), 1_000);
+    }
 }

--- a/rigflow-client/src/widgets/lo_frequency_widget.rs
+++ b/rigflow-client/src/widgets/lo_frequency_widget.rs
@@ -80,6 +80,31 @@ fn format_abs_digits(value: u64, digit_count: usize) -> Vec<u8> {
     s.into_bytes()
 }
 
+fn format_editor_value(value: i64, spec: &DigitWheelSpec<'_>) -> String {
+    let digits = format!("{:0width$}", value.unsigned_abs(), width = spec.digit_count);
+    let grouped_width: usize = spec.groups.iter().sum();
+    debug_assert_eq!(grouped_width, spec.digit_count);
+
+    let mut out = String::with_capacity(digits.len() + spec.groups.len());
+    if spec.signed {
+        out.push(if value < 0 { '-' } else { '+' });
+    }
+
+    // If a caller supplies a value wider than the nominal digit count, retain
+    // the extra leading digits in the first group rather than truncating them.
+    let mut offset = 0;
+    let overflow = digits.len().saturating_sub(grouped_width);
+    for (group_index, group_width) in spec.groups.iter().copied().enumerate() {
+        if group_index != 0 {
+            out.push('.');
+        }
+        let width = group_width + usize::from(group_index == 0) * overflow;
+        out.push_str(&digits[offset..offset + width]);
+        offset += width;
+    }
+    out
+}
+
 fn first_nonzero_digit(digits: &[u8]) -> Option<usize> {
     digits.iter().position(|d| *d != b'0')
 }
@@ -284,7 +309,9 @@ pub fn draw_digit_wheel_widget(
             edit_rect,
             egui::TextEdit::singleline(&mut state.draft)
                 .id(editor_id)
-                .font(font)
+                .font(font.clone())
+                .text_color(active_color)
+                .margin(egui::Margin::symmetric(2, 2))
                 .desired_width(edit_rect.width()),
         );
         if state.edit_error {
@@ -402,7 +429,7 @@ pub fn draw_digit_wheel_widget(
             state.editing = true;
             state.focus_editor = true;
             state.edit_error = false;
-            state.draft = value.to_string();
+            state.draft = format_editor_value(value, spec);
         }
 
         if enabled && response.hovered() {
@@ -517,6 +544,28 @@ mod tests {
         assert_eq!(digit_step(10, 0), 1_000_000_000);
         assert_eq!(digit_step(10, 9), 1);
         assert_eq!(digit_step(6, 2), 1_000);
+    }
+
+    #[test]
+    fn editor_value_matches_the_grouped_digit_display() {
+        let lo = DigitWheelSpec {
+            label: "LO",
+            digit_count: 10,
+            signed: false,
+            groups: &[1, 3, 3, 3],
+            anchor: DigitWheelAnchor::Left,
+        };
+        let offset = DigitWheelSpec {
+            label: "LO Offset",
+            digit_count: 6,
+            signed: true,
+            groups: &[3, 3],
+            anchor: DigitWheelAnchor::Right,
+        };
+
+        assert_eq!(format_editor_value(96_300_000, &lo), "0.096.300.000");
+        assert_eq!(format_editor_value(1_500, &offset), "+001.500");
+        assert_eq!(format_editor_value(-1_500, &offset), "-001.500");
     }
 
     #[test]

--- a/rigflow-client/src/widgets/lo_frequency_widget.rs
+++ b/rigflow-client/src/widgets/lo_frequency_widget.rs
@@ -186,9 +186,46 @@ fn dragged_value(
     adjusted_value(drag.start_value, delta, signed)
 }
 
+fn parse_display_prefix(number: &str, spec: &DigitWheelSpec<'_>) -> Option<i64> {
+    let (sign, unsigned) = if let Some(unsigned) = number.strip_prefix('-') {
+        if !spec.signed {
+            return None;
+        }
+        ("-", unsigned)
+    } else if let Some(unsigned) = number.strip_prefix('+') {
+        ("+", unsigned)
+    } else {
+        ("", number)
+    };
+
+    // Without a display separator, bare input retains its documented literal-Hz
+    // meaning. A dotted value matching the widget's leading groups is instead
+    // treated as a possibly incomplete copy of the displayed value.
+    if !unsigned.contains('.') {
+        return None;
+    }
+    let entered_groups: Vec<&str> = unsigned.split('.').collect();
+    if entered_groups.len() > spec.groups.len() {
+        return None;
+    }
+
+    let mut digits = String::with_capacity(spec.digit_count);
+    for (index, width) in spec.groups.iter().copied().enumerate() {
+        let entered = entered_groups.get(index).copied().unwrap_or("");
+        if entered.len() > width || !entered.chars().all(|c| c.is_ascii_digit()) {
+            return None;
+        }
+        digits.push_str(entered);
+        digits.extend(std::iter::repeat_n('0', width - entered.len()));
+    }
+
+    format!("{sign}{digits}").parse().ok()
+}
+
 /// Parse an editor value. Bare values are Hz (grouping dots/commas are allowed);
-/// an explicit Hz/kHz/MHz suffix enables decimal unit input.
-fn parse_frequency(text: &str, signed: bool) -> Option<i64> {
+/// a left-to-right prefix of the dotted widget display is padded with trailing
+/// zeroes, and an explicit Hz/kHz/MHz suffix enables decimal unit input.
+fn parse_frequency(text: &str, spec: &DigitWheelSpec<'_>) -> Option<i64> {
     let compact: String = text.chars().filter(|c| !c.is_whitespace()).collect();
     let lower = compact.to_ascii_lowercase();
     let (number, multiplier, has_unit) = if let Some(n) = lower.strip_suffix("mhz") {
@@ -208,11 +245,13 @@ fn parse_frequency(text: &str, signed: bool) -> Option<i64> {
             return None;
         }
         hz.round() as i64
+    } else if let Some(parsed) = parse_display_prefix(number, spec) {
+        parsed
     } else {
         number.replace(['.', ',', '_'], "").parse::<i64>().ok()?
     };
 
-    (signed || parsed >= 0).then_some(parsed)
+    (spec.signed || parsed >= 0).then_some(parsed)
 }
 
 fn total_widget_width(
@@ -388,7 +427,7 @@ pub fn draw_digit_wheel_widget(
             state.edit_error = false;
             response.surrender_focus();
         } else if enter || response.lost_focus() {
-            if let Some(parsed) = parse_frequency(&state.draft, spec.signed) {
+            if let Some(parsed) = parse_frequency(&state.draft, spec) {
                 state.editing = false;
                 state.edit_error = false;
                 result = (parsed != value).then_some(parsed);
@@ -576,23 +615,55 @@ pub fn draw_lo_offset_widget(
 mod tests {
     use super::*;
 
+    fn lo_spec() -> DigitWheelSpec<'static> {
+        DigitWheelSpec {
+            label: "LO",
+            digit_count: 10,
+            signed: false,
+            groups: &[1, 3, 3, 3],
+            anchor: DigitWheelAnchor::Left,
+        }
+    }
+
+    fn offset_spec() -> DigitWheelSpec<'static> {
+        DigitWheelSpec {
+            label: "LO Offset",
+            digit_count: 6,
+            signed: true,
+            groups: &[3, 3],
+            anchor: DigitWheelAnchor::Right,
+        }
+    }
+
     #[test]
     fn parses_bare_grouped_hz() {
-        assert_eq!(parse_frequency("14.074.000", false), Some(14_074_000));
-        assert_eq!(parse_frequency("145,500,000", false), Some(145_500_000));
+        let spec = lo_spec();
+        assert_eq!(parse_frequency("14.074.000", &spec), Some(14_074_000));
+        assert_eq!(parse_frequency("145,500,000", &spec), Some(145_500_000));
+        assert_eq!(parse_frequency("98000123", &spec), Some(98_000_123));
+    }
+
+    #[test]
+    fn pads_incomplete_display_groups_with_trailing_zeroes() {
+        let spec = lo_spec();
+        assert_eq!(parse_frequency("0.098.000.", &spec), Some(98_000_000));
+        assert_eq!(parse_frequency("0.098.000", &spec), Some(98_000_000));
+        assert_eq!(parse_frequency("0.098.000.1", &spec), Some(98_000_100));
+        assert_eq!(parse_frequency("0.098.000.12", &spec), Some(98_000_120));
     }
 
     #[test]
     fn parses_explicit_units() {
-        assert_eq!(parse_frequency("14.074 MHz", false), Some(14_074_000));
-        assert_eq!(parse_frequency("14074 kHz", false), Some(14_074_000));
-        assert_eq!(parse_frequency("700 Hz", false), Some(700));
+        let spec = lo_spec();
+        assert_eq!(parse_frequency("14.074 MHz", &spec), Some(14_074_000));
+        assert_eq!(parse_frequency("14074 kHz", &spec), Some(14_074_000));
+        assert_eq!(parse_frequency("700 Hz", &spec), Some(700));
     }
 
     #[test]
     fn signedness_is_enforced() {
-        assert_eq!(parse_frequency("-1500", true), Some(-1_500));
-        assert_eq!(parse_frequency("-1500", false), None);
+        assert_eq!(parse_frequency("-1500", &offset_spec()), Some(-1_500));
+        assert_eq!(parse_frequency("-1500", &lo_spec()), None);
     }
 
     #[test]
@@ -604,20 +675,8 @@ mod tests {
 
     #[test]
     fn editor_value_matches_the_grouped_digit_display() {
-        let lo = DigitWheelSpec {
-            label: "LO",
-            digit_count: 10,
-            signed: false,
-            groups: &[1, 3, 3, 3],
-            anchor: DigitWheelAnchor::Left,
-        };
-        let offset = DigitWheelSpec {
-            label: "LO Offset",
-            digit_count: 6,
-            signed: true,
-            groups: &[3, 3],
-            anchor: DigitWheelAnchor::Right,
-        };
+        let lo = lo_spec();
+        let offset = offset_spec();
 
         assert_eq!(format_editor_value(96_300_000, &lo), "0.096.300.000");
         assert_eq!(format_editor_value(1_500, &offset), "+001.500");

--- a/rigflow-client/src/widgets/lo_frequency_widget/editor.rs
+++ b/rigflow-client/src/widgets/lo_frequency_widget/editor.rs
@@ -1,0 +1,288 @@
+use eframe::egui::{self, Color32, FontId, Key, Modifiers, Rect};
+
+use super::{DIGIT_GAP, DIGIT_W, DigitWheelSpec, DigitWheelState, SEP_W, SIGN_W};
+
+pub(super) fn format_value(value: i64, spec: &DigitWheelSpec<'_>) -> String {
+    let digits = format!("{:0width$}", value.unsigned_abs(), width = spec.digit_count);
+    let grouped_width: usize = spec.groups.iter().sum();
+    debug_assert_eq!(grouped_width, spec.digit_count);
+
+    let mut out = String::with_capacity(digits.len() + spec.groups.len());
+    if spec.signed {
+        out.push(if value < 0 { '-' } else { '+' });
+    }
+
+    // If a caller supplies a value wider than the nominal digit count, retain
+    // the extra leading digits in the first group rather than truncating them.
+    let mut offset = 0;
+    let overflow = digits.len().saturating_sub(grouped_width);
+    for (group_index, group_width) in spec.groups.iter().copied().enumerate() {
+        if group_index != 0 {
+            out.push('.');
+        }
+        let width = group_width + usize::from(group_index == 0) * overflow;
+        out.push_str(&digits[offset..offset + width]);
+        offset += width;
+    }
+    out
+}
+
+fn character_distance(current: char, next: char) -> Option<f32> {
+    match (current, next) {
+        (c, n) if c.is_ascii_digit() && n.is_ascii_digit() => Some(DIGIT_W + DIGIT_GAP),
+        (c, '.') if c.is_ascii_digit() => Some(DIGIT_W * 0.5 + DIGIT_GAP + SEP_W * 0.5),
+        ('.', n) if n.is_ascii_digit() => Some(SEP_W * 0.5 + DIGIT_W * 0.5),
+        ('+' | '-', n) if n.is_ascii_digit() => Some(SIGN_W * 0.5 + DIGIT_GAP + DIGIT_W * 0.5),
+        _ => None,
+    }
+}
+
+fn layout_text(
+    ui: &egui::Ui,
+    text: &str,
+    _wrap_width: f32,
+    font: &FontId,
+    color: Color32,
+) -> std::sync::Arc<egui::Galley> {
+    let chars: Vec<char> = text.chars().collect();
+    let widths: Vec<f32> = ui.fonts(|fonts| {
+        chars
+            .iter()
+            .map(|character| fonts.glyph_width(font, *character))
+            .collect()
+    });
+    let mut job = egui::text::LayoutJob::default();
+    // Match TextEdit's built-in single-line layouter: do not wrap at the field
+    // width (or at separators), and let TextEdit horizontally clip/scroll.
+    job.break_on_newline = false;
+
+    for (index, character) in chars.iter().copied().enumerate() {
+        let format = egui::TextFormat {
+            font_id: font.clone(),
+            color,
+            ..Default::default()
+        };
+        let leading_space = if let Some(previous) = index.checked_sub(1)
+            && let Some(center_distance) = character_distance(chars[previous], character)
+        {
+            // Match the fixed-cell painter by compensating for the actual glyph
+            // advances. This also remains correct if the chosen font's digits
+            // are not tabular.
+            center_distance - (widths[previous] + widths[index]) * 0.5
+        } else {
+            0.0
+        };
+        // Each character is a separate section so its gap can reflect the
+        // fixed digit/separator geometry. `extra_letter_spacing` would have no
+        // effect here because it only separates glyphs within one section.
+        job.append(&character.to_string(), leading_space, format);
+    }
+
+    ui.fonts(|fonts| fonts.layout_job(job))
+}
+
+pub(super) fn draw(
+    ui: &mut egui::Ui,
+    editor_id: egui::Id,
+    rect: Rect,
+    state: &mut DigitWheelState,
+    spec: &DigitWheelSpec<'_>,
+    value: i64,
+    font: &FontId,
+    color: Color32,
+) -> Option<i64> {
+    let mut layouter =
+        |ui: &egui::Ui, text: &str, wrap_width: f32| layout_text(ui, text, wrap_width, font, color);
+    let response = ui.put(
+        rect,
+        egui::TextEdit::singleline(&mut state.draft)
+            .id(editor_id)
+            .font(font.clone())
+            .text_color(color)
+            .margin(egui::Margin::symmetric(2, 2))
+            .layouter(&mut layouter)
+            .desired_width(rect.width()),
+    );
+    if state.edit_error {
+        response
+            .clone()
+            .on_hover_text("Enter a frequency in Hz, or use an explicit kHz/MHz suffix");
+    }
+    if state.focus_editor {
+        response.request_focus();
+        let mut editor_state = egui::TextEdit::load_state(ui.ctx(), editor_id).unwrap_or_default();
+        editor_state
+            .cursor
+            .set_char_range(Some(egui::text::CCursorRange::two(
+                egui::text::CCursor::default(),
+                egui::text::CCursor::new(state.draft.chars().count()),
+            )));
+        editor_state.store(ui.ctx(), editor_id);
+        state.focus_editor = false;
+    }
+
+    let escape = ui.input_mut(|i| i.consume_key(Modifiers::NONE, Key::Escape));
+    let enter = ui.input_mut(|i| i.consume_key(Modifiers::NONE, Key::Enter));
+    if escape {
+        state.editing = false;
+        state.edit_error = false;
+        response.surrender_focus();
+        None
+    } else if enter || response.lost_focus() {
+        if let Some(parsed) = parse_frequency(&state.draft, spec) {
+            state.editing = false;
+            state.edit_error = false;
+            (parsed != value).then_some(parsed)
+        } else {
+            state.edit_error = true;
+            state.focus_editor = true;
+            None
+        }
+    } else {
+        None
+    }
+}
+
+fn parse_display_prefix(number: &str, spec: &DigitWheelSpec<'_>) -> Option<i64> {
+    let (sign, unsigned) = if let Some(unsigned) = number.strip_prefix('-') {
+        if !spec.signed {
+            return None;
+        }
+        ("-", unsigned)
+    } else if let Some(unsigned) = number.strip_prefix('+') {
+        ("+", unsigned)
+    } else {
+        ("", number)
+    };
+
+    // Without a display separator, bare input retains its documented literal-Hz
+    // meaning. A dotted value matching the widget's leading groups is instead
+    // treated as a possibly incomplete copy of the displayed value.
+    if !unsigned.contains('.') {
+        return None;
+    }
+    let entered_groups: Vec<&str> = unsigned.split('.').collect();
+    if entered_groups.len() > spec.groups.len() {
+        return None;
+    }
+
+    let mut digits = String::with_capacity(spec.digit_count);
+    for (index, width) in spec.groups.iter().copied().enumerate() {
+        let entered = entered_groups.get(index).copied().unwrap_or("");
+        if entered.len() > width || !entered.chars().all(|c| c.is_ascii_digit()) {
+            return None;
+        }
+        digits.push_str(entered);
+        digits.extend(std::iter::repeat_n('0', width - entered.len()));
+    }
+
+    format!("{sign}{digits}").parse().ok()
+}
+
+/// Parse an editor value. Bare values are Hz (grouping dots/commas are allowed);
+/// a left-to-right prefix of the dotted widget display is padded with trailing
+/// zeroes, and an explicit Hz/kHz/MHz suffix enables decimal unit input.
+fn parse_frequency(text: &str, spec: &DigitWheelSpec<'_>) -> Option<i64> {
+    let compact: String = text.chars().filter(|c| !c.is_whitespace()).collect();
+    let lower = compact.to_ascii_lowercase();
+    let (number, multiplier, has_unit) = if let Some(n) = lower.strip_suffix("mhz") {
+        (n, 1_000_000.0, true)
+    } else if let Some(n) = lower.strip_suffix("khz") {
+        (n, 1_000.0, true)
+    } else if let Some(n) = lower.strip_suffix("hz") {
+        (n, 1.0, true)
+    } else {
+        (lower.as_str(), 1.0, false)
+    };
+
+    let parsed = if has_unit {
+        let n = number.replace(',', "");
+        let hz = n.parse::<f64>().ok()? * multiplier;
+        if !hz.is_finite() || hz < i64::MIN as f64 || hz > i64::MAX as f64 {
+            return None;
+        }
+        hz.round() as i64
+    } else if let Some(parsed) = parse_display_prefix(number, spec) {
+        parsed
+    } else {
+        number.replace(['.', ',', '_'], "").parse::<i64>().ok()?
+    };
+
+    (spec.signed || parsed >= 0).then_some(parsed)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::{DigitWheelAnchor, DigitWheelSpec};
+    use super::*;
+
+    fn lo_spec() -> DigitWheelSpec<'static> {
+        DigitWheelSpec {
+            label: "LO",
+            digit_count: 10,
+            signed: false,
+            groups: &[1, 3, 3, 3],
+            anchor: DigitWheelAnchor::Left,
+        }
+    }
+
+    fn offset_spec() -> DigitWheelSpec<'static> {
+        DigitWheelSpec {
+            label: "LO Offset",
+            digit_count: 6,
+            signed: true,
+            groups: &[3, 3],
+            anchor: DigitWheelAnchor::Right,
+        }
+    }
+
+    #[test]
+    fn parses_bare_grouped_hz() {
+        let spec = lo_spec();
+        assert_eq!(parse_frequency("14.074.000", &spec), Some(14_074_000));
+        assert_eq!(parse_frequency("145,500,000", &spec), Some(145_500_000));
+        assert_eq!(parse_frequency("98000123", &spec), Some(98_000_123));
+    }
+
+    #[test]
+    fn pads_incomplete_display_groups_with_trailing_zeroes() {
+        let spec = lo_spec();
+        assert_eq!(parse_frequency("0.098.000.", &spec), Some(98_000_000));
+        assert_eq!(parse_frequency("0.098.000", &spec), Some(98_000_000));
+        assert_eq!(parse_frequency("0.098.000.1", &spec), Some(98_000_100));
+        assert_eq!(parse_frequency("0.098.000.12", &spec), Some(98_000_120));
+    }
+
+    #[test]
+    fn parses_explicit_units() {
+        let spec = lo_spec();
+        assert_eq!(parse_frequency("14.074 MHz", &spec), Some(14_074_000));
+        assert_eq!(parse_frequency("14074 kHz", &spec), Some(14_074_000));
+        assert_eq!(parse_frequency("700 Hz", &spec), Some(700));
+    }
+
+    #[test]
+    fn signedness_is_enforced() {
+        assert_eq!(parse_frequency("-1500", &offset_spec()), Some(-1_500));
+        assert_eq!(parse_frequency("-1500", &lo_spec()), None);
+    }
+
+    #[test]
+    fn value_matches_the_grouped_digit_display() {
+        let lo = lo_spec();
+        let offset = offset_spec();
+
+        assert_eq!(format_value(96_300_000, &lo), "0.096.300.000");
+        assert_eq!(format_value(1_500, &offset), "+001.500");
+        assert_eq!(format_value(-1_500, &offset), "-001.500");
+    }
+
+    #[test]
+    fn spacing_matches_the_fixed_digit_cells() {
+        assert_eq!(character_distance('1', '2'), Some(14.0));
+        assert_eq!(character_distance('1', '.'), Some(11.0));
+        assert_eq!(character_distance('.', '2'), Some(10.0));
+        assert_eq!(character_distance('+', '2'), Some(13.5));
+        assert_eq!(character_distance('M', 'H'), None);
+    }
+}

--- a/rigflow-protocol/src/radio_control.rs
+++ b/rigflow-protocol/src/radio_control.rs
@@ -118,6 +118,17 @@ pub enum ClientRadioMessage {
         target_freq_hz: u64,
     },
 
+    /// Atomically set one VFO's LO/centre and tuned target frequencies.
+    ///
+    /// Use this when the two values describe one tuning operation (for example,
+    /// recentering while preserving an offset). The legacy single-field commands
+    /// remain available for operations that intentionally move only one value.
+    SetVfoFrequencies {
+        vfo: VfoSelect,
+        center_freq_hz: u64,
+        target_freq_hz: u64,
+    },
+
     SetDemodMode {
         mode: DemodMode,
     },
@@ -842,4 +853,56 @@ pub enum RadioAvailability {
 
     /// Error state (requires recovery or restart)
     Faulted,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn atomic_vfo_frequencies_round_trip_for_both_vfos() {
+        for vfo in [VfoSelect::A, VfoSelect::B] {
+            let message = ClientRadioMessage::SetVfoFrequencies {
+                vfo,
+                center_freq_hz: 14_000_000,
+                target_freq_hz: 14_074_000,
+            };
+
+            let json = serde_json::to_string(&message).expect("serialize tuning command");
+            let decoded: ClientRadioMessage =
+                serde_json::from_str(&json).expect("deserialize tuning command");
+
+            match decoded {
+                ClientRadioMessage::SetVfoFrequencies {
+                    vfo: decoded_vfo,
+                    center_freq_hz,
+                    target_freq_hz,
+                } => {
+                    assert_eq!(decoded_vfo, vfo);
+                    assert_eq!(center_freq_hz, 14_000_000);
+                    assert_eq!(target_freq_hz, 14_074_000);
+                }
+                _ => panic!("decoded the wrong message variant"),
+            }
+        }
+    }
+
+    #[test]
+    fn atomic_vfo_frequencies_has_stable_wire_shape() {
+        let message = ClientRadioMessage::SetVfoFrequencies {
+            vfo: VfoSelect::B,
+            center_freq_hz: 7_000_000,
+            target_freq_hz: 7_074_000,
+        };
+
+        assert_eq!(
+            serde_json::to_value(message).expect("serialize tuning command"),
+            serde_json::json!({
+                "type": "set_vfo_frequencies",
+                "vfo": "b",
+                "center_freq_hz": 7_000_000,
+                "target_freq_hz": 7_074_000,
+            })
+        );
+    }
 }

--- a/rigflow-protocol/src/radio_control.rs
+++ b/rigflow-protocol/src/radio_control.rs
@@ -121,8 +121,7 @@ pub enum ClientRadioMessage {
     /// Atomically set one VFO's LO/centre and tuned target frequencies.
     ///
     /// Use this when the two values describe one tuning operation (for example,
-    /// recentering while preserving an offset). The legacy single-field commands
-    /// remain available for operations that intentionally move only one value.
+    /// recentering while preserving an offset).
     SetVfoFrequencies {
         vfo: VfoSelect,
         center_freq_hz: u64,

--- a/rigflow-server/src/net/websocket.rs
+++ b/rigflow-server/src/net/websocket.rs
@@ -520,6 +520,25 @@ async fn handle_radio_message(
             }
         }
 
+        ClientRadioMessage::SetVfoFrequencies {
+            vfo,
+            center_freq_hz,
+            target_freq_hz,
+        } => {
+            forward_worker_command(
+                app_state,
+                session,
+                local_tx,
+                WorkerCommand::SetVfoFrequencies {
+                    vfo,
+                    center_freq_hz,
+                    target_freq_hz,
+                },
+                "set_vfo_frequencies_failed",
+            )
+            .await;
+        }
+
         ClientRadioMessage::SetDemodMode { mode } => {
             if let Err(err) = send_worker_command_for_session(
                 app_state,

--- a/rigflow-server/src/radio/types.rs
+++ b/rigflow-server/src/radio/types.rs
@@ -232,6 +232,12 @@ pub struct WorkerRuntimeState {
 /// Commands sent from server/session → worker.
 #[derive(Debug, Clone)]
 pub enum WorkerCommand {
+    /// Set one VFO's centre and target as a single control-state transaction.
+    SetVfoFrequencies {
+        vfo: VfoSelect,
+        center_freq_hz: u64,
+        target_freq_hz: u64,
+    },
     SetTargetFrequency {
         hz: u64,
     },

--- a/rigflow-server/src/radio/worker.rs
+++ b/rigflow-server/src/radio/worker.rs
@@ -179,6 +179,23 @@ struct SharedControlState {
 }
 
 impl SharedControlState {
+    /// Update a VFO's centre and target together while the caller holds the
+    /// control-state lock. Readers can therefore observe only the old pair or
+    /// the new pair, never a centre from one tuning operation and a target from
+    /// another.
+    fn set_vfo_frequencies(&mut self, vfo: VfoSelect, center_freq_hz: u64, target_freq_hz: u64) {
+        match vfo {
+            VfoSelect::A => {
+                self.center_freq_hz = center_freq_hz;
+                self.target_freq_hz = target_freq_hz;
+            }
+            VfoSelect::B => {
+                self.vfo.vfo_b_center_freq_hz = center_freq_hz;
+                self.vfo.vfo_b_target_freq_hz = target_freq_hz;
+            }
+        }
+    }
+
     /// Project VFO A's (flat) receiver settings as a `VfoState`.  VFO A's RIT
     /// lives in `vfo.rit_*`; everything else is the top-level flat fields.
     fn vfo_a_state(&self) -> VfoState {
@@ -1214,6 +1231,15 @@ fn spawn_command_thread(
         while !stop_requested(&stop_flag) {
             match cmd_rx.recv_timeout(Duration::from_millis(20)) {
                 Ok(cmd) => match cmd {
+                    WorkerCommand::SetVfoFrequencies {
+                        vfo,
+                        center_freq_hz,
+                        target_freq_hz,
+                    } => {
+                        if let Ok(mut control_state) = control.lock() {
+                            control_state.set_vfo_frequencies(vfo, center_freq_hz, target_freq_hz);
+                        }
+                    }
                     WorkerCommand::SetTargetFrequency { hz } => {
                         if let Ok(mut control_state) = control.lock() {
                             control_state.target_freq_hz = hz;
@@ -3741,5 +3767,34 @@ mod vfo_b_mirror_tests {
         assert_eq!(cs.vfo.vfo_b_agc_strength, 0.2);
         assert!(cs.vfo.vfo_b_rit_enabled);
         assert_eq!(cs.vfo.vfo_b_rit_offset_hz, -120);
+    }
+
+    #[test]
+    fn atomic_frequency_update_routes_to_vfo_a_only() {
+        let mut cs = vfo_a_control();
+        cs.vfo = distinct_vfo_b();
+        let old_b_center = cs.vfo.vfo_b_center_freq_hz;
+        let old_b_target = cs.vfo.vfo_b_target_freq_hz;
+
+        cs.set_vfo_frequencies(VfoSelect::A, 28_000_000, 28_074_000);
+
+        assert_eq!(cs.center_freq_hz, 28_000_000);
+        assert_eq!(cs.target_freq_hz, 28_074_000);
+        assert_eq!(cs.vfo.vfo_b_center_freq_hz, old_b_center);
+        assert_eq!(cs.vfo.vfo_b_target_freq_hz, old_b_target);
+    }
+
+    #[test]
+    fn atomic_frequency_update_routes_to_vfo_b_only() {
+        let mut cs = vfo_a_control();
+        let old_a_center = cs.center_freq_hz;
+        let old_a_target = cs.target_freq_hz;
+
+        cs.set_vfo_frequencies(VfoSelect::B, 7_000_000, 7_074_000);
+
+        assert_eq!(cs.vfo.vfo_b_center_freq_hz, 7_000_000);
+        assert_eq!(cs.vfo.vfo_b_target_freq_hz, 7_074_000);
+        assert_eq!(cs.center_freq_hz, old_a_center);
+        assert_eq!(cs.target_freq_hz, old_a_target);
     }
 }


### PR DESCRIPTION
> **Depends on #36.** This PR builds on the atomic VFO frequency updates introduced there. Because both PRs target `main`, GitHub will temporarily include #36's commits in this PR; they will disappear from the diff once #36 is merged.

## Summary

Upgrade the LO and LO Offset displays into interactive digit controls while retaining their existing visual layout.

- Click either control to edit the complete value as text, with formatting and character spacing matched to the painted display.
- Scroll, press Up/Down, or drag vertically over an individual digit to adjust its decimal place.
- Lock and hide the pointer during a drag so tuning is not limited by the edge of the screen.
- Normalize high-resolution wheel and touchpad input so a single gesture cannot race across the tuning range. (This was a problem for me on windows - yes it does work on windows!)
- Let widgets consume keyboard input before the application's global shortcuts, allowing Up/Down to operate on a hovered digit while preserving the existing global behavior elsewhere.
- Share the interaction code between the unsigned LO and signed LO Offset controls, with the text editor extracted into a  submodule.

## Text entry

The editor accepts:

- Plain values in Hz, such as `14074000`.
- Grouped values, such as `0.014.074.000`.
- Explicit `Hz`, `kHz`, or `MHz` suffixes, such as `14.074 MHz`.
- Incomplete grouped display values, such as `0.098.000` or `0.098.000.`, padding omitted trailing digits with zeroes.

Clicking initially selects the complete value. Enter or loss of focus commits valid input, while Escape cancels it; invalid input remains focused and displays guidance.

## Implementation notes

The widget keeps per-instance interaction state using an explicit ID salt, so VFO A, VFO B, LO, and LO Offset do not share editor or drag state. Existing frequency clamping, offset-preserving LO behavior, dial locking, and radio-acquisition checks remain in the calling UI.

## Testing

- `cargo fmt --all -- --check`
- `cargo check --workspace`
- Client test suite.
- Unit tests for per-digit adjustment, accumulated drag movement, grouped formatting, incomplete grouped input, explicit units, and signed/unsigned parsing.
- Manually exercised text entry, per-digit wheel/drag/arrow interaction, and cursor capture.
