### PR TITLE
Use platform-native directory for client config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1146,6 +1146,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "dispatch"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3258,6 +3279,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
 name = "orbclient"
 version = "0.3.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3647,6 +3674,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_users"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3710,6 +3748,7 @@ name = "rigflow-client"
 version = "1.0.0"
 dependencies = [
  "cpal",
+ "dirs",
  "eframe",
  "egui",
  "egui_plot",

--- a/rigflow-client/Cargo.toml
+++ b/rigflow-client/Cargo.toml
@@ -19,6 +19,7 @@ futures-util = "0.3"
 minifb = "0.27"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+dirs = "6"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync", "time", "net", "io-util", "signal"] }
 tokio-tungstenite = "0.24"
 rigflow-protocol = { path = "../rigflow-protocol" }

--- a/rigflow-client/src/persistence/paths.rs
+++ b/rigflow-client/src/persistence/paths.rs
@@ -10,8 +10,7 @@ use crate::persistence::error::PersistenceError;
 /// Priority:
 /// 1. explicit CLI override
 /// 2. RIGFLOW_CONFIG_DIR
-/// 3. XDG_CONFIG_HOME/rigflow
-/// 4. ~/.config/rigflow
+/// 3. the platform config directory reported by `dirs`
 pub fn resolve_config_dir(cli_override: Option<&Path>) -> Result<PathBuf, PersistenceError> {
     if let Some(path) = cli_override {
         return Ok(path.to_path_buf());
@@ -21,12 +20,9 @@ pub fn resolve_config_dir(cli_override: Option<&Path>) -> Result<PathBuf, Persis
         return Ok(PathBuf::from(path));
     }
 
-    if let Some(xdg_config_home) = env::var_os("XDG_CONFIG_HOME") {
-        return Ok(PathBuf::from(xdg_config_home).join("rigflow"));
-    }
-
-    let home = env::var_os("HOME").ok_or(PersistenceError::NoConfigDirectory)?;
-    Ok(PathBuf::from(home).join(".config").join("rigflow"))
+    dirs::config_dir()
+        .map(|path| path.join("rigflow"))
+        .ok_or(PersistenceError::NoConfigDirectory)
 }
 
 pub fn app_state_path(config_dir: &Path) -> PathBuf {

--- a/rigflow-client/src/persistence/paths.rs
+++ b/rigflow-client/src/persistence/paths.rs
@@ -20,9 +20,24 @@ pub fn resolve_config_dir(cli_override: Option<&Path>) -> Result<PathBuf, Persis
         return Ok(PathBuf::from(path));
     }
 
+    if let Some(path) = legacy_config_dir() {
+        return Ok(path);
+    }
+
     dirs::config_dir()
         .map(|path| path.join("rigflow"))
         .ok_or(PersistenceError::NoConfigDirectory)
+}
+
+fn legacy_config_dir() -> Option<PathBuf> {
+    let home = env::var_os("HOME")?;
+    let config_path = PathBuf::from(home).join(".config").join("rigflow");
+
+    if config_path.is_dir() {
+        Some(config_path)
+    } else {
+        None
+    }
 }
 
 pub fn app_state_path(config_dir: &Path) -> PathBuf {

--- a/rigflow-client/src/persistence/paths.rs
+++ b/rigflow-client/src/persistence/paths.rs
@@ -10,7 +10,8 @@ use crate::persistence::error::PersistenceError;
 /// Priority:
 /// 1. explicit CLI override
 /// 2. RIGFLOW_CONFIG_DIR
-/// 3. the platform config directory reported by `dirs`
+/// 3. the legacy hardcoded config dir for backward compatibility
+/// 4. the platform config directory reported by `dirs`
 pub fn resolve_config_dir(cli_override: Option<&Path>) -> Result<PathBuf, PersistenceError> {
     if let Some(path) = cli_override {
         return Ok(path.to_path_buf());

--- a/rigflow-client/src/persistence/paths.rs
+++ b/rigflow-client/src/persistence/paths.rs
@@ -10,7 +10,7 @@ use crate::persistence::error::PersistenceError;
 /// Priority:
 /// 1. explicit CLI override
 /// 2. RIGFLOW_CONFIG_DIR
-/// 3. the legacy hardcoded config dir for backward compatibility
+/// 3. the legacy hardcoded config dir for backward compatibility (macos only)
 /// 4. the platform config directory reported by `dirs`
 pub fn resolve_config_dir(cli_override: Option<&Path>) -> Result<PathBuf, PersistenceError> {
     if let Some(path) = cli_override {
@@ -30,6 +30,7 @@ pub fn resolve_config_dir(cli_override: Option<&Path>) -> Result<PathBuf, Persis
         .ok_or(PersistenceError::NoConfigDirectory)
 }
 
+#[cfg(target_os = "macos")]
 fn legacy_config_dir() -> Option<PathBuf> {
     let home = env::var_os("HOME")?;
     let config_path = PathBuf::from(home).join(".config").join("rigflow");
@@ -39,6 +40,11 @@ fn legacy_config_dir() -> Option<PathBuf> {
     } else {
         None
     }
+}
+
+#[cfg(not(target_os = "macos"))]
+fn legacy_config_dir() -> Option<PathBuf> {
+    None
 }
 
 pub fn app_state_path(config_dir: &Path) -> PathBuf {


### PR DESCRIPTION
## Summary

- use `dirs::config_dir()` to resolve the client's default configuration directory
- retain the existing explicit path and `RIGFLOW_CONFIG_DIR` overrides
- add the `dirs` dependency and update the lockfile

## Why

The client currently implements the platform config-directory convention itself by checking XDG variables and falling back to `$HOME/.config`. Using `dirs` delegates that decision to a well-established cross-platform implementation, avoids duplicating platform-specific environment handling, and keeps the resolver consistent with the host operating system.

This preserves the usual XDG location on Linux. It also selects the native application-support location on macOS and the roaming application-data location on Windows, which fixes config discovery when `HOME` is not available there.

Explicit caller and `RIGFLOW_CONFIG_DIR` overrides continue to take precedence.

The big reason for this change is that on windows, the client completely fails to determine a config directory, doesn't show a UI error and then silently fails to save recordings and so on. More PRs are planned to improve error reporting/handling generally.

## Compatibility note

This changes the default config location on macOS from `~/.config/rigflow` to `~/Library/Application Support/rigflow`. Existing settings are not migrated automatically, so an existing macOS installation will initially appear to have fresh settings. Affected users can point `RIGFLOW_CONFIG_DIR` at the old directory to retain the current state, or just move the folder.

If backward compatibility is preferred, we can check for existing legacy `~/.config/rigflow/app_state.json` before selecting the platform-native directory. That would preserve established installations without introducing a file migration, while allowing fresh installations to use the native location.

## Testing

- `cargo test -p rigflow-client` — 99 passed
- `cargo fmt --all -- --check`
- `git diff --check`
- Manual verification.
