### PR TITLE
Harden client settings file updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -457,6 +457,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
+name = "atomic-write-file"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84790c55b5704b0d35130bf16a4ce22a8e70eb0ea773522557524d9a4852663d"
+dependencies = [
+ "nix 0.30.1",
+ "rand 0.9.5",
+]
+
+[[package]]
 name = "atspi"
 version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2815,6 +2825,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+dependencies = [
+ "bitflags 2.11.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
 name = "nohash-hasher"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3590,8 +3612,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -3601,7 +3633,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -3611,6 +3653,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -3709,6 +3760,7 @@ dependencies = [
 name = "rigflow-client"
 version = "1.0.0"
 dependencies = [
+ "atomic-write-file",
  "cpal",
  "eframe",
  "egui",
@@ -4030,7 +4082,7 @@ dependencies = [
  "hkdf",
  "num",
  "once_cell",
- "rand",
+ "rand 0.8.5",
  "serde",
  "sha2",
  "zbus",
@@ -4720,7 +4772,7 @@ dependencies = [
  "http",
  "httparse",
  "log",
- "rand",
+ "rand 0.8.5",
  "sha1",
  "thiserror 1.0.69",
  "utf-8",
@@ -5991,7 +6043,7 @@ dependencies = [
  "hex",
  "nix 0.29.0",
  "ordered-stream",
- "rand",
+ "rand 0.8.5",
  "serde",
  "serde_repr",
  "sha1",

--- a/rigflow-client/Cargo.toml
+++ b/rigflow-client/Cargo.toml
@@ -8,6 +8,7 @@ authors.workspace = true
 repository.workspace = true
 
 [dependencies]
+atomic-write-file = "0.3"
 eframe = "0.31"
 egui = "0.31"
 egui_plot = "0.31"

--- a/rigflow-client/src/persistence/error.rs
+++ b/rigflow-client/src/persistence/error.rs
@@ -34,13 +34,6 @@ impl PersistenceError {
     pub fn is_content_corruption(&self) -> bool {
         matches!(self, Self::Json(_))
     }
-
-    /// True when a config file is valid but written by a *newer* build than this
-    /// one (the only `Migration` error today — a downgrade). The file is good
-    /// data, so it is preserved rather than quarantined.
-    pub fn is_version_too_new(&self) -> bool {
-        matches!(self, Self::Migration(_))
-    }
 }
 
 impl std::error::Error for PersistenceError {}

--- a/rigflow-client/src/persistence/store.rs
+++ b/rigflow-client/src/persistence/store.rs
@@ -111,7 +111,7 @@ impl PersistenceStore {
             return Ok(default);
         }
 
-        match read_json_file::<AppStateFile>(&path) {
+        match read_app_state_file(&path) {
             Ok(state) => Ok(state),
             // Corrupt content: quarantine + reset rather than leaving the user
             // stuck.  Genuine Io/dir errors still propagate.
@@ -177,12 +177,10 @@ impl PersistenceStore {
             Err(err) if err.is_content_corruption() => {
                 self.recover_operator_settings_corrupt(&path, &operator_id, err)
             }
-            // Valid file from a newer build (downgrade): preserve it, use
-            // in-memory defaults, tell the user to upgrade.
-            Err(err) if err.is_version_too_new() => {
-                self.recover_operator_settings_future_version(&operator_id, err)
-            }
-            // Genuine Io / invalid-id errors still propagate.
+            // Valid files from a newer build, along with genuine I/O and
+            // invalid-id errors, propagate. In particular, never turn a newer
+            // file into writable defaults that a later load-modify-save could
+            // use to overwrite the original.
             Err(err) => Err(err),
         }
     }
@@ -250,21 +248,6 @@ impl PersistenceStore {
         Ok(default)
     }
 
-    /// A valid operator file from a *newer* build: leave it on disk untouched,
-    /// run on in-memory defaults, and surface an "upgrade" notice.
-    fn recover_operator_settings_future_version(
-        &self,
-        operator_id: &str,
-        err: PersistenceError,
-    ) -> Result<OperatorSettingsFile, PersistenceError> {
-        self.push_recovery_notice(format!(
-            "config for '{operator_id}' is from a newer Rigflow build and was not \
-             loaded ({err}); using defaults this session — upgrade to use it"
-        ));
-        // Deliberately NOT saved, so the good file is preserved for an upgrade.
-        Ok(OperatorSettingsFile::new(operator_id.to_string()))
-    }
-
     pub fn save_operator_settings(
         &self,
         settings: &OperatorSettingsFile,
@@ -305,13 +288,20 @@ impl PersistenceStore {
     }
 }
 
-fn read_json_file<T>(path: &Path) -> Result<T, PersistenceError>
-where
-    T: serde::de::DeserializeOwned,
-{
+fn read_app_state_file(path: &Path) -> Result<AppStateFile, PersistenceError> {
     let text = fs::read_to_string(path)?;
-    let value = serde_json::from_str::<T>(&text)?;
-    Ok(value)
+    let value: serde_json::Value = serde_json::from_str(&text)?;
+
+    if let Some(version) = value.get("version").and_then(serde_json::Value::as_u64)
+        && version > u64::from(crate::persistence::models::APP_STATE_FILE_VERSION)
+    {
+        return Err(PersistenceError::Migration(format!(
+            "app state version {version} is newer than supported version {}",
+            crate::persistence::models::APP_STATE_FILE_VERSION
+        )));
+    }
+
+    Ok(serde_json::from_value(value)?)
 }
 
 /// Rename a corrupt file aside to `<path>.corrupt-<unix_secs>` so it's preserved
@@ -421,16 +411,14 @@ mod tests {
         let original = br#"{"version": 9999}"#;
         fs::write(&path, original).unwrap();
 
-        let settings = store.load_operator_settings("W1AW").unwrap();
-        assert_eq!(settings.version, OPERATOR_SETTINGS_FILE_VERSION);
+        let err = store.load_operator_settings("W1AW").unwrap_err();
+        assert!(matches!(err, PersistenceError::Migration(_)));
 
-        // The good file is left byte-for-byte intact; no backup made.
+        // The good file is left byte-for-byte intact; no backup or writable
+        // default settings are produced.
         assert_eq!(fs::read(&path).unwrap(), original);
         assert!(corrupt_backups(&operators_dir(&dir)).is_empty());
-
-        let notices = store.take_recovery_notices();
-        assert_eq!(notices.len(), 1);
-        assert!(notices[0].contains("newer"));
+        assert!(store.take_recovery_notices().is_empty());
 
         let _ = fs::remove_dir_all(&dir);
     }
@@ -462,7 +450,8 @@ mod tests {
         write_json_file_atomic(&path, &serde_json::json!({"generation": 1})).unwrap();
         write_json_file_atomic(&path, &serde_json::json!({"generation": 2})).unwrap();
 
-        let saved: serde_json::Value = read_json_file(&path).unwrap();
+        let saved: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(&path).unwrap()).unwrap();
         assert_eq!(saved, serde_json::json!({"generation": 2}));
 
         let _ = fs::remove_dir_all(&dir);
@@ -488,20 +477,39 @@ mod tests {
     }
 
     #[test]
+    fn future_version_app_state_is_preserved() {
+        let dir = unique_tmp_dir();
+        let store = PersistenceStore::new(dir.clone());
+        store.ensure_layout().unwrap();
+
+        let path = app_state_path(&dir);
+        let original = br#"{
+            "version": 9999,
+            "future_field": "must survive"
+        }"#;
+        fs::write(&path, original).unwrap();
+
+        let err = store.load_app_state().unwrap_err();
+        assert!(matches!(err, PersistenceError::Migration(_)));
+        assert_eq!(fs::read(&path).unwrap(), original);
+        assert!(corrupt_backups(&dir).is_empty());
+        assert!(store.take_recovery_notices().is_empty());
+
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
     fn error_classification() {
         let json_err = PersistenceError::from(serde_json::from_str::<i32>("x").unwrap_err());
         assert!(json_err.is_content_corruption());
-        assert!(!json_err.is_version_too_new());
 
         let io_err = PersistenceError::from(std::io::Error::new(
             std::io::ErrorKind::PermissionDenied,
             "x",
         ));
         assert!(!io_err.is_content_corruption());
-        assert!(!io_err.is_version_too_new());
 
         let mig = PersistenceError::Migration("too new".to_string());
-        assert!(mig.is_version_too_new());
         assert!(!mig.is_content_corruption());
     }
 

--- a/rigflow-client/src/persistence/store.rs
+++ b/rigflow-client/src/persistence/store.rs
@@ -6,6 +6,8 @@ use std::{
     time::{SystemTime, UNIX_EPOCH},
 };
 
+use atomic_write_file::AtomicWriteFile;
+
 use crate::persistence::models::StationProfileFile;
 use crate::persistence::{
     error::PersistenceError,
@@ -337,16 +339,12 @@ where
 
     fs::create_dir_all(parent)?;
 
-    let temp_path = path.with_extension("json.tmp");
     let json = serde_json::to_string_pretty(value)?;
 
-    {
-        let mut file = fs::File::create(&temp_path)?;
-        file.write_all(json.as_bytes())?;
-        file.sync_all()?;
-    }
-
-    fs::rename(&temp_path, path)?;
+    let mut file = AtomicWriteFile::open(path)?;
+    file.write_all(json.as_bytes())?;
+    file.sync_all()?;
+    file.commit()?;
     Ok(())
 }
 
@@ -452,6 +450,20 @@ mod tests {
         assert_eq!(fs::read(&path).unwrap(), before);
         assert!(corrupt_backups(&operators_dir(&dir)).is_empty());
         assert!(store.take_recovery_notices().is_empty());
+
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn atomic_json_write_replaces_an_existing_file() {
+        let dir = unique_tmp_dir();
+        let path = dir.join("settings.json");
+
+        write_json_file_atomic(&path, &serde_json::json!({"generation": 1})).unwrap();
+        write_json_file_atomic(&path, &serde_json::json!({"generation": 2})).unwrap();
+
+        let saved: serde_json::Value = read_json_file(&path).unwrap();
+        assert_eq!(saved, serde_json::json!({"generation": 2}));
 
         let _ = fs::remove_dir_all(&dir);
     }


### PR DESCRIPTION
## Summary

- replace the client's hand-rolled JSON temp-file rename with `atomic-write-file`
- retain the existing `sync_all()` durability step before committing each replacement
- reject operator settings written by a newer schema instead of returning writable defaults
- validate the raw `app_state.json` version before current-schema deserialization and preserve newer files unchanged

## Why

The existing writer saves to a fixed `.json.tmp` path and then calls `std::fs::rename` over the destination. Replacement behavior differs across platforms, and in particular does not replace an existing destination on Windows. A purpose-built atomic writer provides unique same-directory temporary files and native replacement behavior while preserving the old destination until commit succeeds.

Future-version operator files currently produce default settings successfully. A later load-modify-save can therefore overwrite the newer file despite the recovery path's intention to preserve it. Global app state also carries a version but does not currently validate it before loading and rewriting the file.

This change makes both future-version cases propagate the existing migration error and leaves the original bytes untouched.

## Compatibility

There are no path or file-format changes. Current and older supported settings continue to load normally, including existing operator migrations. Files from a newer Rigflow schema now fail closed rather than opening with defaults.

## Testing

- added a regression test that replaces an existing JSON file twice
- added preservation tests for future-version operator and global settings, including a future global schema that omits current required fields
- `cargo test -p rigflow-client` — 101 passed
- `cargo fmt --all -- --check`
- `cargo clippy -p rigflow-client --all-targets` — completed with existing project warnings; no warning introduced by this change
- `git diff --check`
- Manually verified