### PR TITLE
test(protocol): pin wire shape for three multi-field ClientRadioMessage variants

### DIFF
--- a/rigflow-protocol/src/radio_control.rs
+++ b/rigflow-protocol/src/radio_control.rs
@@ -905,6 +905,65 @@ mod tests {
         );
     }
 
+    #[test]
+    fn source_tx_sequencing_has_stable_wire_shape() {
+        let message = ClientRadioMessage::SetSourceTxSequencing {
+            lead_ms: 5,
+            tail_ms: 20,
+        };
+
+        assert_eq!(
+            serde_json::to_value(message).expect("serialize TX sequencing command"),
+            serde_json::json!({
+                "type": "set_source_tx_sequencing",
+                "lead_ms": 5,
+                "tail_ms": 20,
+            })
+        );
+    }
+
+    #[test]
+    fn two_tone_test_has_stable_wire_shape() {
+        let message = ClientRadioMessage::SetTwoToneTest {
+            enabled: true,
+            tone_a_hz: 700.0,
+            tone_b_hz: 1900.0,
+            level_percent: 50.0,
+        };
+
+        assert_eq!(
+            serde_json::to_value(message).expect("serialize two-tone test command"),
+            serde_json::json!({
+                "type": "set_two_tone_test",
+                "enabled": true,
+                "tone_a_hz": 700.0,
+                "tone_b_hz": 1900.0,
+                "level_percent": 50.0,
+            })
+        );
+    }
+
+    #[test]
+    fn swr_sweep_request_has_stable_wire_shape() {
+        // start_hz/stop_hz are the same type (u64) with no distinguishing
+        // shape between them - a silent field rename or a swap between the
+        // two would still type-check and still decode, just tune the wrong
+        // range. Pinning the exact keys is the only thing that catches that.
+        let message = ClientRadioMessage::RequestSwrSweep {
+            start_hz: 14_000_000,
+            stop_hz: 14_350_000,
+        };
+
+        assert_eq!(
+            serde_json::to_value(message).expect("serialize SWR sweep request"),
+            serde_json::json!({
+                "type": "request_swr_sweep",
+                "start_hz": 14_000_000,
+                "stop_hz": 14_350_000,
+            })
+        );
+    }
+
     /// Fields with no `#[serde(default...)]` attribute at all — the wire
     /// payload must include them or decoding fails. Kept in sync by hand:
     /// if someone adds a new field to `RuntimeSnapshot` without a default,


### PR DESCRIPTION
Closes item 3 from #49 - wire-shape pins for `SetSourceTxSequencing`, `SetTwoToneTest`, and `RequestSwrSweep`, the multi-field variants most exposed to a silent field rename (same pattern as the `RadioAvailability`/`RuntimeSnapshot` pins from #51).

`RequestSwrSweep`'s two fields (`start_hz`/`stop_hz`) are both `u64` - a rename or swap between them wouldn't even show up as a type error at the call site, only the wire-shape pin catches it.

Verified by mutation: renaming `SetSourceTxSequencing`'s `tail_ms` field fails to *compile* with the existing test still referencing the old name - a stronger signal than a runtime test failure, confirming the test is genuinely load-bearing.

`cargo fmt`/`clippy -p rigflow-protocol --all-targets` clean (only the same pre-existing unrelated `jitter_buffer.rs` warning). `cargo test -p rigflow-protocol` 8/8 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JjaA3TAzcnwCR8z6zRLSvH