### PR TITLE
Fail safely when client configuration cannot be loaded

### DIFF
--- a/rigflow-client/src/main.rs
+++ b/rigflow-client/src/main.rs
@@ -122,6 +122,7 @@ mod net;
 mod persistence;
 mod rigctl_server;
 mod sidetone;
+mod startup_error;
 mod tci_server;
 mod ui;
 mod voice_keyer;
@@ -138,15 +139,10 @@ use tokio::sync::mpsc;
 use crate::client_runtime::start_media_runtime;
 use crate::net::control::ControlCommand;
 use crate::net::websocket::websocket_control_task;
-use crate::persistence::{InitialClientState, StartupError, initialize_client_state};
+use crate::persistence::{InitialClientState, initialize_client_state};
+use crate::startup_error::exit_with_startup_error;
 use crate::ui::app::RigflowApp;
 use crate::ui::state::UiState;
-
-fn exit_with_startup_error(error: &StartupError) -> ! {
-    log::error!("client startup failed: {error}");
-    eprintln!("client startup failed: {error}");
-    std::process::exit(1);
-}
 
 fn main() -> Result<(), eframe::Error> {
     // Initialize logging for both the UI process and background runtime tasks.

--- a/rigflow-client/src/main.rs
+++ b/rigflow-client/src/main.rs
@@ -138,9 +138,15 @@ use tokio::sync::mpsc;
 use crate::client_runtime::start_media_runtime;
 use crate::net::control::ControlCommand;
 use crate::net::websocket::websocket_control_task;
-use crate::persistence::load_initial_ui_state;
+use crate::persistence::{InitialClientState, StartupError, initialize_client_state};
 use crate::ui::app::RigflowApp;
 use crate::ui::state::UiState;
+
+fn exit_with_startup_error(error: &StartupError) -> ! {
+    log::error!("client startup failed: {error}");
+    eprintln!("client startup failed: {error}");
+    std::process::exit(1);
+}
 
 fn main() -> Result<(), eframe::Error> {
     // Initialize logging for both the UI process and background runtime tasks.
@@ -159,19 +165,15 @@ fn main() -> Result<(), eframe::Error> {
     // Parse the command line up front so `--help` exits before any startup work.
     let window_size = parse_cli_or_exit();
 
-    // Load persisted startup state first, then wrap it in shared UI state.
-    let (initial_ui_state, persistence_store) = match load_initial_ui_state(None) {
-        Ok(value) => value,
-        Err(err) => {
-            eprintln!("failed to load persistent state: {err}");
-            (
-                UiState::default(),
-                crate::persistence::PersistenceStore::new(
-                    crate::persistence::resolve_config_dir(None)
-                        .unwrap_or_else(|_| std::path::PathBuf::from(".")),
-                ),
-            )
-        }
+    // Persistent startup is all-or-nothing for the running client: either the
+    // complete initial state and its one resolved store are available, or
+    // startup stops before media, networking, and the main UI are created.
+    let InitialClientState {
+        ui_state: initial_ui_state,
+        persistence_store,
+    } = match initialize_client_state(None) {
+        Ok(initial) => initial,
+        Err(error) => exit_with_startup_error(&error),
     };
 
     // Shared UI/application state used by the egui app and background tasks.

--- a/rigflow-client/src/persistence/bootstrap.rs
+++ b/rigflow-client/src/persistence/bootstrap.rs
@@ -1,16 +1,88 @@
-use std::path::Path;
+use std::{
+    fmt,
+    path::{Path, PathBuf},
+};
 
 use crate::{
     persistence::{
         error::PersistenceError,
         models::{AppStateFile, OperatorSettingsFile},
-        paths::resolve_config_dir,
+        paths::{app_state_path, operator_file_path, resolve_config_dir},
         store::PersistenceStore,
     },
     ui::state::UiState,
 };
 
-/// Load the initial UI state and persistence store.
+#[derive(Debug)]
+pub enum StartupError {
+    ConfigDirectory {
+        source: PersistenceError,
+    },
+    ConfigLayout {
+        path: PathBuf,
+        source: PersistenceError,
+    },
+    AppState {
+        path: PathBuf,
+        source: PersistenceError,
+    },
+    OperatorSettings {
+        operator_id: String,
+        path: PathBuf,
+        source: PersistenceError,
+    },
+}
+
+impl fmt::Display for StartupError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::ConfigDirectory { source } => {
+                write!(
+                    f,
+                    "could not determine the client config directory: {source}"
+                )
+            }
+            Self::ConfigLayout { path, source } => write!(
+                f,
+                "could not prepare the client config directory '{}': {source}",
+                path.display()
+            ),
+            Self::AppState { path, source } => write!(
+                f,
+                "could not load app settings from '{}': {source}",
+                path.display()
+            ),
+            Self::OperatorSettings {
+                operator_id,
+                path,
+                source,
+            } => write!(
+                f,
+                "could not load settings for operator '{operator_id}' from '{}': {source}",
+                path.display()
+            ),
+        }
+    }
+}
+
+impl std::error::Error for StartupError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(match self {
+            Self::ConfigDirectory { source }
+            | Self::ConfigLayout { source, .. }
+            | Self::AppState { source, .. }
+            | Self::OperatorSettings { source, .. } => source,
+        })
+    }
+}
+
+#[derive(Debug)]
+pub struct InitialClientState {
+    pub ui_state: UiState,
+    pub persistence_store: PersistenceStore,
+}
+
+/// Initialize the UI state and persistence store as one all-or-nothing result.
 ///
 /// Behavior:
 /// - resolves the config directory
@@ -20,20 +92,40 @@ use crate::{
 /// - populates known operators
 /// - if a last operator exists, loads and applies that operator's settings
 ///
-/// This is intentionally load-only. Saving is wired later.
-pub fn load_initial_ui_state(
+/// No partially-loaded state or fallback store is returned: any unrecovered
+/// error aborts initialization before the rest of the client starts.
+pub fn initialize_client_state(
     cli_config_dir: Option<&Path>,
-) -> Result<(UiState, PersistenceStore), PersistenceError> {
-    let config_dir = resolve_config_dir(cli_config_dir)?;
-    let store = PersistenceStore::new(config_dir);
+) -> Result<InitialClientState, StartupError> {
+    let config_dir = resolve_config_dir(cli_config_dir)
+        .map_err(|source| StartupError::ConfigDirectory { source })?;
+    let store = PersistenceStore::new(config_dir.clone());
 
-    let app_state = store.load_app_state()?;
+    store
+        .ensure_layout()
+        .map_err(|source| StartupError::ConfigLayout {
+            path: config_dir.clone(),
+            source,
+        })?;
+
+    let app_state = store
+        .load_app_state()
+        .map_err(|source| StartupError::AppState {
+            path: app_state_path(&config_dir),
+            source,
+        })?;
 
     let mut ui_state = UiState::default();
     apply_app_state_to_ui_state(&mut ui_state, &app_state);
 
     if let Some(operator_id) = app_state.last_operator_id.as_deref() {
-        let operator_settings = store.load_or_create_operator_settings(operator_id)?;
+        let operator_settings = store
+            .load_or_create_operator_settings(operator_id)
+            .map_err(|source| StartupError::OperatorSettings {
+                operator_id: operator_id.to_string(),
+                path: operator_file_path(&config_dir, operator_id),
+                source,
+            })?;
         apply_operator_settings_to_ui_state(&mut ui_state, &operator_settings, &app_state);
     }
 
@@ -44,7 +136,10 @@ pub fn load_initial_ui_state(
         ui_state.persistence_status = notices.join("; ");
     }
 
-    Ok((ui_state, store))
+    Ok(InitialClientState {
+        ui_state,
+        persistence_store: store,
+    })
 }
 
 /// Apply global app state to runtime UI state.
@@ -212,4 +307,105 @@ pub fn apply_ui_state_to_operator_settings(state: &UiState, operator: &mut Opera
     operator.mic_gain_percent = state.mic_gain_percent;
 
     operator.voice_keyer_clip = state.voice_keyer_clip.clone();
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        fs,
+        time::{SystemTime, UNIX_EPOCH},
+    };
+
+    use super::*;
+    use crate::persistence::{models::AppStateFile, paths::operators_dir};
+
+    fn unique_tmp_dir() -> PathBuf {
+        use std::sync::atomic::{AtomicU64, Ordering};
+
+        static COUNTER: AtomicU64 = AtomicU64::new(0);
+        let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|duration| duration.as_nanos())
+            .unwrap_or(0);
+        let dir = std::env::temp_dir().join(format!(
+            "rigflow-startup-test-{}-{nanos}-{n}",
+            std::process::id()
+        ));
+        fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    #[test]
+    fn config_layout_failure_stops_initialization() {
+        let parent = unique_tmp_dir();
+        let config_path = parent.join("config-is-a-file");
+        fs::write(&config_path, b"not a directory").unwrap();
+
+        let error = initialize_client_state(Some(&config_path)).unwrap_err();
+        assert!(matches!(
+            error,
+            StartupError::ConfigLayout { path, .. } if path == config_path
+        ));
+
+        let _ = fs::remove_dir_all(parent);
+    }
+
+    #[test]
+    fn app_state_read_failure_stops_initialization() {
+        let config_dir = unique_tmp_dir();
+        fs::create_dir_all(app_state_path(&config_dir)).unwrap();
+
+        let error = initialize_client_state(Some(&config_dir)).unwrap_err();
+        assert!(matches!(
+            error,
+            StartupError::AppState { path, .. } if path == app_state_path(&config_dir)
+        ));
+
+        let _ = fs::remove_dir_all(config_dir);
+    }
+
+    #[test]
+    fn operator_settings_read_failure_stops_initialization() {
+        let config_dir = unique_tmp_dir();
+        let store = PersistenceStore::new(config_dir.clone());
+        let app_state = AppStateFile {
+            last_operator_id: Some("W1AW".to_string()),
+            known_operator_ids: vec!["W1AW".to_string()],
+            ..AppStateFile::default()
+        };
+        store.save_app_state(&app_state).unwrap();
+        fs::create_dir_all(operator_file_path(&config_dir, "W1AW")).unwrap();
+
+        let error = initialize_client_state(Some(&config_dir)).unwrap_err();
+        assert!(matches!(
+            error,
+            StartupError::OperatorSettings {
+                operator_id,
+                path,
+                ..
+            } if operator_id == "W1AW" && path == operator_file_path(&config_dir, "W1AW")
+        ));
+
+        let _ = fs::remove_dir_all(config_dir);
+    }
+
+    #[test]
+    fn recoverable_corruption_still_starts_with_a_notice() {
+        let config_dir = unique_tmp_dir();
+        fs::write(app_state_path(&config_dir), b"not valid json").unwrap();
+
+        let initial = initialize_client_state(Some(&config_dir)).unwrap();
+        assert!(initial.ui_state.persistence_status.contains("corrupt"));
+        assert_eq!(initial.persistence_store.config_dir(), config_dir);
+        assert!(
+            fs::read_dir(&config_dir)
+                .unwrap()
+                .filter_map(Result::ok)
+                .any(|entry| entry.file_name().to_string_lossy().contains(".corrupt-"))
+        );
+        assert!(operators_dir(&config_dir).is_dir());
+
+        let _ = fs::remove_dir_all(config_dir);
+    }
 }

--- a/rigflow-client/src/persistence/mod.rs
+++ b/rigflow-client/src/persistence/mod.rs
@@ -6,7 +6,8 @@ pub mod paths;
 pub mod store;
 
 pub use bootstrap::{
-    apply_operator_settings_to_ui_state, apply_ui_state_to_operator_settings, load_initial_ui_state,
+    InitialClientState, StartupError, apply_operator_settings_to_ui_state,
+    apply_ui_state_to_operator_settings, initialize_client_state,
 };
 pub use models::{BookmarkDisplaySettingsFile, BookmarkFile};
 pub use paths::{normalize_operator_id, operator_file_path, resolve_config_dir};

--- a/rigflow-client/src/startup_error.rs
+++ b/rigflow-client/src/startup_error.rs
@@ -1,0 +1,106 @@
+use eframe::NativeOptions;
+use eframe::egui::{Align, Color32, Frame, Id, Layout, Modal, RichText, Stroke};
+
+use crate::persistence::StartupError;
+
+struct StartupErrorWindow {
+    error: String,
+}
+
+impl eframe::App for StartupErrorWindow {
+    fn update(&mut self, ctx: &eframe::egui::Context, _frame: &mut eframe::Frame) {
+        eframe::egui::CentralPanel::default().show(ctx, |_ui| {});
+
+        let dialog_width = (ctx.screen_rect().width() - 48.0).clamp(320.0, 520.0);
+        Modal::new(Id::new("startup_error_modal"))
+            .frame(
+                Frame::popup(&ctx.style())
+                    .inner_margin(20.0)
+                    .corner_radius(8.0),
+            )
+            .show(ctx, |ui| {
+                ui.set_width(dialog_width);
+
+                ui.horizontal(|ui| {
+                    ui.label(RichText::new("⚠").size(28.0).color(Color32::LIGHT_RED));
+                    ui.vertical(|ui| {
+                        ui.heading(
+                            RichText::new("Rigflow could not start").color(Color32::LIGHT_RED),
+                        );
+                        ui.label("The persistent configuration could not be loaded safely.");
+                    });
+                });
+
+                ui.add_space(12.0);
+                Frame::new()
+                    .fill(ui.visuals().faint_bg_color)
+                    .stroke(Stroke::new(
+                        1.0,
+                        ui.visuals().widgets.noninteractive.bg_stroke.color,
+                    ))
+                    .corner_radius(4.0)
+                    .inner_margin(12.0)
+                    .show(ui, |ui| {
+                        ui.set_width(dialog_width - 24.0);
+                        ui.label(&self.error);
+                    });
+
+                ui.add_space(12.0);
+                ui.label(
+                    "No fallback configuration directory was used. Check the path and its \
+                     permissions, or set RIGFLOW_CONFIG_DIR to a usable directory before trying \
+                     again.",
+                );
+                ui.add_space(16.0);
+                ui.separator();
+                ui.add_space(8.0);
+
+                ui.with_layout(Layout::right_to_left(Align::Center), |ui| {
+                    if ui
+                        .add_sized([80.0, 28.0], eframe::egui::Button::new("Close"))
+                        .clicked()
+                    {
+                        ctx.send_viewport_cmd(eframe::egui::ViewportCommand::Close);
+                    }
+                });
+            });
+
+        if ctx.input(|input| {
+            input.key_pressed(eframe::egui::Key::Escape)
+                || input.key_pressed(eframe::egui::Key::Enter)
+        }) {
+            ctx.send_viewport_cmd(eframe::egui::ViewportCommand::Close);
+        }
+    }
+}
+
+pub(crate) fn exit_with_startup_error(error: &StartupError) -> ! {
+    let error_message = error.to_string();
+
+    log::error!("client startup failed: {error}");
+    eprintln!("client startup failed: {error}");
+
+    let options = NativeOptions {
+        viewport: eframe::egui::ViewportBuilder::default()
+            .with_inner_size([600.0, 340.0])
+            .with_resizable(false)
+            .with_minimize_button(false)
+            .with_maximize_button(false),
+        ..NativeOptions::default()
+    };
+    if let Err(dialog_error) = eframe::run_native(
+        "Rigflow could not start",
+        options,
+        Box::new(move |cc| {
+            cc.egui_ctx.set_theme(eframe::egui::ThemePreference::Dark);
+            Ok(Box::new(StartupErrorWindow {
+                error: error_message,
+            }))
+        }),
+    ) {
+        log::error!("could not open the startup error window: {dialog_error}");
+        eprintln!("could not open the startup error window: {dialog_error}");
+    }
+
+    std::process::exit(1);
+}

--- a/rigflow-client/src/startup_error.rs
+++ b/rigflow-client/src/startup_error.rs
@@ -27,7 +27,7 @@ impl eframe::App for StartupErrorWindow {
                         ui.heading(
                             RichText::new("Rigflow could not start").color(Color32::LIGHT_RED),
                         );
-                        ui.label("The persistent configuration could not be loaded safely.");
+                        ui.label("The configuration could not be loaded safely.");
                     });
                 });
 
@@ -47,9 +47,8 @@ impl eframe::App for StartupErrorWindow {
 
                 ui.add_space(12.0);
                 ui.label(
-                    "No fallback configuration directory was used. Check the path and its \
-                     permissions, or set RIGFLOW_CONFIG_DIR to a usable directory before trying \
-                     again.",
+                    "Check the path and its permissions, or set RIGFLOW_CONFIG_DIR \
+                    to a usable directory before trying again.",
                 );
                 ui.add_space(16.0);
                 ui.separator();


### PR DESCRIPTION
## Summary

- initialize the client's UI state and persistence store as one all-or-nothing result
- resolve the config directory once and remove the default-state/current-directory fallback
- attach the affected path and operation to startup persistence errors
- report unrecovered startup failures to the log, terminal, and a standalone error window before exiting nonzero
- keep successful corrupt-file quarantine and recovery as a recoverable startup path

## Why

The current startup path catches any persistence load failure, prints it to the terminal, then starts the UI with defaults. It resolves the config directory a second time and can fall back to the process working directory. This makes a serious configuration failure look like a fresh installation and allows later persistence operations to target a directory unrelated to the user's real configuration, or no directory at all. On windows (prior to #38) it silently drops audio recordings for example.

This PR makes persistence initialization all-or-nothing for the running client. If the config layout, global app state, or last operator settings cannot be loaded or recovered, the client stops before media, networking, and the main UI are started. It reports the exact operation and path, does not create a fallback store, and exits with status 1 after the user closes the error window.

With the changes in #38, the config path resolution will become more robust and there is no sensible reason to continue starting the application in the case of failures, as they will correspond to a serious problem with permissions or something like that, given that the app can already recover from corrupted config. In this case we will just be setting the user up for failure.

## Recoverable behavior

Missing config files are still created normally. Existing corrupt-file handling is also unchanged when recovery succeeds: the file is quarantined, defaults are saved, startup continues, and the recovery notice appears in the existing Problems area.

This PR only changes startup behavior. Runtime persistence failures and their UI treatment are intentionally left for later structured runtime issue work.

## Independence from other persistence PRs

This functionality is based directly on `main` and does not depend on the config-path changes in #38, although the two changes complement each other.

## Testing

Added deterministic tests covering:

- a config path that is a file rather than a directory
- an unreadable app-state path represented by a directory
- an unreadable last-operator settings path represented by a directory
- successful corrupt app-state recovery continuing with a visible notice

Validation completed:

- `cargo test -p rigflow-client` — 103 passed
- `cargo fmt --all -- --check`
- `cargo clippy -p rigflow-client --all-targets` — completed with existing project warnings; no warning introduced by this change
- `git diff --check`

Manual testing with `RIGFLOW_CONFIG_DIR` set to a regular file confirmed that startup stops, reports the affected path to the terminal and log, shows the standalone error window, does not open the main UI, and exits nonzero after the window is closed. This test also exposed an undeclared Zenity dependency in `rfd`'s Linux message-dialog backend; using the existing eframe/egui stack for the error window avoids that external runtime dependency.
